### PR TITLE
Fix dashboard link on index

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
 <h1 class="text-4xl font-bold text-center mb-10">Load the Glass Cannon</h1>
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
   {% for card in cards %}
-  <a href="{{ '/' if card.table_name == 'dashboard' else '/' + card.table_name }}"
+  <a href="{{ '/dashboard' if card.table_name == 'dashboard' else '/' + card.table_name }}"
      class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
     <h2 class="text-2xl font-bold mb-2">{{ card.display_name }}</h2>
     <p class="text-gray-600">{{ card.description }}</p>


### PR DESCRIPTION
## Summary
- update home page card for dashboard to point to `/dashboard`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68447814f0ec8333b078e1c05dc70a67