### PR TITLE
Improve autosize text containers

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -107,10 +107,10 @@ input[type=number] {
 
 .autosize-text {
   width: 100%;
-  height: 100%;
+  height: calc(100% - 1.5em); /* leave room for field label */
   display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
-  overflow: auto;
+  overflow: hidden;
 }

--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -4,6 +4,9 @@ export function fitText(el) {
     return;
   }
 
+  // reset font size before fitting so enlargements after resize work
+  el.style.fontSize = '';
+
   const style = window.getComputedStyle(el);
   let fontSize = parseFloat(style.fontSize);
   if (!fontSize) return;

--- a/static/js/layout_editor.js
+++ b/static/js/layout_editor.js
@@ -89,6 +89,9 @@ function resetLayout() {
     console.debug(`[layout] resetLayout field "${field}": col ${colStart}→span ${widthUnits}, row ${rowStart}→span ${rowSpan}em → cache:`, layoutCache[field]);
   });
   console.groupEnd();
+  if (window.initAutosizeText) {
+    window.initAutosizeText();
+  }
 }
 
 function handleSaveLayout() {
@@ -125,6 +128,9 @@ function handleSaveLayout() {
       saveLayoutBtn.classList.add('hidden');
       console.info("[layout] saveLayout end");
       console.groupEnd();
+      if (window.initAutosizeText) {
+        window.initAutosizeText();
+      }
     })
     .catch(err => { console.error("[layout] saveLayout error", err); console.groupEnd(); });
 }
@@ -233,6 +239,9 @@ function enableVanillaDrag() {
 
     document.removeEventListener('mousemove', onMouseMove);
     document.removeEventListener('mouseup', onMouseUp);
+    if (window.initAutosizeText) {
+      window.initAutosizeText();
+    }
   }
 }
 
@@ -328,6 +337,9 @@ function enableVanillaResize() {
       revertPosition(fieldEl);
     } else {
       layoutCache[field] = newRect;
+    }
+    if (window.initAutosizeText) {
+      window.initAutosizeText();
     }
   }
 }


### PR DESCRIPTION
## Summary
- ensure autosize text boxes fit inside draggable containers
- re-run font fitting after resizing or moving fields
- reset font size before recalculating

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846f72ced9c8333b085bef16e1a3b30