### PR TITLE
Refactor to use load_base_tables

### DIFF
--- a/db/schema.py
+++ b/db/schema.py
@@ -125,7 +125,7 @@ def update_foreign_field_options():
 def get_field_schema():
     return FIELD_SCHEMA
 
-def load_card_info(conn):
+def load_base_tables(conn):
     """Return card metadata from the config_base_tables table."""
     rows = conn.execute(
         """
@@ -142,12 +142,6 @@ def load_card_info(conn):
         }
         for r in rows
     ]
-
-
-def load_base_tables(conn):
-    """Return the list of base table names used by the application."""
-    cards = load_card_info(conn)
-    return [c["table_name"] for c in cards if c["table_name"] != "dashboard"]
 
 def update_layout(table: str, layout_items: list[dict]) -> int:
     current_schema = load_field_schema()

--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ from db.schema import (
     update_foreign_field_options,
     get_field_schema,
     load_base_tables,
-    load_card_info,
     update_layout,
     create_base_table,
 )
@@ -34,8 +33,8 @@ app = Flask(__name__, static_url_path='/static')
 app.jinja_env.add_extension('jinja2.ext.do') # for field type in detail_view
 DB_PATH = os.path.join("data", "crossbook.db")
 conn = get_connection()
-CARD_INFO = load_card_info(conn)
-BASE_TABLES = load_base_tables(conn)
+CARD_INFO = load_base_tables(conn)
+BASE_TABLES = [c["table_name"] for c in CARD_INFO if c["table_name"] != "dashboard"]
 
 # Configure logging using helper function
 configure_logging(app)
@@ -413,8 +412,8 @@ def add_table():
         return jsonify({"error": "Failed to create table"}), 400
 
     with sqlite3.connect(DB_PATH) as c:
-        CARD_INFO = load_card_info(c)
-        BASE_TABLES = load_base_tables(c)
+        CARD_INFO = load_base_tables(c)
+        BASE_TABLES = [card["table_name"] for card in CARD_INFO if card["table_name"] != "dashboard"]
 
     return jsonify({"success": True})
 


### PR DESCRIPTION
## Summary
- remove `load_card_info`
- fold its logic into `load_base_tables`
- update main app to use `load_base_tables` for card info and table names

## Testing
- `python -m py_compile main.py db/schema.py`


------
https://chatgpt.com/codex/tasks/task_e_6845722cbf7083339d136584c02c3a22