### PR TITLE
Configure file and console logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 
 * **Templating & Macros:** Jinja2 templates in `templates/` include `base.html`, `index.html`, `new_record.html`, `import_view.html`, `list_view.html`, and `detail_view.html`. Reusable macros live in `templates/macros/fields.html`, `filter_controls.html`.
 
-* **Logging & Monitoring:** Basic logging configured via Python’s `logging` module in `main.py`. Logs capture errors, import operations, and user actions.
+* **Logging & Monitoring:** Basic logging configured via Python’s `logging` module in `main.py`. A rotating/timed file handler uses the configured level, while console output logs only warnings and above. Logs capture errors, import operations, and user actions.
 
 * **Data Directory:** Runtime files under `data/`: `crossbook.db` (primary database), `huey.db` (task queue store), and `uploads/` for storing imported CSV files.
 

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ DB_PATH = os.path.join("data", "crossbook.db")
 conn = get_connection()
 CORE_TABLES = load_core_tables(conn)
 cfg = get_logging_config()
+app.logger.handlers.clear()
 level_name = cfg.get("log_level", "INFO").upper()
 level = getattr(logging, level_name, logging.INFO)
 handler_type = cfg.get("handler_type", "stream")
@@ -47,26 +48,33 @@ if handler_type == "rotating":
     if log_dir and not os.path.isdir(log_dir):
         os.makedirs(log_dir, exist_ok=True)
 
-    handler = RotatingFileHandler(
+    file_handler = RotatingFileHandler(
         filename,
         maxBytes=max_bytes,
         backupCount=backup
     )
 elif handler_type == "timed":
-    handler = TimedRotatingFileHandler(
+    file_handler = TimedRotatingFileHandler(
         filename,
         when=when_interval,
         interval=interval,
         backupCount=backup
     )
 else:  # default to 'stream'
-    handler = logging.StreamHandler()
+    file_handler = logging.StreamHandler()
 
 formatter = logging.Formatter(log_fmt)
-handler.setFormatter(formatter)
-handler.setLevel(level)
+file_handler.setFormatter(formatter)
+file_handler.setLevel(level)
+
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(formatter)
+console_handler.setLevel(logging.WARNING)
+
 app.logger.setLevel(level)
-app.logger.addHandler(handler)
+app.logger.addHandler(file_handler)
+app.logger.addHandler(console_handler)
+app.logger.propagate = False
 
 @app.before_request
 def start_timer():


### PR DESCRIPTION
## Summary
- clear Flask default log handlers
- add both rotating/timed file logging and a `WARNING` console stream
- note console log level in README

## Testing
- `python -m py_compile main.py db/*.py imports/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68445643df548333845ecce2eb0433d4