### PR TITLE
Switch Quill import to ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Column Visibility:** Columns can be shown or hidden on the fly using the **Columns** dropdown (`column_visibility.js`).
 * **Detail View & Inline Edit:** Displays all fields on the detail page with inline editing via text input, date picker, checkbox, or rich text editor. Numeric field changes now save via AJAX and append to the edit log without reloading the page.
 * **Relationship Management:** Displays related records and allows adding/removing relationships through a modal interface (+ to add, ✖ to remove), using AJAX to update join tables dynamically.
-* **Rich Text Support:** Textarea fields now use the Quill editor (v2.0.3) for formatting. The script and stylesheet are loaded from **unpkg.com** (using the `?module` flag for the script) so browsers can fetch them with CORS enabled.
+* **Rich Text Support:** Textarea fields now use the Quill editor (v2.0.3) for formatting. The script and stylesheet are loaded from **unpkg.com**. The editor is imported with `import Quill from 'https://unpkg.com/quill@2.0.3?module'` so browsers can fetch the ES module build with CORS enabled.
 * **Edit History:** Tracks each record’s modifications in an `edit_log`, viewable via an expandable history section.
 * **Navigation Bar:** A consistent top navigation (`base.html`) links to Home and all base table sections.
 * **Supported Field Types:** text, number, date, select, multi-select, foreign-key, boolean, and textarea, each rendered with the appropriate input control.

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -1,4 +1,4 @@
-import Quill from 'https://unpkg.com/quill@2.0.3/dist/quill.js?module';
+import Quill from 'https://unpkg.com/quill@2.0.3?module';
 
 
 export function initQuillEditor(field, statusId) {


### PR DESCRIPTION
## Summary
- update `editor.js` to load Quill via the ES module build
- document the updated import path in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454991507883338bfd79ee4a5a57c1