### PR TITLE
Use config value for index heading

### DIFF
--- a/db/config.py
+++ b/db/config.py
@@ -17,3 +17,16 @@ def get_logging_config():
         subkey = full_key.split(".", 1)[1]
         config[subkey] = val
     return config
+
+
+def get_config_value(key: str, default=None):
+    """Return the configuration value for a given key."""
+
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT value FROM config WHERE key = ?", (key,))
+    row = cur.fetchone()
+    conn.close()
+    if row is None:
+        return default
+    return row[0]

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ from db.relationships import get_related_records, add_relationship, remove_relat
 from static.imports.validation import validation_sorter
 from imports.import_csv import parse_csv
 from db.edit_fields import add_column_to_table, add_field_to_schema, drop_column_from_table, remove_field_from_schema
-from db.config import get_logging_config
+from db.config import get_logging_config, get_config_value
 
 
 app = Flask(__name__, static_url_path='/static')
@@ -125,7 +125,8 @@ def inject_field_schema():
 
 @app.route("/")
 def home():
-    return render_template("index.html", cards=CARD_INFO)
+    heading = get_config_value("index.heading", "Load the Glass Cannon")
+    return render_template("index.html", cards=CARD_INFO, heading=heading)
 
 
 @app.route("/dashboard")

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<h1 class="text-4xl font-bold text-center mb-10">Load the Glass Cannon</h1>
+<h1 class="text-4xl font-bold text-center mb-10">{{ heading }}</h1>
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
   {% for card in cards %}
   <a href="{{ '/dashboard' if card.table_name == 'dashboard' else '/' + card.table_name }}"


### PR DESCRIPTION
## Summary
- add generic `get_config_value()` helper
- read home page heading from the config table
- render heading variable in index template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68454377fdc88333926ba681657f0beb