### PR TITLE
Fix dashboard modal tabs init

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -244,6 +244,12 @@ function initDashboardModal() {
 }
 
 document.addEventListener('DOMContentLoaded', initDashboardModal);
+// If the script loads after DOMContentLoaded has already fired (e.g. when
+// included at the end of the page), the event above won't trigger. Call the
+// initializer immediately in that case so the modal tabs are interactive.
+if (document.readyState !== 'loading') {
+  initDashboardModal();
+}
 
 window.openDashboardModal = openDashboardModal;
 window.closeDashboardModal = closeDashboardModal;


### PR DESCRIPTION
## Summary
- fix initialization timing so dashboard modal tabs respond to clicks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684706542b0c83339c73fe91c0f55642