### PR TITLE
Fix Quill CORS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Column Visibility:** Columns can be shown or hidden on the fly using the **Columns** dropdown (`column_visibility.js`).
 * **Detail View & Inline Edit:** Displays all fields on the detail page with inline editing via text input, date picker, checkbox, or rich text editor. Numeric field changes now save via AJAX and append to the edit log without reloading the page.
 * **Relationship Management:** Displays related records and allows adding/removing relationships through a modal interface (+ to add, ✖ to remove), using AJAX to update join tables dynamically.
-* **Rich Text Support:** Textarea fields now use the Quill editor (v2.0.3) for formatting.
+* **Rich Text Support:** Textarea fields now use the Quill editor (v2.0.3) for formatting. The script and stylesheet are loaded from **unpkg.com** so browsers can fetch them with CORS enabled.
 * **Edit History:** Tracks each record’s modifications in an `edit_log`, viewable via an expandable history section.
 * **Navigation Bar:** A consistent top navigation (`base.html`) links to Home and all base table sections.
 * **Supported Field Types:** text, number, date, select, multi-select, foreign-key, boolean, and textarea, each rendered with the appropriate input control.

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -1,8 +1,13 @@
+// Import Quill from a CDN that serves the module with CORS headers enabled.
+// The previous cdn.quilljs.com source blocked cross-origin module loading,
+// resulting in a CORS error in browsers. Using unpkg fixes this.
+import Quill from 'https://unpkg.com/quill@2.0.3/dist/quill.js';
+
 export function initQuillEditor(field, statusId) {
   const container = document.getElementById(`editor_${field}`);
   const hidden = document.getElementById(`hidden_${field}`);
   const statusEl = statusId ? document.getElementById(statusId) : null;
-  if (!container || !hidden || typeof Quill === 'undefined') return;
+  if (!container || !hidden) return;
 
   const quill = new Quill(container, {
     theme: 'snow',

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -9,8 +9,8 @@
 {% macro render_editable_field(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
   <div class="mt-2">
     {% if field_type == "textarea" %}
-    <link rel="stylesheet" href="https://cdn.quilljs.com/2.0.3/quill.snow.css">
-    <script src="https://cdn.quilljs.com/2.0.3/quill.min.js"></script>
+    {# Use unpkg for CORS-friendly stylesheet loading #}
+    <link rel="stylesheet" href="https://unpkg.com/quill@2.0.3/dist/quill.snow.css">
     <div id="save_status_{{ field }}" class="text-xs text-gray-500 mb-1"></div>
     <form method="POST"
           action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}"


### PR DESCRIPTION
## Summary
- load Quill JS and CSS from unpkg CDN
- note unpkg in README for CORS support

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check $(git ls-files '*.py')` *(fails: would reformat db/database.py, ...)*

------
https://chatgpt.com/codex/tasks/task_e_684540642d0c8333b4a0a1187b07db21