### PR TITLE
Implement dynamic index and nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This is the core of the Flask application. It defines the web routes, handles da
 
 - **Flask App Initialization:** The Flask app is created with `static_url_path='/static'` so that files in the `static/` directory are served at the `/static` URL path.
 - **`DB_PATH`:** Path to the SQLite database file, set to `data/crossbook.db`. (This is currently hardcoded; the database must reside at this path relative to the app.)
-- **`CORE_TABLES`:** A list of the primary entity tables in the database: `["character", "thing", "location", "faction", "topic", "content"]`. This list is used to validate route parameters and to build navigation links. *(If new core tables are added to the database, this list must be updated in code for the app to recognize them.)*
+- **`CORE_TABLES`:** Derived from the `core_table_info` table via `load_core_tables()`. It contains all entity table names except the special `dashboard` entry and is used to validate route parameters.
 - **`FIELD_SCHEMA`:** A global dictionary that will hold the schema definition for fields of each table. It’s populated at startup by reading the `field_schema` table from the database. The structure is: `FIELD_SCHEMA = { table_name: { field_name: field_type, ... }, ... }`. This lets the templates and logic know how to treat each field (e.g., as text, number, boolean, etc., and whether to render it or hide it).
 - **`field_options`:** A field_options column in the field_schema table contains a JSON-encoded list of options for select fields (e.g., ["Elf", "Human"]).
 - These options are not loaded into FIELD_SCHEMA.
@@ -240,7 +240,7 @@ The Flask Jinja2 templates define the structure of the HTML pages. The templates
 **Layout and Features:**
 
 - **Tailwind Inclusion:** Loads Tailwind CSS from the official CDN for styling. No separate CSS files are used; styles are from Tailwind utility classes.
-- **Navigation Bar:** A responsive `<nav>` bar at the top contains links to Home and each core section. These links are currently hardcoded to the known sections: Home (`/`), Content, Characters, Things, Factions, Locations, Lore Topics (each link goes to the list view of the respective table). The link labels are prettified (e.g., `"Lore Topics"` for `topic`). *(In the current implementation, this nav does not auto-update if `CORE_TABLES` changes; it must be edited manually to add new sections.)*
+- **Navigation Bar:** A responsive `<nav>` bar at the top lists sections from the `core_table_info` table (plus Home). This means new tables automatically appear in the nav with their configured display names.
 - **Content Block:** Uses Jinja `{% block content %}{% endblock %}` to define where child templates insert their page-specific content. Similarly, a `{% block title %}` sets the `<title>` tag for each page (so pages can specify a custom title, like “Characters List” or “Character 5”). The base provides a padded container `<div class="p-6">` around the content block for consistent spacing.
 - **Global Context:** Thanks to the `inject_field_schema` context processor, every template extending base.html automatically has access to `field_schema` (the schema dict) as well as other Flask globals like `request`. This base does not itself display dynamic data (aside from the nav links), but it provides the framework within which other templates render their content.
 
@@ -248,12 +248,7 @@ The Flask Jinja2 templates define the structure of the HTML pages. The templates
 
 **Purpose:** Home page, providing a quick entry point to each section of the application.
 
-**Content:** The index extends `base.html` and fills the content block with a title and a grid of cards linking to each entity’s list page. Each card has:
-- A heading (e.g., "Characters", "Locations") and 
-- A brief description or tagline (e.g., "View all known characters in Alagaesia" for Characters, or "Important places throughout the land" for Locations). These descriptions are specific to the example dataset (Alagaësia lore) and can be adjusted for other use cases.
-- The cards are wrapped in anchor `<a>` tags linking to the respective list view (e.g., `/character`).
-
-This page is static in content (no dynamic looping; the sections are explicitly written out for the core tables).
+**Content:** The index extends `base.html` and renders a grid of cards from the `core_table_info` table. Each card specifies a `display_name`, `description`, and destination link (`/dashboard` or `/<table>`). New rows added to this table automatically appear on the home page.
 
 #### 📄 **`list_view.html`**
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,13 +10,9 @@
   <nav class="bg-gray-200 p-4 flex justify-between items-center">
     <div class="flex space-x-4">
       <a href="/" class="text-blue-600 font-semibold">Home</a>
-      <a href="/dashboard" class="text-blue-600">Dashboard</a>
-      <a href="/content" class="text-blue-600">Content</a>
-      <a href="/character" class="text-blue-600">Characters</a>
-      <a href="/thing" class="text-blue-600">Things</a>
-      <a href="/faction" class="text-blue-600">Factions</a>
-      <a href="/location" class="text-blue-600">Locations</a>
-      <a href="/topic" class="text-blue-600">Lore Topics</a>
+      {% for nav in nav_cards %}
+        <a href="{{ '/' if nav.table_name == 'dashboard' else '/' + nav.table_name }}" class="text-blue-600">{{ nav.display_name }}</a>
+      {% endfor %}
     </div>
 
     {% set segments = request.path.strip('/').split('/') %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,42 +9,12 @@
 {% block content %}
 <h1 class="text-4xl font-bold text-center mb-10">Load the Glass Cannon</h1>
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
-
-  <!-- Content -->
-  <a href="/content" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
-    <h2 class="text-2xl font-bold mb-2">Content</h2>
-    <p class="text-gray-600">Content Index</p>
+  {% for card in cards %}
+  <a href="{{ '/' if card.table_name == 'dashboard' else '/' + card.table_name }}"
+     class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
+    <h2 class="text-2xl font-bold mb-2">{{ card.display_name }}</h2>
+    <p class="text-gray-600">{{ card.description }}</p>
   </a>
-
-  <!-- Characters -->
-  <a href="/character" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
-    <h2 class="text-2xl font-bold mb-2">Characters</h2>
-    <p class="text-gray-600">View all known characters in Alagaesia</p>
-  </a>
-
-  <!-- Things -->
-  <a href="/thing" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
-    <h2 class="text-2xl font-bold mb-2">Things</h2>
-    <p class="text-gray-600">Artifacts, tools, and curiosities</p>
-  </a>
-
-  <!-- Factions -->
-  <a href="/faction" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
-    <h2 class="text-2xl font-bold mb-2">Factions</h2>
-    <p class="text-gray-600">Factions, cultures, and organizations</p>
-  </a>
-
-  <!-- Locations -->
-  <a href="/location" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
-    <h2 class="text-2xl font-bold mb-2">Locations</h2>
-    <p class="text-gray-600">Important places throughout the land</p>
-  </a>
-
-  <!-- Lore Topics -->
-  <a href="/topic" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
-    <h2 class="text-2xl font-bold mb-2">Lore Topics</h2>
-    <p class="text-gray-600">Themes, magic systems, and unanswered questions</p>
-  </a>
-
+  {% endfor %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- introduce `core_table_info` table to store card metadata
- load card info at startup and use it for `CORE_TABLES`
- render index page and nav links dynamically from this data
- document new table and dynamic behavior in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68446a9e5b18833392c9014b83e3e185