### PR TITLE
Add base table selector in dashboard modal

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,6 +72,7 @@ def inject_field_schema():
         'field_schema': load_field_schema(),
         'update_foreign_field_options': update_foreign_field_options,
         'nav_cards': CARD_INFO,
+        'base_tables': BASE_TABLES,
     }
 
 @app.route("/")

--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -38,7 +38,59 @@ function initDashboardTabs() {
   });
 }
 
-document.addEventListener('DOMContentLoaded', initDashboardTabs);
+function initTableSelect() {
+  const container = document.getElementById('selectedTables');
+  const toggleBtn = document.getElementById('tableSelectToggle');
+  const dropdown = document.getElementById('tableSelectOptions');
+  if (!container || !toggleBtn || !dropdown) return;
+
+  const checkboxes = dropdown.querySelectorAll('input[type="checkbox"]');
+
+  function refreshTags() {
+    container.innerHTML = '';
+    checkboxes.forEach(cb => {
+      if (cb.checked) {
+        const span = document.createElement('span');
+        span.className = 'inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full';
+        span.textContent = cb.value;
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'ml-1 text-blue-500 hover:text-red-500';
+        btn.textContent = '×';
+        btn.addEventListener('click', () => {
+          cb.checked = false;
+          refreshTags();
+        });
+        span.appendChild(btn);
+        container.appendChild(span);
+      }
+    });
+  }
+
+  toggleBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    dropdown.classList.toggle('hidden');
+  });
+
+  document.addEventListener('click', e => {
+    if (!dropdown.contains(e.target) && e.target !== toggleBtn) {
+      dropdown.classList.add('hidden');
+    }
+  });
+
+  dropdown.addEventListener('click', e => e.stopPropagation());
+
+  checkboxes.forEach(cb => cb.addEventListener('change', refreshTags));
+
+  refreshTags();
+}
+
+function initDashboardModal() {
+  initDashboardTabs();
+  initTableSelect();
+}
+
+document.addEventListener('DOMContentLoaded', initDashboardModal);
 
 window.openDashboardModal = openDashboardModal;
 window.closeDashboardModal = closeDashboardModal;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -27,7 +27,19 @@
       </ul>
     </div>
     <div id="pane-value">
-      <p class="mb-4">Value tab content coming soon.</p>
+      <form id="dashboardTableForm" class="relative w-full" onsubmit="event.preventDefault();">
+        <div id="selectedTables" class="flex flex-wrap gap-1 mb-2"></div>
+        <button id="tableSelectToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500">Choose Tables</button>
+        <div id="tableSelectOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1">
+          <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l=>l.classList.toggle('hidden',!l.textContent.toLowerCase().includes(v)))">
+          {% for table in base_tables %}
+          <label class="flex items-center space-x-2">
+            <input type="checkbox" value="{{ table }}" class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
+            <span class="text-sm">{{ table }}</span>
+          </label>
+          {% endfor %}
+        </div>
+      </form>
     </div>
     <div id="pane-table" class="hidden">
       <p class="mb-4">Table tab content coming soon.</p>


### PR DESCRIPTION
## Summary
- inject `base_tables` in Flask context
- add multi-select dropdown on dashboard modal value tab
- implement JS to manage tag selection

## Testing
- `python -m py_compile main.py db/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6845762562f0833398f90fff3c2ae7f5