### PR TITLE
Implement autosizing text field display

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -104,3 +104,13 @@ input[type=number] {
   background-repeat: repeat, repeat;
 }
 
+
+.autosize-text {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  overflow: hidden;
+}

--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -1,0 +1,72 @@
+export function fitText(el) {
+  const style = window.getComputedStyle(el);
+  let fontSize = parseFloat(style.fontSize);
+  if (!fontSize) return;
+  while ((el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight) && fontSize > 4) {
+    fontSize -= 1;
+    el.style.fontSize = fontSize + 'px';
+  }
+}
+
+function makeEditable(displayEl) {
+  const value = displayEl.textContent.trim();
+  const form = document.createElement('form');
+  form.method = 'POST';
+  form.action = displayEl.dataset.updateUrl;
+  form.className = 'inline';
+
+  const hidden = document.createElement('input');
+  hidden.type = 'hidden';
+  hidden.name = 'field';
+  hidden.value = displayEl.dataset.field;
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.name = 'new_value';
+  input.value = value;
+  input.className = 'border px-1 py-0.5 text-sm rounded';
+
+  const status = document.createElement('span');
+  status.className = 'ajax-status text-xs text-gray-500 ml-1 hidden';
+
+  form.append(hidden, input, status);
+  displayEl.replaceWith(form);
+  input.focus();
+
+  const finish = () => {
+    submitFieldAjax(form);
+    const newDiv = document.createElement('div');
+    newDiv.className = 'autosize-text';
+    newDiv.dataset.field = displayEl.dataset.field;
+    newDiv.dataset.recordId = displayEl.dataset.recordId;
+    newDiv.dataset.updateUrl = displayEl.dataset.updateUrl;
+    newDiv.textContent = input.value;
+    form.replaceWith(newDiv);
+    attach(newDiv);
+  };
+
+  input.addEventListener('blur', finish, { once: true });
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      input.blur();
+    }
+  });
+}
+
+export function attach(el) {
+  fitText(el);
+  el.addEventListener('click', () => makeEditable(el));
+}
+
+export function initAutosizeText() {
+  document.querySelectorAll('.autosize-text').forEach(el => attach(el));
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initAutosizeText);
+} else {
+  initAutosizeText();
+}
+
+window.initAutosizeText = initAutosizeText;

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -187,6 +187,7 @@
   window.closeLayoutModal = () => document.getElementById("layoutModal").classList.add("hidden");
 </script>
 <script type="module" src="{{ url_for('static', filename='js/field_ajax.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/autosize_text.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/editor.js') }}"></script>
 
 {% include "edit_fields_modal.html" %}

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -130,9 +130,7 @@
           <span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>
         </form>
         {% elif field_type == "text" %}
-        {{ inline_input(field, update_endpoint, table, record_id,
-             '<input type="text" name="new_value" value="' ~ value ~
-             '" class="border px-1 py-0.5 text-sm rounded" onchange="submitFieldAjax(this.form)"><span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
+        <div class="autosize-text" data-field="{{ field }}" data-record-id="{{ record_id }}" data-update-url="{{ url_for(update_endpoint, table=table, record_id=record_id) }}">{{ value }}</div>
       {% else %}
         <span class="ml-1">{{ value }}</span>
       {% endif %}


### PR DESCRIPTION
## Summary
- add autosize_text.js module for auto-fitting text and inline editing
- render text fields as `<div class="autosize-text">` blocks
- load the new autosize JS on the detail page
- style autosize text blocks in overrides.css

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68457b519c1483338ff118dac4037f2d