### PR TITLE
Fix dashboard modal script placement

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -9,7 +9,6 @@
 {% block content %}
 <h1 class="text-3xl font-bold mb-4">Dashboard</h1>
 <p class="text-gray-600">This page is under construction.</p>
-{% endblock %}
 
 <!-- Dashboard Add Modal -->
 <div id="dashboardModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50">
@@ -20,3 +19,4 @@
 </div>
 
 <script type="module" src="{{ url_for('static', filename='js/dashboard_modal.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- ensure dashboard modal markup and script are inside the `content` block so they're included in the page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456d8256c88333a4560c231ed526ae