### PR TITLE
Upgrade Quill editor to v2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Column Visibility:** Columns can be shown or hidden on the fly using the **Columns** dropdown (`column_visibility.js`).
 * **Detail View & Inline Edit:** Displays all fields on the detail page with inline editing via text input, date picker, checkbox, or rich text editor. Numeric field changes now save via AJAX and append to the edit log without reloading the page.
 * **Relationship Management:** Displays related records and allows adding/removing relationships through a modal interface (+ to add, ✖ to remove), using AJAX to update join tables dynamically.
-* **Rich Text Support:** Textarea fields now use the Quill editor for formatting.
+* **Rich Text Support:** Textarea fields now use the Quill editor (v2.0.3) for formatting.
 * **Edit History:** Tracks each record’s modifications in an `edit_log`, viewable via an expandable history section.
 * **Navigation Bar:** A consistent top navigation (`base.html`) links to Home and all base table sections.
 * **Supported Field Types:** text, number, date, select, multi-select, foreign-key, boolean, and textarea, each rendered with the appropriate input control.

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -9,8 +9,8 @@
 {% macro render_editable_field(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
   <div class="mt-2">
     {% if field_type == "textarea" %}
-    <link rel="stylesheet" href="https://cdn.quilljs.com/1.3.6/quill.snow.css">
-    <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.quilljs.com/2.0.3/quill.snow.css">
+    <script src="https://cdn.quilljs.com/2.0.3/quill.min.js"></script>
     <div id="save_status_{{ field }}" class="text-xs text-gray-500 mb-1"></div>
     <form method="POST"
           action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}"


### PR DESCRIPTION
## Summary
- use Quill v2.0.3 in detail view textarea fields
- document Quill version in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844c63aa2e083339c0a26d0fedb8ffe