### PR TITLE
Simplify text resize logic with CSS

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -108,7 +108,9 @@ input[type=number] {
 
 .autosize-text {
   width: 100%;
-  height: calc(100% - 1.5em); /* leave room for field label */
+  /* allow font size to depend on container width */
+  container-type: inline-size;
+  font-size: clamp(0.75rem, 10cqw, 1.5rem);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -1,20 +1,4 @@
-export function fitText(el) {
-  // Skip shrinking when layout grid is currently being edited
-  if (document.querySelector('#layout-grid.editing')) {
-    return;
-  }
-
-  // reset font size before fitting so enlargements after resize work
-  el.style.fontSize = '';
-
-  const style = window.getComputedStyle(el);
-  let fontSize = parseFloat(style.fontSize);
-  if (!fontSize) return;
-  while ((el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight) && fontSize > 4) {
-    fontSize -= 1;
-    el.style.fontSize = fontSize + 'px';
-  }
-}
+// Inline editing for text fields
 
 function makeEditable(displayEl) {
   const value = displayEl.textContent.trim();
@@ -63,7 +47,6 @@ function makeEditable(displayEl) {
 }
 
 export function attach(el) {
-  fitText(el);
   el.addEventListener('click', () => makeEditable(el));
 }
 


### PR DESCRIPTION
## Summary
- drop JavaScript font fitting
- use container queries for `.autosize-text`
- keep inline editing JS for text fields

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846f92a97508333a2486706a536543b