### PR TITLE
Fix autosize behavior while editing

### DIFF
--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -1,9 +1,12 @@
 export function fitText(el) {
+  // Skip shrinking when layout grid is currently being edited
+  if (document.querySelector('#layout-grid.editing')) {
+    return;
+  }
+
   const style = window.getComputedStyle(el);
   let fontSize = parseFloat(style.fontSize);
   if (!fontSize) return;
-  // Skip shrinking when layout grid is in editing mode
-  if (document.querySelector('#layout-grid.editing')) return;
   while ((el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight) && fontSize > 4) {
     fontSize -= 1;
     el.style.fontSize = fontSize + 'px';


### PR DESCRIPTION
## Summary
- avoid running `fitText` when the layout grid is in editing mode
- confirm `.autosize-text` uses `overflow: auto`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `eslint static/js/autosize_text.js` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6846ede617e88333b6c6770b29eab299