### PR TITLE
Add Bulk Edit button on detail pages

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -28,6 +28,7 @@
           <form method="post" action="/{{ current_table }}/{{ current_id }}/delete" onsubmit="return confirm('Are you sure?')">
             <button type="submit" class="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">Delete</button>
           </form>
+          <a href="/{{ current_table }}/{{ current_id }}/bulk-edit" class="bg-indigo-500 text-white px-3 py-1 rounded hover:bg-indigo-600">Bulk Edit</a>
         {% endif %}
       {% endif %}
       {% block nav_buttons %}{% endblock %}


### PR DESCRIPTION
## Summary
- add a Bulk Edit button in the navigation bar when viewing a record

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846c260ddb483338028b8f171ae42ac