### PR TITLE
Add column dropdown to dashboard modal

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -39,6 +39,12 @@
           </label>
           {% endfor %}
         </div>
+
+        <hr class="my-3">
+
+        <div id="selectedColumns" class="flex flex-wrap gap-1 mb-2"></div>
+        <button id="columnSelectToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500">Choose Columns</button>
+        <div id="columnSelectOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
       </form>
     </div>
     <div id="pane-table" class="hidden">
@@ -53,5 +59,6 @@
   </div>
 </div>
 
+<script>const FIELD_SCHEMA = {{ field_schema | tojson }};</script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_modal.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a second dropdown in the dashboard add modal
- populate column dropdown with fields from selected tables
- expose `FIELD_SCHEMA` for JS use

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684578694c20833397eedb9c16295249