### PR TITLE
Update autosize text behavior

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -112,5 +112,5 @@ input[type=number] {
   align-items: center;
   justify-content: center;
   text-align: center;
-  overflow: hidden;
+  overflow: auto;
 }

--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -2,6 +2,8 @@ export function fitText(el) {
   const style = window.getComputedStyle(el);
   let fontSize = parseFloat(style.fontSize);
   if (!fontSize) return;
+  // Skip shrinking when layout grid is in editing mode
+  if (document.querySelector('#layout-grid.editing')) return;
   while ((el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight) && fontSize > 4) {
     fontSize -= 1;
     el.style.fontSize = fontSize + 'px';


### PR DESCRIPTION
## Summary
- allow scrollbars for `.autosize-text`
- skip font resizing while layout editor is active

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846e948df908333a30e9f96a8c3af6e