### PR TITLE
Restore dashboard table selection

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -8,7 +8,9 @@ export function closeDashboardModal() {
 
 let selectedOperation = null;
 let selectedColumn = null;
+let selectedTables = [];
 let columnContainer, columnToggleBtn, columnDropdown;
+let tableContainer, tableToggleBtn, tableDropdown, tableDivider;
 
 function setActiveTab(name) {
   const tabs = ['value', 'table', 'chart'];
@@ -68,20 +70,75 @@ function refreshColumnTags() {
       refreshColumnTags();
     });
     span.appendChild(btn);
-    columnContainer.appendChild(span);
+  columnContainer.appendChild(span);
   });
+}
+
+function refreshTableTags() {
+  if (!tableContainer) return;
+  tableContainer.innerHTML = '';
+  selectedTables = [];
+  tableDropdown.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+    if (cb.checked) {
+      selectedTables.push(cb.value);
+      const span = document.createElement('span');
+      span.className = 'inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full';
+      span.textContent = cb.value;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'ml-1 text-blue-500 hover:text-red-500';
+      btn.textContent = '×';
+      btn.addEventListener('click', () => {
+        cb.checked = false;
+        refreshTableTags();
+      });
+      span.appendChild(btn);
+      tableContainer.appendChild(span);
+    }
+  });
+  updateColumnOptions();
+}
+
+function initTableSelect() {
+  tableContainer = document.getElementById('selectedTables');
+  tableToggleBtn = document.getElementById('chooseTablesToggle');
+  tableDropdown = document.getElementById('chooseTablesOptions');
+  tableDivider = document.getElementById('columnDivider');
+  if (!tableContainer || !tableToggleBtn || !tableDropdown) return;
+
+  tableToggleBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    tableDropdown.classList.toggle('hidden');
+  });
+  document.addEventListener('click', e => {
+    if (!tableDropdown.contains(e.target) && e.target !== tableToggleBtn) {
+      tableDropdown.classList.add('hidden');
+    }
+  });
+  tableDropdown.addEventListener('click', e => e.stopPropagation());
+
+  tableDropdown.querySelectorAll('input[type="checkbox"]').forEach(cb => cb.addEventListener('change', () => {
+    refreshTableTags();
+    if (tableDivider) tableDivider.classList.toggle('hidden', selectedTables.length === 0);
+  }));
+
+  refreshTableTags();
+  if (tableDivider) tableDivider.classList.add('hidden');
 }
 
 function updateColumnOptions() {
   if (!columnDropdown || !columnToggleBtn) return;
 
-  if (!selectedOperation) {
+  if (!selectedOperation || selectedTables.length === 0) {
     columnToggleBtn.classList.add('hidden');
     columnDropdown.classList.add('hidden');
-    selectedColumn = null;
+    if (tableDivider) tableDivider.classList.add('hidden');
+    selectedColumn = selectedOperation === 'math' ? [] : null;
     refreshColumnTags();
     return;
   }
+
+  if (tableDivider) tableDivider.classList.remove('hidden');
 
   columnToggleBtn.classList.remove('hidden');
   columnDropdown.innerHTML = '';
@@ -105,7 +162,7 @@ function updateColumnOptions() {
   });
   columnDropdown.appendChild(search);
 
-  Object.keys(FIELD_SCHEMA).forEach(table => {
+  selectedTables.forEach(table => {
     const fields = FIELD_SCHEMA[table] ? Object.keys(FIELD_SCHEMA[table]) : [];
     fields.forEach(field => {
       const val = `${table}:${field}`;
@@ -182,6 +239,7 @@ function initOperationSelect() {
 function initDashboardModal() {
   initDashboardTabs();
   initOperationSelect();
+  initTableSelect();
   initColumnSelect();
 }
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -41,6 +41,20 @@
           {% endfor %}
         </div>
 
+        <div id="selectedTables" class="flex flex-wrap gap-1 mb-2"></div>
+        <button id="chooseTablesToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500">Choose Tables</button>
+        <div id="chooseTablesOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1">
+          <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l=>l.classList.toggle('hidden',!l.textContent.toLowerCase().includes(v)))">
+          {% for table in base_tables %}
+          <label class="flex items-center space-x-2">
+            <input type="checkbox" value="{{ table }}" class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
+            <span class="text-sm">{{ table }}</span>
+          </label>
+          {% endfor %}
+        </div>
+
+        <hr id="columnDivider" class="my-3 border-t-2 border-blue-600 hidden">
+
         <div id="selectedColumns" class="flex flex-wrap gap-1 mb-2"></div>
         <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden">Select Field</button>
         <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>


### PR DESCRIPTION
## Summary
- reintroduce table selection markup
- show column options once tables and operation chosen
- support multi-select columns for math operations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684703176d5883339252818b576ebb66