### PR TITLE
Enable bulk edit modal from list view

### DIFF
--- a/static/js/bulk_edit_modal.js
+++ b/static/js/bulk_edit_modal.js
@@ -1,0 +1,14 @@
+export function openBulkEditModal() {
+  document.getElementById('bulkEditModal').classList.remove('hidden');
+}
+
+export function closeBulkEditModal() {
+  document.getElementById('bulkEditModal').classList.add('hidden');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Placeholder for future initialization
+});
+
+window.openBulkEditModal = openBulkEditModal;
+window.closeBulkEditModal = closeBulkEditModal;

--- a/templates/bulk_edit_modal.html
+++ b/templates/bulk_edit_modal.html
@@ -1,0 +1,8 @@
+<div id="bulkEditModal" class="fixed inset-0 bg-black bg-opacity-50 hidden flex justify-center items-center z-50">
+  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full">
+    <h3 class="text-lg font-bold mb-4">Bulk Edit {{ table }}</h3>
+    <div class="text-center">
+      <button type="button" onclick="closeBulkEditModal()" class="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400">Close</button>
+    </div>
+  </div>
+</div>

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -100,11 +100,14 @@
         {% endfor %}
       </tbody>
     </table>
-  </div>
-  {% else %}
-    <p class="text-gray-600">No records found.</p>
-  {% endif %}
 </div>
+{% else %}
+  <p class="text-gray-600">No records found.</p>
+{% endif %}
+</div>
+
+{% include "bulk_edit_modal.html" %}
+<script type="module" src="{{ url_for('static', filename='js/bulk_edit_modal.js') }}"></script>
 
 <!-- Include column visibility JS -->
 <script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>


### PR DESCRIPTION
## Summary
- add a reusable `bulk_edit_modal.html` template
- create `bulk_edit_modal.js` with open/close helpers
- include the modal and script from `list_view.html`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6846d3562fa08333bcc033f02bdde5fe