### PR TITLE
Integrate Quill editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Column Visibility:** Columns can be shown or hidden on the fly using the **Columns** dropdown (`column_visibility.js`).
 * **Detail View & Inline Edit:** Displays all fields on the detail page with inline editing via text inputs, date pickers, checkboxes, or textareas. Numeric field changes now save via AJAX and append to the edit log without reloading the page.
 * **Relationship Management:** Displays related records and allows adding/removing relationships through a modal interface (+ to add, ✖ to remove), using AJAX to update join tables dynamically.
-* **Rich Text Support:** Textarea fields accept HTML markup directly using a standard `<textarea>` element.
+* **Rich Text Support:** Textareas are enhanced with [Quill](https://quilljs.com/) for WYSIWYG editing.
 * **Edit History:** Tracks each record’s modifications in an `edit_log`, viewable via an expandable history section.
 * **Navigation Bar:** A consistent top navigation (`base.html`) links to Home and all base table sections.
 * **Supported Field Types:** text, number, date, select, multi-select, foreign-key, boolean, and textarea, each rendered with the appropriate input control.
@@ -125,6 +125,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
   * `tag_selector.js` (multi-select dropdown UI)
   * `edit_fields.js` for client-side schema and field editing
   * `field_ajax.js` for inline field updates without page reloads (imported by `detail_view.html`)
+  * `editor.js` initializes Quill editors for textarea fields (see the [Quill documentation](https://quilljs.com/docs/quickstart/) for editor usage)
 
 * **Static Assets & Styling:** Global styles in `static/css/styles.css`, with Tailwind overrides in `static/css/overrides.css`.
 
@@ -305,7 +306,7 @@ Key features of the detail view:
     - Text fields -> a simple text input.
     - Number fields -> a number input.
     - Date fields -> an HTML date picker.
-    - Textarea (long text) -> a standard `<textarea>` element for HTML content.
+    - Textarea (long text) -> a Quill-powered editor for HTML content.
     - Boolean fields -> a toggle checkbox input.
     - `multi_select` fields now render as searchable dropdowns with checkboxes and tag-style badges for selected values. Users can filter options live, deselect tags with ✖, and all changes autosave automatically. A Tailwind-styled dropdown appears inline with live filtering and closing behavior.
   - If the field is **not** in edit mode, the macro will display the value in a read-only format:
@@ -343,7 +344,7 @@ Overall, `detail_view.html` works in tandem with `macros/fields.html` and the JS
 - If the current request’s query param `edit` matches this field’s name, it means the user is editing this field. The macro will produce an `<form>` element targeting the `update_field` route (using `url_for(update_endpoint, table=..., record_id=...)`). 
   - It always includes a hidden `<input name="field">` with the field’s name (so the backend knows which field to update).
   - Then, depending on `field_type`, it renders an appropriate input:
-    - **textarea:** Uses a plain `<textarea>` element. The HTML is stored directly in the `new_value` field.
+    - **textarea:** Uses a Quill editor with the HTML stored in a hidden `new_value` input.
     - **boolean:** Renders a checkbox input (styled as a toggle switch via CSS classes). It’s checked if the current value is truthy ( "1", 1, or True). This lets the user change the boolean value. (Note: in edit mode, this is a single checkbox inside the form; in view mode, booleans are handled differently as described below).
     - **number:** Renders a numeric input (`<input type="number">`) with the current value.
     - **date:** Renders a date picker (`<input type="date">`) with the current value.

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -1,0 +1,25 @@
+import { submitFieldAjax } from './field_ajax.js';
+
+function initEditors() {
+  document.querySelectorAll('[data-quill]').forEach(el => {
+    const form = el.closest('form');
+    if (!form) return;
+    let input = form.querySelector('input[name="new_value"]');
+    if (!input) {
+      input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = 'new_value';
+      form.appendChild(input);
+    }
+    const quill = new Quill(el, { theme: 'snow' });
+    input.value = quill.root.innerHTML;
+    quill.on('text-change', () => {
+      input.value = quill.root.innerHTML;
+      if (form.hasAttribute('data-autosave') && typeof submitFieldAjax === 'function') {
+        submitFieldAjax(form);
+      }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initEditors);

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/overrides.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+  <link rel="stylesheet" href="https://cdn.quilljs.com/1.3.7/quill.snow.css">
+  <script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
   <title>{% block title %}Crossbook{% endblock %}</title>
 </head>
 <body class="bg-white text-gray-900">

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -187,6 +187,7 @@
   window.closeLayoutModal = () => document.getElementById("layoutModal").classList.add("hidden");
 </script>
 <script type="module" src="{{ url_for('static', filename='js/field_ajax.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/editor.js') }}"></script>
 
 {% include "edit_fields_modal.html" %}
 

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -11,11 +11,11 @@
     {% if field_type == "textarea" %}
     <form method="POST"
           action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}"
-          class="w-full mb-2">
+          class="w-full mb-2"
+          data-autosave>
       <input type="hidden" name="field" value="{{ field }}">
-      <textarea name="new_value" rows="6"
-                class="w-full border px-2 py-1 text-sm rounded"
-                onchange="submitFieldAjax(this.form)">{{ value }}</textarea>
+      <input type="hidden" name="new_value" value="{{ value|e }}">
+      <div class="quill-editor" data-quill>{{ value|safe }}</div>
       <span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>
     </form>
       {% elif field_type == "select" %}

--- a/templates/new_record.html
+++ b/templates/new_record.html
@@ -10,7 +10,8 @@
       <div>
         <label class="block text-sm font-medium capitalize mb-1">{{ field }}</label>
         {% if ftype == "textarea" %}
-          <textarea name="{{ field }}" rows="4" class="w-full border rounded p-2 text-sm"></textarea>
+          <input type="hidden" name="{{ field }}">
+          <div class="quill-editor" data-quill></div>
         {% elif ftype == "boolean" %}
           <input type="checkbox" name="{{ field }}" value="1">
         {% elif ftype == "number" %}
@@ -26,4 +27,5 @@
 
   <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Create</button>
 </form>
+<script type="module" src="{{ url_for('static', filename='js/editor.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- include Quill CSS and JS
- add editor.js module to initialize Quill
- render textarea fields as Quill editors
- enable Quill on the new record page
- document Quill usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684550e8a5c48333b7940d9efbbae9fc