### PR TITLE
Revise single selects styling

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -41,102 +41,31 @@ function initDashboardTabs() {
 }
 
 function initTableSelect() {
-  const columnContainer = document.getElementById('selectedColumns');
-  const columnSelectDashboardToggle = document.getElementById('columnSelectDashboardToggle');
-  const columnSelectDashboardOptions = document.getElementById('columnSelectDashboardOptions');
-  if (!columnContainer || !columnSelectDashboardToggle || !columnSelectDashboardOptions) return;
+  const selectEl = document.getElementById('columnSelectDashboard');
+  if (!selectEl) return;
 
-  let selectedColumn = null;
-
-  function refreshColumnTags() {
-    if (!columnContainer || !columnSelectDashboardOptions) return;
-    columnContainer.innerHTML = '';
-    if (selectedColumn) {
-      const [table, field] = selectedColumn.split(':');
-      const span = document.createElement('span');
-      span.className = 'inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full';
-      span.innerHTML = `<strong>${table}</strong>: ${field}`;
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'ml-1 text-blue-500 hover:text-red-500';
-      btn.textContent = '×';
-      btn.addEventListener('click', () => {
-        const cb = columnSelectDashboardOptions.querySelector(`input[value="${selectedColumn}"]`);
-        if (cb) cb.checked = false;
-        selectedColumn = null;
-        refreshColumnTags();
-      });
-      span.appendChild(btn);
-      columnContainer.appendChild(span);
-    }
-  }
-
-  function populateColumnOptions() {
-    columnSelectDashboardOptions.innerHTML = '';
-    const search = document.createElement('input');
-    search.type = 'text';
-    search.placeholder = 'Search...';
-    search.className = 'w-full px-2 py-1 border rounded text-sm mb-2';
-    search.addEventListener('input', function() {
-      const v = this.value.toLowerCase();
-      [...columnSelectDashboardOptions.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)));
+  selectEl.innerHTML = '<option value="" disabled selected>Select Field</option>';
+  Object.keys(FIELD_SCHEMA).forEach(table => {
+    const fields = FIELD_SCHEMA[table] ? Object.keys(FIELD_SCHEMA[table]) : [];
+    fields.forEach(field => {
+      const type = FIELD_SCHEMA[table][field] ? FIELD_SCHEMA[table][field].type : '';
+      const opt = document.createElement('option');
+      opt.value = `${table}:${field}`;
+      opt.textContent = `${table}: ${field} (${type})`;
+      selectEl.appendChild(opt);
     });
-    columnSelectDashboardOptions.appendChild(search);
-
-    const valid = new Set();
-    Object.keys(FIELD_SCHEMA).forEach(table => {
-      const fields = FIELD_SCHEMA[table] ? Object.keys(FIELD_SCHEMA[table]) : [];
-      fields.forEach(field => {
-        const val = `${table}:${field}`;
-        valid.add(val);
-        const label = document.createElement('label');
-        label.className = 'flex items-center space-x-2';
-        const input = document.createElement('input');
-        input.type = 'radio';
-        input.name = 'columnSelect';
-        input.value = val;
-        input.className = 'rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500';
-        if (selectedColumn === val) input.checked = true;
-        input.addEventListener('change', () => { selectedColumn = val; refreshColumnTags(); });
-        const span = document.createElement('span');
-        span.className = 'text-sm';
-        const type = FIELD_SCHEMA[table] && FIELD_SCHEMA[table][field] ? FIELD_SCHEMA[table][field].type : '';
-        span.innerHTML = `<strong>${table}</strong>: ${field} <span class="text-blue-600 text-xs">(${type})</span>`;
-        label.appendChild(input);
-        label.appendChild(span);
-        columnSelectDashboardOptions.appendChild(label);
-      });
-    });
-
-    if (!valid.has(selectedColumn)) selectedColumn = null;
-    refreshColumnTags();
-  }
-
-  if (columnSelectDashboardToggle && columnSelectDashboardOptions) {
-    columnSelectDashboardToggle.addEventListener('click', e => {
-      e.stopPropagation();
-      columnSelectDashboardOptions.classList.toggle('hidden');
-    });
-    document.addEventListener('click', e => {
-      if (!columnSelectDashboardOptions.contains(e.target) && e.target !== columnSelectDashboardToggle) {
-        columnSelectDashboardOptions.classList.add('hidden');
-      }
-    });
-    columnSelectDashboardOptions.addEventListener('click', e => e.stopPropagation());
-  }
-
-  populateColumnOptions();
+  });
 }
 
 function initOperationSelect() {
   const opSelect = document.getElementById('dashboardOperation');
-  const columnToggle = document.getElementById('columnSelectDashboardToggle');
+  const columnSelect = document.getElementById('columnSelectDashboard');
   if (!opSelect) return;
   opSelect.addEventListener('change', () => {
     const checked = opSelect.querySelector('input[name="dashboardOperation"]:checked');
     selectedOperation = checked ? checked.value : null;
-    if (columnToggle && selectedOperation) {
-      columnToggle.classList.remove('hidden');
+    if (columnSelect && selectedOperation) {
+      columnSelect.classList.remove('hidden');
     }
   });
 }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -40,9 +40,9 @@
           {% endfor %}
         </div>
 
-        <div id="selectedColumns" class="flex flex-wrap gap-1 mb-2"></div>
-        <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden">Select Field</button>
-        <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+        <select id="columnSelectDashboard" name="columnSelect" class="hidden block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200">
+          <option value="" disabled selected>Select Field</option>
+        </select>
       </form>
     </div>
     <div id="pane-table" class="hidden">

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -140,7 +140,7 @@
      class="fixed inset-0 bg-black bg-opacity-50 hidden flex justify-center items-center z-50">
   <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full">
     <h3 class="text-lg font-bold mb-4">Add Relation</h3>
-    <select id="relationOptions" class="w-full border rounded p-2 mb-4">
+    <select id="relationOptions" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200 mb-4">
       <option>Loading...</option>
     </select>
     <div class="flex justify-end space-x-2">

--- a/templates/edit_fields_modal.html
+++ b/templates/edit_fields_modal.html
@@ -23,7 +23,7 @@
         <input name="field_name" type="text" class="w-full border px-3 py-2 rounded mb-4" required>
         <label class="block mb-2 text-sm font-medium">Field Type</label>
         {% set types_seen = [] %}
-        <select id="field_type" name="field_type" class="w-full border px-3 py-2 rounded">
+        <select id="field_type" name="field_type" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200">
           <option disabled selected>Select type</option>
           {% for table_fields in field_schema.values() %}
             {% for field, meta in table_fields.items() %}
@@ -40,7 +40,7 @@
         </div>
         <div id="fk-select-container" class="hidden mb-4">
           <label class="block mb-2 text-sm font-medium">Select linked field</label>
-          <select name="foreign_key_target" class="w-full border px-3 py-2 rounded">
+          <select name="foreign_key_target" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200">
             <option value="" disabled selected>Select field</option>
             {% for source_table, fields in field_schema.items() %}
               {% for field, meta in fields.items() %}
@@ -66,10 +66,10 @@
       <h3 class="text-lg font-bold mb-4">Remove Field from {{table}}</h3>
       <form id="remove-field-form" method="POST" action="/{{table}}/{{record.id}}/remove-field">
         <label for="field-to-remove" class="block text-sm font-medium">Select Field to Remove</label>
-        <select 
-          id="field-to-remove" 
-          name="field_name" 
-          class="mt-1 block w-full border px-3 py-2 rounded" 
+        <select
+          id="field-to-remove"
+          name="field_name"
+          class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200 mt-1"
           onchange="fetchRemoveCount(this.value)"
           required>
           <option value="" disabled selected>Select field</option>

--- a/templates/import_view.html
+++ b/templates/import_view.html
@@ -9,7 +9,7 @@
     <div class="flex items-center space-x-4">
       <form method="GET" action="/import" class="flex items-center space-x-2">
         <label for="table" class="font-medium mr-2">Select Base Table</label>
-        <select name="table" id="table" class="border rounded px-3 py-2" onchange="this.form.submit()">
+        <select name="table" id="table" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200" onchange="this.form.submit()">
             <option value="" disabled {% if not selected_table %}selected{% endif %}>Choose a table</option>
             {% for table in schema.keys() %}
                 <option value="{{ table }}" {% if selected_table == table %}selected{% endif %}>{{ table|capitalize }}</option>
@@ -45,7 +45,7 @@
               <div class="flex justify-between items-center">
                 <strong>{{ header }}</strong>
                 <div id="select-wrapper-{{ header }}" class="ml-auto">
-                  <select name="match_{{ header }}" data-header="{{ header }}" data-table="{{ selected_table }}" class="border rounded px-2 py-1 text-sm">
+                  <select name="match_{{ header }}" data-header="{{ header }}" data-table="{{ selected_table }}" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200">
                     <option value="">Unmatched</option>
                     {% for field, data in field_status.items() %}
                       {% if not data.matched %}
@@ -78,7 +78,7 @@
   </div>
   {% endif %}
   <template id="dropdown-template">
-    <select name="match___HEADER__" data-header="__HEADER__" class="border rounded px-2 py-1 text-sm" data-table="{{ selected_table }}">
+    <select name="match___HEADER__" data-header="__HEADER__" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200" data-table="{{ selected_table }}">
       <option value="">Unmatched</option>
       {% for field, data in field_status.items() %}
         {% if not data.matched %}

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -22,7 +22,7 @@
       <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="inline">
         <input type="hidden" name="field" value="{{ field }}">
         <select name="new_value"
-        class="appearance-none bg-white border border-gray-300 text-sm px-3 py-2 pr-8 rounded shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+        class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200"
         onchange="submitFieldAjax(this.form)">
           {% for option in field_schema[table][field].options %}
             <option value="{{ option }}" {% if option == value %}selected{% endif %}>{{ option }}</option>


### PR DESCRIPTION
## Summary
- simplify column select in dashboard modal
- restyle single select elements with underline look

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846f1dc19a483339cb36bcc4196bc5e