### PR TITLE
Improve dashboard modal IDs and show field types

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -40,11 +40,11 @@ function initDashboardTabs() {
 
 function initTableSelect() {
   const container = document.getElementById('selectedTables');
-  const toggleBtn = document.getElementById('tableSelectToggle');
-  const dropdown = document.getElementById('tableSelectOptions');
+  const toggleBtn = document.getElementById('chooseTablesToggle');
+  const dropdown = document.getElementById('chooseTablesOptions');
   const columnContainer = document.getElementById('selectedColumns');
-  const columnToggleBtn = document.getElementById('columnSelectToggle');
-  const columnDropdown = document.getElementById('columnSelectOptions');
+  const columnToggleBtn = document.getElementById('chooseFirstColumnToggle');
+  const columnDropdown = document.getElementById('chooseFirstColumnOptions');
   const divider = document.getElementById('columnDivider');
   if (!container || !toggleBtn || !dropdown) return;
 
@@ -118,7 +118,8 @@ function initTableSelect() {
         input.addEventListener('change', () => { selectedColumn = val; refreshColumnTags(); });
         const span = document.createElement('span');
         span.className = 'text-sm';
-        span.innerHTML = `<strong>${table}</strong>: ${field}`;
+        const type = FIELD_SCHEMA[table] && FIELD_SCHEMA[table][field] ? FIELD_SCHEMA[table][field].type : '';
+        span.innerHTML = `<strong>${table}</strong>: ${field} <span class="text-blue-600 text-xs">(${type})</span>`;
         label.appendChild(input);
         label.appendChild(span);
         columnDropdown.appendChild(label);

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -29,8 +29,8 @@
     <div id="pane-value">
       <form id="dashboardTableForm" class="relative w-full" onsubmit="event.preventDefault();">
         <div id="selectedTables" class="flex flex-wrap gap-1 mb-2"></div>
-        <button id="tableSelectToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500">Choose Tables</button>
-        <div id="tableSelectOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1">
+        <button id="chooseTablesToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500">Choose Tables</button>
+        <div id="chooseTablesOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1">
           <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l=>l.classList.toggle('hidden',!l.textContent.toLowerCase().includes(v)))">
           {% for table in base_tables %}
           <label class="flex items-center space-x-2">
@@ -43,8 +43,8 @@
         <hr id="columnDivider" class="my-3 border-t-2 border-blue-600 hidden">
 
         <div id="selectedColumns" class="flex flex-wrap gap-1 mb-2"></div>
-        <button id="columnSelectToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden">Choose First Column</button>
-        <div id="columnSelectOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+        <button id="chooseFirstColumnToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden">Choose First Column</button>
+        <div id="chooseFirstColumnOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
       </form>
     </div>
     <div id="pane-table" class="hidden">


### PR DESCRIPTION
## Summary
- rename dropdown element IDs in dashboard modal to match labels
- show the datatype for each field in the "Choose First Column" dropdown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d2dd81d08333bcab676bff4ccc0a