### PR TITLE
Add color support to rich text editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Column Visibility:** Columns can be shown or hidden on the fly using the **Columns** dropdown (`column_visibility.js`).
 * **Detail View & Inline Edit:** Displays all fields on the detail page with inline editing via text input, date picker, checkbox, or rich text editor. Numeric field changes now save via AJAX and append to the edit log without reloading the page.
 * **Relationship Management:** Displays related records and allows adding/removing relationships through a modal interface (+ to add, ✖ to remove), using AJAX to update join tables dynamically.
-* **Rich Text Support:** Textarea fields support basic formatting with buttons: Bold, Italic, Underline, Link.
+* **Rich Text Support:** Textarea fields support formatting with buttons: Bold, Italic, Underline, Link, and text color.
 * **Edit History:** Tracks each record’s modifications in an `edit_log`, viewable via an expandable history section.
 * **Navigation Bar:** A consistent top navigation (`base.html`) links to Home and all core entity sections.
 * **Supported Field Types:** text, number, date, select, multi-select, foreign-key, boolean, and textarea, each rendered with the appropriate input control.

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -8,13 +8,20 @@ export function initRichTextEditor(field, statusId) {
 
   if (!editor || !hidden) return;
 
-  // Formatting buttons (bold, italic, underline)
+  // Formatting buttons (bold, italic, underline, color)
   const container = editor.closest('.mb-4');
   const buttons = container.querySelectorAll('[data-command]');
   buttons.forEach(btn => {
-    btn.addEventListener('click', () => {
+    const eventType = (btn.tagName === 'INPUT' && btn.type === 'color') ? 'input' : 'click';
+    btn.addEventListener(eventType, () => {
       const cmd = btn.getAttribute('data-command');
-      document.execCommand(cmd, false, null);
+      let value = null;
+      if (btn.hasAttribute('data-value')) {
+        value = btn.getAttribute('data-value');
+      } else if (btn.tagName === 'INPUT' && btn.type === 'color') {
+        value = btn.value;
+      }
+      document.execCommand(cmd, false, value);
       editor.focus();
     });
   });

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -20,6 +20,7 @@
           <button type="button" data-command="bold" class="format-btn font-bold text-sm px-2 py-1 rounded bg-white border">B</button>
           <button type="button" data-command="italic" class="format-btn italic text-sm px-2 py-1 rounded bg-white border">I</button>
           <button type="button" data-command="underline" class="format-btn underline text-sm px-2 py-1 rounded bg-white border">U</button>
+          <input type="color" value="#000000" data-command="foreColor" class="w-6 h-6 p-0 border rounded">
         </div>
         <div class="px-4 py-2 bg-white rounded-b-lg">
           <div id="editor_{{ field }}" contenteditable="true"


### PR DESCRIPTION
## Summary
- add color input to editor toolbar
- update editor.js to pass command values like color
- document text color formatting in README

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6844731cc3d08333a75c3fc354f5af77