### PR TITLE
Enable textarea columns

### DIFF
--- a/db/edit_fields.py
+++ b/db/edit_fields.py
@@ -85,6 +85,7 @@ def add_column_to_table(table_name, field_name, field_type):
         "number": "REAL",
         "date": "TEXT",
         "boolean": "INTEGER",
+        "textarea": "TEXT",
         "select": "TEXT",
         "multi_select": "TEXT",
         "foreign_key": "TEXT"


### PR DESCRIPTION
## Summary
- allow textarea form type when altering tables

## Testing
- `pytest -q`
- `python -m py_compile db/edit_fields.py`

------
https://chatgpt.com/codex/tasks/task_e_6844584e4b588333b483f2944cbd1c62