### PR TITLE
Enable DOM updates for multi-select fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The front-end JavaScript files enhance the user experience by adding interactivi
 
 **Purpose:** Manages the relationship-addition modal on detail pages and handles sending add/remove requests for relationships. This script enables users to link existing records together without leaving the detail view.
 
-As of April 2025, `relations.js` also includes `submitMultiSelectAuto(form)` to support autosaving changes from `multi_select` fields, and logic to automatically close dropdowns when clicking outside them.
+As of April 2025, `field_ajax.js` includes `submitMultiSelectAuto(form)` to autosave changes from `multi_select` fields and update the selected tags without a full page reload. Dropdowns still close automatically when clicking outside them (handled in `relations.js`).
 
 **Exported Functions:**
 

--- a/static/js/field_ajax.js
+++ b/static/js/field_ajax.js
@@ -64,3 +64,44 @@ export function toggleBooleanAjax(formEl) {
     });
 }
 window.toggleBooleanAjax = toggleBooleanAjax;
+
+// Autosave handler for multi_select checkboxes
+export function submitMultiSelectAuto(formEl) {
+  const formData = new FormData(formEl);
+  fetch(formEl.action, {
+    method: 'POST',
+    headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    body: formData
+  })
+    .then(resp => {
+      if (!resp.ok) throw new Error('Network response was not ok');
+      updateSelectedTagsDOM(formEl);
+    })
+    .catch(err => console.error('submitMultiSelectAuto failed', err));
+}
+
+function updateSelectedTagsDOM(formEl) {
+  const container = formEl.querySelector('div.flex.flex-wrap');
+  if (!container) return;
+  container.innerHTML = '';
+  const checkboxes = formEl.querySelectorAll('input[name="new_value[]"]');
+  checkboxes.forEach(cb => {
+    if (cb.checked) {
+      const span = document.createElement('span');
+      span.className = 'inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full';
+      span.textContent = cb.value;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'ml-1 text-blue-500 hover:text-red-500';
+      btn.textContent = '×';
+      btn.onclick = () => {
+        cb.checked = false;
+        submitMultiSelectAuto(formEl);
+      };
+      span.appendChild(btn);
+      container.appendChild(span);
+    }
+  });
+}
+
+window.submitMultiSelectAuto = submitMultiSelectAuto;

--- a/static/js/relations.js
+++ b/static/js/relations.js
@@ -83,15 +83,6 @@ export function removeRelation(tableA, idA, tableB, idB) {
   }).then(() => location.reload()); // Refresh to reflect removal
 }
 
-// Autosave handler for multi_select checkboxes
-export function submitMultiSelectAuto(formEl) {
-  const formData = new FormData(formEl);
-  fetch(formEl.action, {
-    method: 'POST',
-    body: formData
-  }).then(() => location.reload());
-}
-
 // Add support for closing dropdowns on outside click
 document.addEventListener('click', (e) => {
   document.querySelectorAll('[data-multiselect-dropdown]').forEach(dropdown => {
@@ -100,5 +91,3 @@ document.addEventListener('click', (e) => {
     }
   });
 });
-
-window.submitMultiSelectAuto = submitMultiSelectAuto;


### PR DESCRIPTION
## Summary
- update multi-select helper to update the DOM without reloading
- move helper from `relations.js` to `field_ajax.js`
- document new helper location

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684410e42dc88333b12565251131965d