### PR TITLE
Add multi-select for Math dashboard operation

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -7,6 +7,8 @@ export function closeDashboardModal() {
 }
 
 let selectedOperation = null;
+let selectedColumn = null;
+let columnContainer, columnToggleBtn, columnDropdown;
 
 function setActiveTab(name) {
   const tabs = ['value', 'table', 'chart'];
@@ -40,40 +42,147 @@ function initDashboardTabs() {
   });
 }
 
-function initTableSelect() {
-  const selectEl = document.getElementById('columnSelectDashboard');
-  if (!selectEl) return;
+function refreshColumnTags() {
+  if (!columnContainer) return;
+  columnContainer.innerHTML = '';
+  if (!selectedColumn) return;
 
-  selectEl.innerHTML = '<option value="" disabled selected>Select Field</option>';
+  const values = Array.isArray(selectedColumn) ? selectedColumn : [selectedColumn];
+  values.forEach(val => {
+    const [table, field] = val.split(':');
+    const span = document.createElement('span');
+    span.className = 'inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full';
+    span.innerHTML = `<strong>${table}</strong>: ${field}`;
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'ml-1 text-blue-500 hover:text-red-500';
+    btn.textContent = '×';
+    btn.addEventListener('click', () => {
+      const input = columnDropdown.querySelector(`input[value="${val}"]`);
+      if (input) input.checked = false;
+      if (Array.isArray(selectedColumn)) {
+        selectedColumn = selectedColumn.filter(v => v !== val);
+      } else {
+        selectedColumn = null;
+      }
+      refreshColumnTags();
+    });
+    span.appendChild(btn);
+    columnContainer.appendChild(span);
+  });
+}
+
+function updateColumnOptions() {
+  if (!columnDropdown || !columnToggleBtn) return;
+
+  if (!selectedOperation) {
+    columnToggleBtn.classList.add('hidden');
+    columnDropdown.classList.add('hidden');
+    selectedColumn = null;
+    refreshColumnTags();
+    return;
+  }
+
+  columnToggleBtn.classList.remove('hidden');
+  columnDropdown.innerHTML = '';
+
+  const inputType = selectedOperation === 'math' ? 'checkbox' : 'radio';
+
+  if (selectedOperation === 'math' && !Array.isArray(selectedColumn)) {
+    selectedColumn = [];
+  }
+  if (selectedOperation !== 'math' && Array.isArray(selectedColumn)) {
+    selectedColumn = selectedColumn[0] || null;
+  }
+
+  const search = document.createElement('input');
+  search.type = 'text';
+  search.placeholder = 'Search...';
+  search.className = 'w-full px-2 py-1 border rounded text-sm mb-2';
+  search.addEventListener('input', function() {
+    const v = this.value.toLowerCase();
+    [...columnDropdown.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)));
+  });
+  columnDropdown.appendChild(search);
+
   Object.keys(FIELD_SCHEMA).forEach(table => {
     const fields = FIELD_SCHEMA[table] ? Object.keys(FIELD_SCHEMA[table]) : [];
     fields.forEach(field => {
-      const type = FIELD_SCHEMA[table][field] ? FIELD_SCHEMA[table][field].type : '';
-      const opt = document.createElement('option');
-      opt.value = `${table}:${field}`;
-      opt.textContent = `${table}: ${field} (${type})`;
-      selectEl.appendChild(opt);
+      const val = `${table}:${field}`;
+      const label = document.createElement('label');
+      label.className = 'flex items-center space-x-2';
+      const input = document.createElement('input');
+      input.type = inputType;
+      input.name = 'columnSelect';
+      input.value = val;
+      input.className = 'rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500';
+
+      if (inputType === 'checkbox') {
+        if (selectedColumn.includes(val)) input.checked = true;
+        input.addEventListener('change', () => {
+          if (input.checked) {
+            if (!selectedColumn.includes(val)) selectedColumn.push(val);
+          } else {
+            selectedColumn = selectedColumn.filter(v => v !== val);
+          }
+          refreshColumnTags();
+        });
+      } else {
+        if (selectedColumn === val) input.checked = true;
+        input.addEventListener('change', () => {
+          selectedColumn = val;
+          refreshColumnTags();
+        });
+      }
+
+      const span = document.createElement('span');
+      span.className = 'text-sm';
+      const type = FIELD_SCHEMA[table] && FIELD_SCHEMA[table][field] ? FIELD_SCHEMA[table][field].type : '';
+      span.innerHTML = `<strong>${table}</strong>: ${field} <span class="text-blue-600 text-xs">(${type})</span>`;
+      label.appendChild(input);
+      label.appendChild(span);
+      columnDropdown.appendChild(label);
     });
   });
+
+  refreshColumnTags();
+}
+
+function initColumnSelect() {
+  columnContainer = document.getElementById('selectedColumns');
+  columnToggleBtn = document.getElementById('columnSelectDashboardToggle');
+  columnDropdown = document.getElementById('columnSelectDashboardOptions');
+  if (!columnContainer || !columnToggleBtn || !columnDropdown) return;
+
+  columnToggleBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    columnDropdown.classList.toggle('hidden');
+  });
+  document.addEventListener('click', e => {
+    if (!columnDropdown.contains(e.target) && e.target !== columnToggleBtn) {
+      columnDropdown.classList.add('hidden');
+    }
+  });
+  columnDropdown.addEventListener('click', e => e.stopPropagation());
+
+  updateColumnOptions();
 }
 
 function initOperationSelect() {
   const opSelect = document.getElementById('dashboardOperation');
-  const columnSelect = document.getElementById('columnSelectDashboard');
   if (!opSelect) return;
   opSelect.addEventListener('change', () => {
     const checked = opSelect.querySelector('input[name="dashboardOperation"]:checked');
     selectedOperation = checked ? checked.value : null;
-    if (columnSelect && selectedOperation) {
-      columnSelect.classList.remove('hidden');
-    }
+    selectedColumn = selectedOperation === 'math' ? [] : null;
+    updateColumnOptions();
   });
 }
 
 function initDashboardModal() {
   initDashboardTabs();
   initOperationSelect();
-  initTableSelect();
+  initColumnSelect();
 }
 
 document.addEventListener('DOMContentLoaded', initDashboardModal);

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -41,9 +41,9 @@
           {% endfor %}
         </div>
 
-        <select id="columnSelectDashboard" name="columnSelect" class="hidden block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200">
-          <option value="" disabled selected>Select Field</option>
-        </select>
+        <div id="selectedColumns" class="flex flex-wrap gap-1 mb-2"></div>
+        <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden">Select Field</button>
+        <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
       </form>
     </div>
     <div id="pane-table" class="hidden">


### PR DESCRIPTION
## Summary
- allow multiple column selection on the Math tab of the dashboard modal
- show selected columns as removable tags
- generate radio buttons for Sum/Count, checkboxes for Math

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/js/dashboard_modal.js`


------
https://chatgpt.com/codex/tasks/task_e_6846fe1529a083339f8feaa1665d9280