### PR TITLE
Add dashboard operation selection

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -6,6 +6,8 @@ export function closeDashboardModal() {
   document.getElementById('dashboardModal').classList.add('hidden');
 }
 
+let selectedOperation = null;
+
 function setActiveTab(name) {
   const tabs = ['value', 'table', 'chart'];
   const colorMap = {
@@ -123,12 +125,25 @@ function initTableSelect() {
     columnSelectDashboardOptions.addEventListener('click', e => e.stopPropagation());
   }
 
-  columnSelectDashboardToggle.classList.remove('hidden');
   populateColumnOptions();
+}
+
+function initOperationSelect() {
+  const opSelect = document.getElementById('dashboardOperation');
+  const columnToggle = document.getElementById('columnSelectDashboardToggle');
+  if (!opSelect) return;
+  opSelect.addEventListener('change', () => {
+    const checked = opSelect.querySelector('input[name="dashboardOperation"]:checked');
+    selectedOperation = checked ? checked.value : null;
+    if (columnToggle && selectedOperation) {
+      columnToggle.classList.remove('hidden');
+    }
+  });
 }
 
 function initDashboardModal() {
   initDashboardTabs();
+  initOperationSelect();
   initTableSelect();
 }
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -29,6 +29,17 @@
     <div id="pane-value">
       <form id="dashboardTableForm" class="relative w-full" onsubmit="event.preventDefault();">
 
+        <div id="dashboardOperation" class="flex gap-2 mb-4">
+          {% for op in ['Sum', 'Count', 'Math'] %}
+          <label class="flex-1 cursor-pointer">
+            <input type="radio" name="dashboardOperation" value="{{ op|lower }}" class="sr-only peer">
+            <div class="p-2 border rounded text-center peer-checked:bg-blue-500 peer-checked:text-white">
+              {{ op }}
+            </div>
+          </label>
+          {% endfor %}
+        </div>
+
         <div id="selectedColumns" class="flex flex-wrap gap-1 mb-2"></div>
         <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden">Choose First Column</button>
         <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>


### PR DESCRIPTION
## Summary
- add radio cards for dashboard operations
- hide column select until operation chosen
- track selected operation in dashboard JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ecec55ac8333a451ccee73380138