### PR TITLE
Enable AJAX saving for more input types

### DIFF
--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -39,11 +39,12 @@
         <input type="hidden" name="field" value="{{ field }}">
         <select name="new_value"
         class="appearance-none bg-white border border-gray-300 text-sm px-3 py-2 pr-8 rounded shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-        onchange="this.form.submit()">
+        onchange="submitFieldAjax(this.form)">
           {% for option in field_schema[table][field].options %}
             <option value="{{ option }}" {% if option == value %}selected{% endif %}>{{ option }}</option>
           {% endfor %}
         </select>
+        <span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>
       </form>
       {% elif field_type == "multi_select" %}
       <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="relative w-full multiselect" data-multiselect-dropdown onsubmit="event.preventDefault();">
@@ -91,7 +92,7 @@
     {% elif field_type == "date" %}
     {{ inline_input(field,update_endpoint,table,record_id,
          '<input type="date" name="new_value" value="' ~ value ~
-         '" class="border px-1 py-0.5 text-sm rounded" onchange="this.form.submit()">' ) }}
+         '" class="border px-1 py-0.5 text-sm rounded" onchange="submitFieldAjax(this.form)"><span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
   
       {% elif field_type == "foreign_key" %}
       <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="relative w-full" data-multiselect-dropdown onsubmit="event.preventDefault();">
@@ -147,7 +148,7 @@
         {% elif field_type == "text" %}
         {{ inline_input(field, update_endpoint, table, record_id,
              '<input type="text" name="new_value" value="' ~ value ~
-             '" class="border px-1 py-0.5 text-sm rounded" onchange="this.form.submit()">' ) }}
+             '" class="border px-1 py-0.5 text-sm rounded" onchange="submitFieldAjax(this.form)"><span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
       {% else %}
         <span class="ml-1">{{ value }}</span>
       {% endif %}


### PR DESCRIPTION
## Summary
- update select fields to autosave via `submitFieldAjax`
- apply `submitFieldAjax` to date inputs
- autosave text inputs using the same AJAX call

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68441247861c8333878fb6c567d1847a