### PR TITLE
Autosize title field on detail view

### DIFF
--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -27,14 +27,14 @@ function makeEditable(displayEl) {
 
   const finish = () => {
     submitFieldAjax(form);
-    const newDiv = document.createElement('div');
-    newDiv.className = 'autosize-text';
-    newDiv.dataset.field = displayEl.dataset.field;
-    newDiv.dataset.recordId = displayEl.dataset.recordId;
-    newDiv.dataset.updateUrl = displayEl.dataset.updateUrl;
-    newDiv.textContent = input.value;
-    form.replaceWith(newDiv);
-    attach(newDiv);
+    const newEl = document.createElement(displayEl.tagName.toLowerCase());
+    newEl.className = displayEl.className;
+    newEl.dataset.field = displayEl.dataset.field;
+    newEl.dataset.recordId = displayEl.dataset.recordId;
+    newEl.dataset.updateUrl = displayEl.dataset.updateUrl;
+    newEl.textContent = input.value;
+    form.replaceWith(newEl);
+    attach(newEl);
   };
 
   input.addEventListener('blur', finish, { once: true });

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -11,8 +11,14 @@
   <!-- Left: Main Details -->
   <div class="flex-1">
     {% set display_value = record.get(table) or record.get("title") or record.get("name") or "Untitled" %}
-    <h1 class="text-2xl font-bold mb-4">
-      {{ display_value }}
+    {% set title_field = (table if record.get(table) is not none else ( 'title' if record.get('title') is not none else 'name' )) %}
+    <h1 class="font-bold text-2xl mb-4 flex items-center space-x-2">
+      <span class="autosize-text" style="width:auto; display:inline-flex;"
+            data-field="{{ title_field }}"
+            data-record-id="{{ record.id }}"
+            data-update-url="{{ url_for('update_field', table=table, record_id=record.id) }}">
+        {{ display_value }}
+      </span>
       <span class="text-gray-500 text-base">(ID {{ record.id }})</span>
     </h1>
 


### PR DESCRIPTION
## Summary
- allow autosize_text.js to recreate the same tag when finishing edits
- enable autosizing and inline edit for the page title in `detail_view.html`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68471ad7f4508333bd39dfe953bdfe19