### PR TITLE
Improve modal closing UX

### DIFF
--- a/templates/bulk_edit_modal.html
+++ b/templates/bulk_edit_modal.html
@@ -1,8 +1,7 @@
-<div id="bulkEditModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full">
+<div id="bulkEditModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
+     onclick="if(event.target.id === 'bulkEditModal') closeBulkEditModal()">
+  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+    <button type="button" onclick="closeBulkEditModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <h3 class="text-lg font-bold mb-4">Bulk Edit {{ table }}</h3>
-    <div class="text-center">
-      <button type="button" onclick="closeBulkEditModal()" class="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400">Close</button>
-    </div>
   </div>
 </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -11,7 +11,8 @@
 <p class="text-gray-600">This page is under construction.</p>
 
 <!-- Dashboard Add Modal -->
-<div id="dashboardModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50">
+<div id="dashboardModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
+     onclick="if(event.target.id === 'dashboardModal') closeDashboardModal()">
   <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button onclick="closeDashboardModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <div class="mb-4">

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -137,19 +137,15 @@
 
 <!-- Relation Modal -->
 <div id="relationModal"
-     class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full">
+     class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
+     onclick="if(event.target.id === 'relationModal') closeModal()">
+  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+    <button type="button" onclick="closeModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <h3 class="text-lg font-bold mb-4">Add Relation</h3>
     <select id="relationOptions" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200 mb-4">
       <option>Loading...</option>
     </select>
-    <div class="flex justify-end space-x-2">
-      <button
-        onclick="closeModal()"
-        class="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400"
-      >
-        Cancel
-      </button>
+    <div class="flex justify-end">
       <button
         onclick="submitRelation()"
         class="px-4 py-2 rounded bg-green-500 text-white hover:bg-green-600"

--- a/templates/edit_fields_modal.html
+++ b/templates/edit_fields_modal.html
@@ -1,5 +1,7 @@
-<div id="layoutModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full">
+<div id="layoutModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
+     onclick="if(event.target.id === 'layoutModal') closeLayoutModal()">
+  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+    <button type="button" onclick="closeLayoutModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <div class="mb-4">
       <ul class="flex border-b border-gray-200">
         <li class="-mb-px mr-1">
@@ -51,9 +53,7 @@
             {% endfor %}
           </select>
         </div>
-        <div class="flex justify-end space-x-2 mt-4">
-          <button type="button" onclick="closeLayoutModal()"
-                  class="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400">Cancel</button>
+        <div class="flex justify-end mt-4">
           <button type="submit"
                   class="px-4 py-2 rounded bg-green-500 text-white hover:bg-green-600">Submit</button>
         </div>
@@ -93,12 +93,11 @@
           </label>
         </div>
 
-        <div class="flex justify-end mt-4 space-x-2">
-          <button type="button" onclick="closeLayoutModal()" class="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400">Cancel</button>
-          <button 
-            id="remove-submit-btn" 
-            type="submit" 
-            class="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50" 
+        <div class="flex justify-end mt-4">
+          <button
+            id="remove-submit-btn"
+            type="submit"
+            class="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
             disabled>
             Remove
           </button>

--- a/templates/import_view.html
+++ b/templates/import_view.html
@@ -70,8 +70,10 @@
         {% endfor %}
       </div>
     </div>
-    <div id="validationOverlay" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50">
-        <div id="validation-popup" class="bg-white p-6 rounded-lg shadow-lg w-auto max-w-[70vw] max-h-[66vh] overflow-auto">
+    <div id="validationOverlay" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
+         onclick="if(event.target.id === 'validationOverlay') this.classList.add('hidden')">
+        <div id="validation-popup" class="bg-white p-6 rounded-lg shadow-lg w-auto max-w-[70vw] max-h-[66vh] overflow-auto relative">
+            <button type="button" onclick="document.getElementById('validationOverlay').classList.add('hidden')" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
             <!-- Validation messages get injected here -->
         </div>
     </div> 

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,8 +27,10 @@
 </div>
 
 <!-- Add Table Modal -->
-<div id="addTableModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full">
+<div id="addTableModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
+     onclick="if(event.target.id === 'addTableModal') closeAddTableModal()">
+  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+    <button type="button" onclick="closeAddTableModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <h3 class="text-lg font-bold mb-4">Add new base table</h3>
     <div id="tableError" class="text-red-600 hidden"></div>
     <form onsubmit="submitNewTable(event)" class="space-y-4">
@@ -40,8 +42,7 @@
         <label for="tableDescription" class="block mb-1">Description</label>
         <textarea id="tableDescription" class="w-full border rounded p-2"></textarea>
       </div>
-      <div class="flex justify-end space-x-2">
-        <button type="button" onclick="closeAddTableModal()" class="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400">Cancel</button>
+      <div class="flex justify-end">
         <button type="submit" class="px-4 py-2 rounded bg-blue-500 text-white hover:bg-blue-600">Add</button>
       </div>
     </form>


### PR DESCRIPTION
## Summary
- allow closing modals via click on the overlay
- replace "Close" and "Cancel" buttons with corner X buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847329f428883338a8ee5cc144768b3