### PR TITLE
Switch db modules to module-specific loggers

### DIFF
--- a/db/relationships.py
+++ b/db/relationships.py
@@ -1,4 +1,6 @@
 import logging
+
+logger = logging.getLogger(__name__)
 from db.database import get_connection
 from db.validation import validate_table
 
@@ -54,7 +56,7 @@ def get_related_records(source_table, record_id):
                 "items": [{"id": r[0], "name": r[1]} for r in rows]
             }
         except Exception as e:
-            logging.warning(f"[RELATED QUERY ERROR on {join_table}] {e}")
+            logger.warning(f"[RELATED QUERY ERROR on {join_table}] {e}")
             continue
 
     conn.close()
@@ -81,7 +83,7 @@ def add_relationship(table_a, id_a, table_b, id_b):
             (join_table,)
         )
         if not cursor.fetchone():
-            logging.warning(f"[RELATIONSHIP ADD ERROR] join table {join_table} not found")
+            logger.warning(f"[RELATIONSHIP ADD ERROR] join table {join_table} not found")
             return False
 
         # Order IDs to match sorted table order
@@ -94,7 +96,7 @@ def add_relationship(table_a, id_a, table_b, id_b):
         conn.commit()
         return True
     except Exception as e:
-        logging.warning(f"[RELATIONSHIP ADD ERROR] {e}")
+        logger.warning(f"[RELATIONSHIP ADD ERROR] {e}")
         return False
     finally:
         conn.close()
@@ -120,7 +122,7 @@ def remove_relationship(table_a, id_a, table_b, id_b):
             (join_table,)
         )
         if not cursor.fetchone():
-            logging.warning(f"[RELATIONSHIP REMOVE ERROR] join table {join_table} not found")
+            logger.warning(f"[RELATIONSHIP REMOVE ERROR] join table {join_table} not found")
             return False
 
         # Order IDs to match sorted table order
@@ -133,7 +135,7 @@ def remove_relationship(table_a, id_a, table_b, id_b):
         conn.commit()
         return True
     except Exception as e:
-        logging.warning(f"[RELATIONSHIP REMOVE ERROR] {e}")
+        logger.warning(f"[RELATIONSHIP REMOVE ERROR] {e}")
         return False
     finally:
         conn.close()

--- a/db/schema.py
+++ b/db/schema.py
@@ -2,6 +2,8 @@ import sqlite3
 import json
 import logging
 
+logger = logging.getLogger(__name__)
+
 DB_PATH = "data/crossbook.db"
 FIELD_SCHEMA = {}
 
@@ -55,7 +57,7 @@ def load_field_schema():
 try:
     FIELD_SCHEMA = load_field_schema()
 except Exception as e:
-    logging.exception("Error loading FIELD_SCHEMA: %s", e)
+    logger.exception("Error loading FIELD_SCHEMA: %s", e)
 
 
 def update_foreign_field_options():
@@ -80,7 +82,7 @@ def update_foreign_field_options():
         try:
             validate_table(foreign_table)
         except ValueError as e:
-            logging.warning(
+            logger.warning(
                 "Skipping %s.%s: invalid table %s (%s)",
                 table_name,
                 field_name,
@@ -101,7 +103,7 @@ def update_foreign_field_options():
             cur.execute(f"SELECT id, {label_field} FROM {foreign_table}")
             options = [r[1] for r in cur.fetchall()]
         except Exception as e:
-            logging.warning(
+            logger.warning(
                 "Skipping %s.%s → %s: %s",
                 table_name,
                 field_name,


### PR DESCRIPTION
## Summary
- create a `logger` per file under `db`
- replace direct `logging.*` calls with the local logger

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684461a474e483339be57c485ae29f29