### PR TITLE
Enable AJAX for boolean toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 
 * **List View with Search:** Each entity list page allows filtering records by text-based fields with a search box (`list_view.html`).
 * **Column Visibility:** Columns can be shown or hidden on the fly using the **Columns** dropdown (`column_visibility.js`).
-* **Detail View & Inline Edit:** Displays all fields on the detail page with inline editing via text input, date picker, checkbox, or rich text editor; edits are saved via POST and appended to the edit log.
+* **Detail View & Inline Edit:** Displays all fields on the detail page with inline editing via text input, date picker, checkbox, or rich text editor. Numeric and boolean field changes now save via AJAX and append to the edit log without reloading the page.
 * **Relationship Management:** Displays related records and allows adding/removing relationships through a modal interface (+ to add, ✖ to remove), using AJAX to update join tables dynamically.
 * **Rich Text Support:** Textarea fields support basic formatting with buttons: Bold, Italic, Underline, Link.
 * **Edit History:** Tracks each record’s modifications in an `edit_log`, viewable via an expandable history section.
@@ -106,6 +106,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
   * `tag_selector.js` (multi-select dropdown UI)
   * `edit_fields.js` for client-side schema and field editing
   * `editor.js` for rich-text formatting integration
+  * `field_ajax.js` for inline field updates without page reloads (imported by `detail_view.html`)
 
 * **Static Assets & Styling:** Global styles in `static/css/styles.css`, with Tailwind overrides in `static/css/overrides.css`.
 
@@ -343,6 +344,7 @@ Overall, `detail_view.html` works in tandem with `macros/fields.html` and the JS
     - **number:** Renders a numeric input (`<input type="number">`) with the current value.
     - **date:** Renders a date picker (`<input type="date">`) with the current value.
     - **default (text):** Renders a basic text input for any other field type (e.g., simple text or unrecognized types).
+    - For number fields, the input’s `onchange` handler calls `field_ajax.js` to save the new value via `fetch`, displaying a short “Saved” indicator without refreshing the page.
   - After the input, a "Save" submit button and a "Cancel" link are provided. The Cancel link leads back to the detail view of the record (without the `edit` param), effectively canceling edit mode.
 - If the field is **not** being edited (normal display mode):
   - For **textarea** fields (which contain HTML content), it wraps the value in a `<div class="prose">` and marks it safe, so the HTML formatting is rendered. This nicely displays paragraphs, links, etc., with Tailwind’s typography styles.

--- a/static/js/field_ajax.js
+++ b/static/js/field_ajax.js
@@ -1,0 +1,65 @@
+export function submitFieldAjax(formEl) {
+  const statusEl = formEl.querySelector('.ajax-status');
+  if (statusEl) {
+    statusEl.textContent = 'Saving…';
+    statusEl.classList.remove('hidden');
+  }
+  fetch(formEl.action, {
+    method: formEl.method || 'POST',
+    headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    body: new FormData(formEl)
+  })
+    .then(resp => {
+      if (!resp.ok) throw new Error('Network response was not ok');
+      if (statusEl) {
+        statusEl.textContent = 'Saved';
+        setTimeout(() => statusEl.classList.add('hidden'), 2000);
+      }
+    })
+    .catch(() => {
+      if (statusEl) {
+        statusEl.textContent = 'Error';
+        setTimeout(() => statusEl.classList.add('hidden'), 2000);
+      }
+    });
+}
+window.submitFieldAjax = submitFieldAjax;
+
+export function toggleBooleanAjax(formEl) {
+  const statusEl = formEl.querySelector('.ajax-status');
+  const btn = formEl.querySelector('button');
+  const hidden = formEl.querySelector('input[name="new_value_override"]');
+  const newVal = hidden.value;
+  if (statusEl) {
+    statusEl.textContent = 'Saving…';
+    statusEl.classList.remove('hidden');
+  }
+  fetch(formEl.action, {
+    method: formEl.method || 'POST',
+    headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    body: new FormData(formEl)
+  })
+    .then(resp => {
+      if (!resp.ok) throw new Error('Network response was not ok');
+      const isTrue = newVal === '1' || newVal === 1 || newVal === true;
+      btn.classList.toggle('bg-green-500', isTrue);
+      btn.classList.toggle('bg-red-500', !isTrue);
+      const dot = btn.querySelector('span:nth-of-type(2)');
+      if (dot) {
+        dot.classList.toggle('translate-x-5', isTrue);
+        dot.classList.toggle('translate-x-1', !isTrue);
+      }
+      hidden.value = isTrue ? '0' : '1';
+      if (statusEl) {
+        statusEl.textContent = 'Saved';
+        setTimeout(() => statusEl.classList.add('hidden'), 2000);
+      }
+    })
+    .catch(() => {
+      if (statusEl) {
+        statusEl.textContent = 'Error';
+        setTimeout(() => statusEl.classList.add('hidden'), 2000);
+      }
+    });
+}
+window.toggleBooleanAjax = toggleBooleanAjax;

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -186,6 +186,7 @@
   window.openLayoutModal = () => document.getElementById("layoutModal").classList.remove("hidden");
   window.closeLayoutModal = () => document.getElementById("layoutModal").classList.add("hidden");
 </script>
