### PR TITLE
Add X button for dashboard modal

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -12,7 +12,8 @@
 
 <!-- Dashboard Add Modal -->
 <div id="dashboardModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full">
+  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+    <button onclick="closeDashboardModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <div class="mb-4">
       <ul class="flex border-b border-gray-200">
         <li class="-mb-px mr-1">
@@ -50,9 +51,6 @@
     </div>
     <div id="pane-chart" class="hidden">
       <p class="mb-4">Chart tab content coming soon.</p>
-    </div>
-    <div class="text-center">
-      <button onclick="closeDashboardModal()" class="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400">Close</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- replace the bottom Close button in dashboard modal
- add a small `×` button in the upper-right corner of the modal

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6846f93d51848333b0ff756601eba487