### PR TITLE
Fix Quill integration after upgrade

### DIFF
--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -1,8 +1,10 @@
+import Quill from 'https://cdn.quilljs.com/2.0.3/quill.js';
+
 export function initQuillEditor(field, statusId) {
   const container = document.getElementById(`editor_${field}`);
   const hidden = document.getElementById(`hidden_${field}`);
   const statusEl = statusId ? document.getElementById(statusId) : null;
-  if (!container || !hidden || typeof Quill === 'undefined') return;
+  if (!container || !hidden) return;
 
   const quill = new Quill(container, {
     theme: 'snow',

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -10,7 +10,6 @@
   <div class="mt-2">
     {% if field_type == "textarea" %}
     <link rel="stylesheet" href="https://cdn.quilljs.com/2.0.3/quill.snow.css">
-    <script src="https://cdn.quilljs.com/2.0.3/quill.min.js"></script>
     <div id="save_status_{{ field }}" class="text-xs text-gray-500 mb-1"></div>
     <form method="POST"
           action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}"


### PR DESCRIPTION
## Summary
- import Quill as an ES module instead of relying on a global
- remove the legacy script tag in the field macro

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684540642d0c8333b4a0a1187b07db21