### PR TITLE
Add plus card to index page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -16,5 +16,8 @@
     <p class="text-gray-600">{{ card.description }}</p>
   </a>
   {% endfor %}
+  <a href="#" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition flex items-center justify-center">
+    <span class="text-blue-500 text-5xl font-bold">+</span>
+  </a>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a final card on the home page showing a blue plus icon

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68447e18e6c88333ac0f9e37faa175e3