### PR TITLE
Fix autosizing for draggable text fields

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -14,6 +14,8 @@ input[type=number] {
   box-shadow: none !important;
   background-color: transparent !important;
   padding: 0.25rem !important; /* tiny barrier in all modes */
+  /* allow content to size based on the draggable card width */
+  container-type: inline-size;
 }
 
 /* 2) In edit mode, reset padding only */


### PR DESCRIPTION
## Summary
- ensure draggable field acts as a container for text size queries

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684715eab5308333b407e01d0dace29c