### PR TITLE
Remove unused table dropdown from dashboard

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -8,9 +8,7 @@ export function closeDashboardModal() {
 
 let selectedOperation = null;
 let selectedColumn = null;
-let selectedTables = [];
 let columnContainer, columnToggleBtn, columnDropdown;
-let tableContainer, tableToggleBtn, tableDropdown, tableDivider;
 
 function setActiveTab(name) {
   const tabs = ['value', 'table', 'chart'];
@@ -74,71 +72,17 @@ function refreshColumnTags() {
   });
 }
 
-function refreshTableTags() {
-  if (!tableContainer) return;
-  tableContainer.innerHTML = '';
-  selectedTables = [];
-  tableDropdown.querySelectorAll('input[type="checkbox"]').forEach(cb => {
-    if (cb.checked) {
-      selectedTables.push(cb.value);
-      const span = document.createElement('span');
-      span.className = 'inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full';
-      span.textContent = cb.value;
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'ml-1 text-blue-500 hover:text-red-500';
-      btn.textContent = '×';
-      btn.addEventListener('click', () => {
-        cb.checked = false;
-        refreshTableTags();
-      });
-      span.appendChild(btn);
-      tableContainer.appendChild(span);
-    }
-  });
-  updateColumnOptions();
-}
-
-function initTableSelect() {
-  tableContainer = document.getElementById('selectedTables');
-  tableToggleBtn = document.getElementById('chooseTablesToggle');
-  tableDropdown = document.getElementById('chooseTablesOptions');
-  tableDivider = document.getElementById('columnDivider');
-  if (!tableContainer || !tableToggleBtn || !tableDropdown) return;
-
-  tableToggleBtn.addEventListener('click', e => {
-    e.stopPropagation();
-    tableDropdown.classList.toggle('hidden');
-  });
-  document.addEventListener('click', e => {
-    if (!tableDropdown.contains(e.target) && e.target !== tableToggleBtn) {
-      tableDropdown.classList.add('hidden');
-    }
-  });
-  tableDropdown.addEventListener('click', e => e.stopPropagation());
-
-  tableDropdown.querySelectorAll('input[type="checkbox"]').forEach(cb => cb.addEventListener('change', () => {
-    refreshTableTags();
-    if (tableDivider) tableDivider.classList.toggle('hidden', selectedTables.length === 0);
-  }));
-
-  refreshTableTags();
-  if (tableDivider) tableDivider.classList.add('hidden');
-}
 
 function updateColumnOptions() {
   if (!columnDropdown || !columnToggleBtn) return;
 
-  if (!selectedOperation || selectedTables.length === 0) {
+  if (!selectedOperation) {
     columnToggleBtn.classList.add('hidden');
     columnDropdown.classList.add('hidden');
-    if (tableDivider) tableDivider.classList.add('hidden');
     selectedColumn = selectedOperation === 'math' ? [] : null;
     refreshColumnTags();
     return;
   }
-
-  if (tableDivider) tableDivider.classList.remove('hidden');
 
   columnToggleBtn.classList.remove('hidden');
   columnDropdown.innerHTML = '';
@@ -162,7 +106,7 @@ function updateColumnOptions() {
   });
   columnDropdown.appendChild(search);
 
-  selectedTables.forEach(table => {
+  BASE_TABLES.forEach(table => {
     const fields = FIELD_SCHEMA[table] ? Object.keys(FIELD_SCHEMA[table]) : [];
     fields.forEach(field => {
       const val = `${table}:${field}`;
@@ -239,7 +183,6 @@ function initOperationSelect() {
 function initDashboardModal() {
   initDashboardTabs();
   initOperationSelect();
-  initTableSelect();
   initColumnSelect();
 }
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -41,19 +41,7 @@
           {% endfor %}
         </div>
 
-        <div id="selectedTables" class="flex flex-wrap gap-1 mb-2"></div>
-        <button id="chooseTablesToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500">Choose Tables</button>
-        <div id="chooseTablesOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1">
-          <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l=>l.classList.toggle('hidden',!l.textContent.toLowerCase().includes(v)))">
-          {% for table in base_tables %}
-          <label class="flex items-center space-x-2">
-            <input type="checkbox" value="{{ table }}" class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
-            <span class="text-sm">{{ table }}</span>
-          </label>
-          {% endfor %}
-        </div>
-
-        <hr id="columnDivider" class="my-3 border-t-2 border-blue-600 hidden">
+        <hr class="my-3 border-t-2 border-blue-600">
 
         <div id="selectedColumns" class="flex flex-wrap gap-1 mb-2"></div>
         <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden">Select Field</button>
@@ -69,6 +57,9 @@
   </div>
 </div>
 
-<script>const FIELD_SCHEMA = {{ field_schema | tojson }};</script>
+<script>
+  const FIELD_SCHEMA = {{ field_schema | tojson }};
+  const BASE_TABLES = {{ base_tables | tojson }};
+</script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_modal.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove table selection markup and JS
- show column options across all tables
- inject BASE_TABLES constant for JS

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684707e4481483338fea86436ff7c390