### PR TITLE
Add dashboard modal with blur overlay

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -1,0 +1,11 @@
+export function openDashboardModal() {
+  document.getElementById('dashboardModal').classList.remove('hidden');
+}
+
+export function closeDashboardModal() {
+  document.getElementById('dashboardModal').classList.add('hidden');
+}
+
+window.openDashboardModal = openDashboardModal;
+window.closeDashboardModal = closeDashboardModal;
+

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -3,10 +3,20 @@
 {% block title %}Dashboard{% endblock %}
 
 {% block nav_buttons %}
-<button id="dashboard_add" class="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600">+ Add</button>
+<button id="dashboard_add" onclick="openDashboardModal()" class="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600">+ Add</button>
 {% endblock %}
 
 {% block content %}
 <h1 class="text-3xl font-bold mb-4">Dashboard</h1>
 <p class="text-gray-600">This page is under construction.</p>
 {% endblock %}
+
+<!-- Dashboard Add Modal -->
+<div id="dashboardModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50">
+  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full text-center">
+    <p class="mb-4">Add dashboard feature coming soon.</p>
+    <button onclick="closeDashboardModal()" class="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400">Close</button>
+  </div>
+</div>
+
+<script type="module" src="{{ url_for('static', filename='js/dashboard_modal.js') }}"></script>


### PR DESCRIPTION
## Summary
- add modal for dashboard add feature
- implement JS functions to open and close modal
- hook new script in dashboard template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684569dec1ac833392f11ad6dfb18c8b