### PR TITLE
Update bulk edit modal with close icon

### DIFF
--- a/templates/bulk_edit_modal.html
+++ b/templates/bulk_edit_modal.html
@@ -1,8 +1,6 @@
 <div id="bulkEditModal" class="fixed inset-0 bg-black bg-opacity-50 hidden flex justify-center items-center z-50">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full">
+  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+    <button onclick="closeBulkEditModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <h3 class="text-lg font-bold mb-4">Bulk Edit {{ table }}</h3>
-    <div class="text-center">
-      <button type="button" onclick="closeBulkEditModal()" class="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400">Close</button>
-    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- tweak bulk edit modal
  - remove text "Close" button
  - add positioned `×` icon for closing the modal

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846ff8b601c8333bd6c23328768d80f