### PR TITLE
Remove dashboard table selector

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -39,16 +39,11 @@ function initDashboardTabs() {
 }
 
 function initTableSelect() {
-  const container = document.getElementById('selectedTables');
-  const toggleBtn = document.getElementById('chooseTablesToggle');
-  const dropdown = document.getElementById('chooseTablesOptions');
   const columnContainer = document.getElementById('selectedColumns');
   const columnToggleBtn = document.getElementById('chooseFirstColumnToggle');
   const columnDropdown = document.getElementById('chooseFirstColumnOptions');
-  const divider = document.getElementById('columnDivider');
-  if (!container || !toggleBtn || !dropdown) return;
+  if (!columnContainer || !columnToggleBtn || !columnDropdown) return;
 
-  const checkboxes = dropdown.querySelectorAll('input[type="checkbox"]');
   let selectedColumn = null;
 
   function refreshColumnTags() {
@@ -74,24 +69,8 @@ function initTableSelect() {
     }
   }
 
-  function updateColumnOptions() {
-    if (!columnDropdown) return;
-    const tables = Array.from(checkboxes).filter(cb => cb.checked).map(cb => cb.value);
-    const valid = new Set();
-
+  function populateColumnOptions() {
     columnDropdown.innerHTML = '';
-    if (tables.length === 0) {
-      selectedColumn = null;
-      refreshColumnTags();
-      if (columnToggleBtn) columnToggleBtn.classList.add('hidden');
-      if (divider) divider.classList.add('hidden');
-      columnDropdown.classList.add('hidden');
-      return;
-    }
-
-    if (columnToggleBtn) columnToggleBtn.classList.remove('hidden');
-    if (divider) divider.classList.remove('hidden');
-
     const search = document.createElement('input');
     search.type = 'text';
     search.placeholder = 'Search...';
@@ -102,7 +81,8 @@ function initTableSelect() {
     });
     columnDropdown.appendChild(search);
 
-    tables.forEach(table => {
+    const valid = new Set();
+    Object.keys(FIELD_SCHEMA).forEach(table => {
       const fields = FIELD_SCHEMA[table] ? Object.keys(FIELD_SCHEMA[table]) : [];
       fields.forEach(field => {
         const val = `${table}:${field}`;
@@ -130,43 +110,6 @@ function initTableSelect() {
     refreshColumnTags();
   }
 
-  function refreshTags() {
-    container.innerHTML = '';
-    checkboxes.forEach(cb => {
-      if (cb.checked) {
-        const span = document.createElement('span');
-        span.className = 'inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full';
-        span.textContent = cb.value;
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'ml-1 text-blue-500 hover:text-red-500';
-        btn.textContent = '×';
-        btn.addEventListener('click', () => {
-          cb.checked = false;
-          refreshTags();
-        });
-        span.appendChild(btn);
-        container.appendChild(span);
-      }
-    });
-    updateColumnOptions();
-  }
-
-  toggleBtn.addEventListener('click', e => {
-    e.stopPropagation();
-    dropdown.classList.toggle('hidden');
-  });
-
-  document.addEventListener('click', e => {
-    if (!dropdown.contains(e.target) && e.target !== toggleBtn) {
-      dropdown.classList.add('hidden');
-    }
-  });
-
-  dropdown.addEventListener('click', e => e.stopPropagation());
-
-  checkboxes.forEach(cb => cb.addEventListener('change', refreshTags));
-
   if (columnToggleBtn && columnDropdown) {
     columnToggleBtn.addEventListener('click', e => {
       e.stopPropagation();
@@ -180,7 +123,8 @@ function initTableSelect() {
     columnDropdown.addEventListener('click', e => e.stopPropagation());
   }
 
-  refreshTags();
+  columnToggleBtn.classList.remove('hidden');
+  populateColumnOptions();
 }
 
 function initDashboardModal() {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -28,19 +28,6 @@
     </div>
     <div id="pane-value">
       <form id="dashboardTableForm" class="relative w-full" onsubmit="event.preventDefault();">
-        <div id="selectedTables" class="flex flex-wrap gap-1 mb-2"></div>
-        <button id="chooseTablesToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500">Choose Tables</button>
-        <div id="chooseTablesOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1">
-          <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l=>l.classList.toggle('hidden',!l.textContent.toLowerCase().includes(v)))">
-          {% for table in base_tables %}
-          <label class="flex items-center space-x-2">
-            <input type="checkbox" value="{{ table }}" class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
-            <span class="text-sm">{{ table }}</span>
-          </label>
-          {% endfor %}
-        </div>
-
-        <hr id="columnDivider" class="my-3 border-t-2 border-blue-600 hidden">
 
         <div id="selectedColumns" class="flex flex-wrap gap-1 mb-2"></div>
         <button id="chooseFirstColumnToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden">Choose First Column</button>


### PR DESCRIPTION
## Summary
- simplify dashboard modal form
- remove table selection logic in JavaScript

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846e612b358833394b8a1313d9b0c31