### PR TITLE
Fix select dropdown click handling

### DIFF
--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -46,7 +46,7 @@
         </div>
 
         <!-- Toggle & search -->
-        <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500" onclick="this.nextElementSibling.classList.toggle('hidden')">
+        <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500" onclick="event.stopPropagation(); this.nextElementSibling.classList.toggle('hidden')">
           Choose Tags
         </button>
 
@@ -94,7 +94,7 @@
         </div>
 
         <!-- Toggle & search -->
-        <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500" onclick="this.nextElementSibling.classList.toggle('hidden')">
+        <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500" onclick="event.stopPropagation(); this.nextElementSibling.classList.toggle('hidden')">
           Choose Tags
         </button>
 


### PR DESCRIPTION
## Summary
- allow dropdown open click by stopping event propagation in tag selector button

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68471d5a289c83339e7ee4c6920642ef