### PR TITLE
Add dashboard page and navigation link

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,6 +98,12 @@ def inject_field_schema():
 def home():
     return render_template("index.html")
 
+
+@app.route("/dashboard")
+def dashboard():
+    """Render the dashboard page."""
+    return render_template("dashboard.html")
+
 @app.route("/<table>")
 def list_view(table):
     if table not in CORE_TABLES:

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,7 @@
   <nav class="bg-gray-200 p-4 flex justify-between items-center">
     <div class="flex space-x-4">
       <a href="/" class="text-blue-600 font-semibold">Home</a>
+      <a href="/dashboard" class="text-blue-600">Dashboard</a>
       <a href="/content" class="text-blue-600">Content</a>
       <a href="/character" class="text-blue-600">Characters</a>
       <a href="/thing" class="text-blue-600">Things</a>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard{% endblock %}
+
+{% block content %}
+<h1 class="text-3xl font-bold mb-4">Dashboard</h1>
+<p class="text-gray-600">This page is under construction.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/dashboard` route returning new template
- update `base.html` navigation with Dashboard link
- create placeholder dashboard template

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: invalid syntax in main.py)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f66922488333a86dbda656a43d17