### PR TITLE
Add helper for refreshing card cache

### DIFF
--- a/db/schema.py
+++ b/db/schema.py
@@ -149,6 +149,17 @@ def load_base_tables(conn):
     cards = load_card_info(conn)
     return [c["table_name"] for c in cards if c["table_name"] != "dashboard"]
 
+
+def refresh_card_cache():
+    """Return updated CARD_INFO and BASE_TABLES lists."""
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        card_info = load_card_info(conn)
+        base_tables = load_base_tables(conn)
+    finally:
+        conn.close()
+    return card_info, base_tables
+
 def update_layout(table: str, layout_items: list[dict]) -> int:
     current_schema = load_field_schema()
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 from flask import Flask, render_template, abort, request, redirect, url_for, jsonify, session, g
 import os
-import sqlite3
 import logging
 import time
 import json
@@ -14,6 +13,7 @@ from db.schema import (
     load_card_info,
     update_layout,
     create_base_table,
+    refresh_card_cache,
 )
 from db.records import (
     get_all_records,
@@ -412,9 +412,7 @@ def add_table():
     if not success:
         return jsonify({"error": "Failed to create table"}), 400
 
-    with sqlite3.connect(DB_PATH) as c:
-        CARD_INFO = load_card_info(c)
-        BASE_TABLES = load_base_tables(c)
+    CARD_INFO, BASE_TABLES = refresh_card_cache()
 
     return jsonify({"success": True})
 


### PR DESCRIPTION
## Summary
- implement `refresh_card_cache` in `db/schema.py`
- use the helper instead of a manual sqlite connection in `add_table`
- drop unused sqlite3 import in `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845755e7b088333840413b3ab3d6f74