### PR TITLE
Fix select dropdown in layout editor

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -77,7 +77,8 @@ input[type=number] {
 
 /* Disable clicks on inner content, but keep handles active */
 #layout-grid.editing .draggable-field > *:not(.resize-handle):not(.ui-resizable-handle) {
-  pointer-events: none;
+  /* allow interaction with form controls while editing */
+  pointer-events: auto;
 }
 
 #layout-grid.editing .ui-resizable-handle,

--- a/static/js/layout_editor.js
+++ b/static/js/layout_editor.js
@@ -156,6 +156,7 @@ function enableVanillaDrag() {
 
   layoutGrid.addEventListener('mousedown', e => {
     if (e.target.classList.contains('resize-handle')) return;
+    if (e.target.closest('input, select, textarea, button, label')) return;
     fieldEl = e.target.closest('.draggable-field');
     field = fieldEl?.dataset.field;
     if (!fieldEl || !field) return;


### PR DESCRIPTION
## Summary
- allow interaction with form controls during layout editing
- avoid starting drag operations when clicking on form elements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68471c368f4c8333995752f009140bdb