### PR TITLE
Fix select dropdown in layout edit mode

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -79,6 +79,10 @@ input[type=number] {
 #layout-grid.editing .draggable-field > *:not(.resize-handle):not(.ui-resizable-handle) {
   pointer-events: none;
 }
+/* Allow select dropdowns to be used while editing layout */
+#layout-grid.editing .draggable-field select {
+  pointer-events: auto;
+}
 
 #layout-grid.editing .ui-resizable-handle,
 #layout-grid.editing .draggable-field {


### PR DESCRIPTION
## Summary
- allow pointer events on select elements even when editing layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_68471aaeba3083338fc998e3c5f09b57