### PR TITLE
Add static dashboard card

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ This is the core of the Flask application. It defines the web routes, handles da
 
 - **Flask App Initialization:** The Flask app is created with `static_url_path='/static'` so that files in the `static/` directory are served at the `/static` URL path.
 - **`DB_PATH`:** Path to the SQLite database file, set to `data/crossbook.db`. (This is currently hardcoded; the database must reside at this path relative to the app.)
-- **`BASE_TABLES`:** Derived from the `config_base_tables` table via `load_base_tables()`. It contains all entity table names except the special `dashboard` entry and is used to validate route parameters.
+- **`BASE_TABLES`:** Derived from the `config_base_tables` table via `load_base_tables()`. It contains all entity table names and is used to validate route parameters.
 - **`FIELD_SCHEMA`:** A global dictionary that will hold the schema definition for fields of each table. It’s populated at startup by reading the `field_schema` table from the database. The structure is: `FIELD_SCHEMA = { table_name: { field_name: field_type, ... }, ... }`. This lets the templates and logic know how to treat each field (e.g., as text, number, boolean, etc., and whether to render it or hide it).
 - **`field_options`:** A field_options column in the field_schema table contains a JSON-encoded list of options for select fields (e.g., ["Elf", "Human"]).
 - These options are not loaded into FIELD_SCHEMA.
@@ -253,7 +253,7 @@ The Flask Jinja2 templates define the structure of the HTML pages. The templates
 
 **Purpose:** Home page, providing a quick entry point to each section of the application.
 
-**Content:** The index extends `base.html` and renders a grid of cards from the `config_base_tables` table. Each card specifies a `display_name`, `description`, and destination link (`/dashboard` or `/<table>`). New rows added to this table automatically appear on the home page.
+**Content:** The index extends `base.html` and renders a grid of cards. A static dashboard card links to `/dashboard`, followed by cards loaded from the `config_base_tables` table. Each table card specifies a `display_name`, `description`, and links to `/<table>`. New rows added to this table automatically appear on the home page.
 
 #### 📄 **`list_view.html`**
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,8 +9,12 @@
 {% block content %}
 <h1 class="text-4xl font-bold text-center mb-10">Load the Glass Cannon</h1>
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
+  <a href="/dashboard" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
+    <h2 class="text-2xl font-bold mb-2">Dashboard</h2>
+    <p class="text-gray-600">View overall summary and stats</p>
+  </a>
   {% for card in cards %}
-  <a href="{{ '/dashboard' if card.table_name == 'dashboard' else '/' + card.table_name }}"
+  <a href="/{{ card.table_name }}"
      class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
     <h2 class="text-2xl font-bold mb-2">{{ card.display_name }}</h2>
     <p class="text-gray-600">{{ card.description }}</p>


### PR DESCRIPTION
## Summary
- add a static dashboard card at the start of the home page
- simplify home page link generation
- document the change in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845444c84748333b125d3af45b2eafb