### PR TITLE
Fix JS function naming

### DIFF
--- a/static/js/layout_editor.js
+++ b/static/js/layout_editor.js
@@ -30,7 +30,7 @@ function bindEventHandlers() {
   const saveLayoutBtn  = document.getElementById('save-layout');
   const resetLayoutBtn = document.getElementById('reset-layout');
   saveLayoutBtn.addEventListener('click', handleSaveLayout);
-  resetLayoutBtn.addEventListener('click', reset_layout);
+  resetLayoutBtn.addEventListener('click', resetLayout);
   console.debug("[layout] bindEventHandlers registered save+reset click");
 }
 
@@ -71,7 +71,7 @@ function revertPosition(el) {
   console.info("[layout] revertPosition called for", el.dataset.field, "previous rect=", prev);
 }
 
-function reset_layout() {
+function resetLayout() {
   console.groupCollapsed("[layout] resetLayout start");
   let curRow = 1;
   Object.entries(layoutCache).forEach(([field, rect]) => {


### PR DESCRIPTION
## Summary
- rename `reset_layout` to `resetLayout` for consistency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/js/layout_editor.js`


------
https://chatgpt.com/codex/tasks/task_e_6846c9633334833393799c24e94f5a54