### PR TITLE
Enable textarea columns

### DIFF
--- a/db/edit_fields.py
+++ b/db/edit_fields.py
@@ -85,6 +85,7 @@ def add_column_to_table(table_name, field_name, field_type):
         "number": "REAL",
         "date": "TEXT",
         "boolean": "INTEGER",
+        "textarea": "TEXT",
         "select": "TEXT",
         "multi_select": "TEXT",
         "foreign_key": "TEXT"

--- a/main.py
+++ b/main.py
@@ -191,14 +191,10 @@ def add_field_route(table, record_id):
         layout = {"x": 0, "y": 0, "w": 6, "h": 1}
 
         app.logger.debug(
-            f"add_field_route calling add_column_to_table table={table!r} field_name={field_name!r} field_type={field_type!r}"
-        )
-        add_column_to_table(table, field_name, field_type)
-        app.logger.debug(
-            f"add_field_route returned from add_column_to_table for {field_name!r}"
-        )
-        app.logger.debug(
-            f"add_field_route calling add_field_to_schema table={table!r} field_name={field_name!r} field_type={field_type!r} options={field_options!r} fk={foreign_key!r}"
+            "add_field_route calling add_column_to_table table=%r field_name=%r field_type=%r",
+            table,
+            field_name,
+            field_type,
         )
         app.logger.info(
             "Calling add_column_to_table table=%s field_name=%s field_type=%s",
@@ -208,6 +204,14 @@ def add_field_route(table, record_id):
         )
         add_column_to_table(table, field_name, field_type)
         app.logger.info("Returned from add_column_to_table for field %s", field_name)
+        app.logger.debug(
+            "add_field_route calling add_field_to_schema table=%r field_name=%r field_type=%r options=%r fk=%r",
+            table,
+            field_name,
+            field_type,
+            field_options,
+            foreign_key,
+        )
         app.logger.info(
             "Calling add_field_to_schema table=%s field_name=%s field_type=%s options=%s fk=%s",
             table,


### PR DESCRIPTION
## Summary
- allow textarea form type when altering tables
- fix add-field logic so column creation only happens once

## Testing
- `pytest -q`
- `python -m py_compile db/edit_fields.py`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6844584e4b588333b483f2944cbd1c62