### PR TITLE
Improve nav bar styling

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,17 +7,17 @@
   <title>{% block title %}Crossbook{% endblock %}</title>
 </head>
 <body class="bg-white text-gray-900">
-  <nav class="bg-gray-200 p-4 flex justify-between items-center">
-    <div class="flex space-x-4">
-      <a href="/" class="text-blue-600 font-semibold">Home</a>
-      {% for nav in nav_cards if nav.table_name != 'dashboard' %}
-        <a href="/{{ nav.table_name }}" class="text-blue-600">{{ nav.display_name }}</a>
-      {% endfor %}
-    </div>
-
     {% set segments = request.path.strip('/').split('/') %}
     {% set current_table = segments[0] %}
     {% set current_id = segments[1] if segments|length > 1 else None %}
+  <nav class="bg-gray-800 dark:bg-gray-900 text-gray-100 p-4 flex justify-between items-center">
+    <div class="flex space-x-4">
+      <a href="/" class="px-2 {{ 'text-white border-b-2 border-white' if not current_table else 'text-gray-300 hover:text-white' }} font-semibold">Home</a>
+      {% for nav in nav_cards if nav.table_name != 'dashboard' %}
+        <a href="/{{ nav.table_name }}" class="px-2 {{ 'text-white border-b-2 border-white' if current_table == nav.table_name else 'text-gray-300 hover:text-white' }}">{{ nav.display_name }}</a>
+      {% endfor %}
+    </div>
+
 
     <div class="ml-auto flex space-x-2">
       {% if current_table in field_schema %}


### PR DESCRIPTION
## Summary
- modernize the navigation bar to use a dark color scheme
- highlight the active page link
- compute current page before rendering links

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68454c9ca7808333b0ea68ca95a70238