### PR TITLE
Reload DB cache after adding tables

### DIFF
--- a/db/schema.py
+++ b/db/schema.py
@@ -308,16 +308,8 @@ def create_base_table(table_name: str, description: str) -> bool:
     finally:
         conn.close()
 
-    # Refresh in-memory caches
+    # Refresh the in-memory FIELD_SCHEMA cache
     global FIELD_SCHEMA
     FIELD_SCHEMA = load_field_schema()
-    try:
-        import main
-
-        with sqlite3.connect(DB_PATH) as c:
-            main.CARD_INFO = load_card_info(c)
-            main.BASE_TABLES = load_base_tables(c)
-    except Exception as exc:
-        logger.exception("Failed to refresh global caches: %s", exc)
 
     return True

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, abort, request, redirect, url_for, jsonify, session, g
 import os
+import sqlite3
 import logging
 import time
 import json
@@ -437,6 +438,7 @@ def update_layout(table):
 @app.route("/add-table", methods=["POST"])
 def add_table():
     """Create a new base table using JSON input."""
+    global CARD_INFO, BASE_TABLES
     data = request.get_json(silent=True) or {}
     table_name = (data.get("table_name") or "").strip()
     description = (data.get("description") or "").strip()
@@ -458,6 +460,10 @@ def add_table():
 
     if not success:
         return jsonify({"error": "Failed to create table"}), 400
+
+    with sqlite3.connect(DB_PATH) as c:
+        CARD_INFO = load_card_info(c)
+        BASE_TABLES = load_base_tables(c)
 
     return jsonify({"success": True})
 


### PR DESCRIPTION
## Summary
- streamline cache refresh when new tables are created
- update `/add-table` route to reload CARD_INFO and BASE_TABLES
- remove import side-effect in create_base_table
- import sqlite3 in main

## Testing
- `python -m py_compile main.py db/schema.py`


------
https://chatgpt.com/codex/tasks/task_e_6844c5e971bc8333b84b29ea46f8cd08