+<script type="module" src="{{ url_for('static', filename='js/field_ajax.js') }}"></script>
 
 {% include "edit_fields_modal.html" %}
 

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -87,7 +87,7 @@
       {% elif field_type == "number" %}
         {{ inline_input(field, update_endpoint, table, record_id,
         '<input type="number" name="new_value" value="' ~ value ~
-        '" class="appearance-none border px-1 py-0.5 text-sm rounded"  onchange="this.form.submit()">' ) }}
+        '" class="appearance-none border px-1 py-0.5 text-sm rounded"  onchange="submitFieldAjax(this.form)"><span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
     {% elif field_type == "date" %}
     {{ inline_input(field,update_endpoint,table,record_id,
          '<input type="date" name="new_value" value="' ~ value ~
@@ -133,20 +133,21 @@
         </div>
       </form>
         {% elif field_type == "boolean" %}
-        <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="inline-flex items-center space-x-2">
+        <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="inline-flex items-center space-x-2" onsubmit="event.preventDefault(); toggleBooleanAjax(this);">
           <input type="hidden" name="field" value="{{ field }}">
           <input type="hidden" name="new_value_override" value="{{ '0' if value in ('1', 1, True) else '1' }}">
-          <button type="submit" class="relative inline-flex items-center w-10 h-6 rounded-full transition-colors duration-300 
+          <button type="submit" class="relative inline-flex items-center w-10 h-6 rounded-full transition-colors duration-300
                           {{ 'bg-green-500' if value in ('1', 1, True) else 'bg-red-500' }}">
             <span class="sr-only">{{ 'Yes' if value in ('1', 1, True) else 'No' }}</span>
-            <span class="inline-block w-4 h-4 transform bg-white rounded-full transition-transform duration-300 
+            <span class="inline-block w-4 h-4 transform bg-white rounded-full transition-transform duration-300
                           {{ 'translate-x-5' if value in ('1', 1, True) else 'translate-x-1' }}"></span>
           </button>
+          <span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>
         </form>
         {% elif field_type == "text" %}
         {{ inline_input(field, update_endpoint, table, record_id,
              '<input type="text" name="new_value" value="' ~ value ~
-             '" class="border px-1 py-0.5 text-sm rounded" onchange="this.form.submit()">' ) }}      
+             '" class="border px-1 py-0.5 text-sm rounded" onchange="this.form.submit()">' ) }}
       {% else %}
         <span class="ml-1">{{ value }}</span>
       {% endif %}


### PR DESCRIPTION
## Summary
- add `toggleBooleanAjax` helper in `field_ajax.js`
- submit boolean edits via AJAX in `render_editable_field`
- document AJAX behaviour for boolean fields

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6842eada190483339eb0f0b33c178fd2