### PR TITLE
Add DB config helpers

### DIFF
--- a/db/config.py
+++ b/db/config.py
@@ -1,11 +1,11 @@
-import os
-import sqlite3
+from datetime import datetime
+from db.database import get_connection
 
-DB_PATH = "data/crossbook.db"
 
 def get_logging_config():
+    """Return logging-related configuration values from the database."""
 
-    conn = sqlite3.connect(DB_PATH)
+    conn = get_connection()
     cur = conn.cursor()
     cur.execute("SELECT key, value FROM config WHERE key LIKE 'logging.%'")
     rows = cur.fetchall()
@@ -14,6 +14,35 @@ def get_logging_config():
     config = {}
     for full_key, val in rows:
         # full_key is like 'logging.log_level'; we want 'log_level'
-        subkey = full_key.split(".", 1)[1]
+        subkey = full_key.split('.', 1)[1]
         config[subkey] = val
     return config
+
+
+def get_all_config():
+    """Return the entire config table as a simple key/value dict."""
+
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT key, value FROM config")
+    rows = cur.fetchall()
+    conn.close()
+
+    return {key: val for key, val in rows}
+
+
+def update_config(key: str, value: str) -> int:
+    """Update a configuration value and timestamp."""
+
+    conn = get_connection()
+    cur = conn.cursor()
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    cur.execute(
+        "UPDATE config SET value = ?, date_updated = ? WHERE key = ?",
+        (value, timestamp, key),
+    )
+    conn.commit()
+    affected = cur.rowcount
+    conn.close()
+    return affected
+


### PR DESCRIPTION
## Summary
- refactor `get_logging_config` to use `get_connection`
- add `get_all_config` for reading full config table
- add `update_config` for modifying config values

## Testing
- `python -m py_compile db/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847fb0cab608333b927d7d328f27342