### PR TITLE
Update config admin template

### DIFF
--- a/db/config.py
+++ b/db/config.py
@@ -2,6 +2,21 @@ from datetime import datetime
 from db.database import get_connection
 
 
+def get_config_rows():
+    """Return all configuration rows with metadata."""
+
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT key, value, section, type, description, date_updated FROM config"
+    )
+    rows = cur.fetchall()
+    conn.close()
+
+    columns = ["key", "value", "section", "type", "description", "date_updated"]
+    return [dict(zip(columns, row)) for row in rows]
+
+
 def get_logging_config():
     """Return logging-related configuration values from the database."""
 
@@ -22,13 +37,7 @@ def get_logging_config():
 def get_all_config():
     """Return the entire config table as a simple key/value dict."""
 
-    conn = get_connection()
-    cur = conn.cursor()
-    cur.execute("SELECT key, value FROM config")
-    rows = cur.fetchall()
-    conn.close()
-
-    return {key: val for key, val in rows}
+    return {row["key"]: row["value"] for row in get_config_rows()}
 
 
 def update_config(key: str, value: str) -> int:

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import logging
 import time
 import json
 from logging_setup import configure_logging
-from db.config import get_all_config, update_config
+from db.config import get_config_rows, update_config
 from db.database import get_connection
 from db.schema import (
     load_field_schema,
@@ -93,11 +93,10 @@ def admin_page():
 @app.route("/config")
 def config_page():
     """Display all configuration values grouped by section."""
-    cfg = get_all_config()
+    configs = get_config_rows()
     sections = {}
-    for k, v in cfg.items():
-        section = k.split(".", 1)[0]
-        sections.setdefault(section, []).append({"key": k, "value": v})
+    for item in configs:
+        sections.setdefault(item["section"], []).append(item)
     return render_template("config_admin.html", sections=sections)
 
 

--- a/templates/config_admin.html
+++ b/templates/config_admin.html
@@ -7,15 +7,39 @@
 
 {% for section, items in sections.items() %}
   <h2 class="text-xl font-semibold mt-4 mb-2">{{ section|capitalize }}</h2>
-  <div class="space-y-2">
-  {% for item in items %}
-    <form method="post" action="{{ url_for('update_config_route', key=item.key) }}" class="flex items-center space-x-2">
-      <label class="w-64 font-mono text-sm">{{ item.key }}</label>
-      <input type="text" name="value" value="{{ item.value }}" class="flex-grow border rounded px-2 py-1 text-sm">
-      <button type="submit" class="bg-blue-500 text-white px-3 py-1 rounded">Save</button>
-    </form>
-  {% endfor %}
-  </div>
+  <table class="w-full text-sm mb-6">
+    <thead>
+      <tr class="text-left border-b">
+        <th class="w-56">Key</th>
+        <th class="w-64">Value</th>
+        <th>Description</th>
+        <th class="w-40">Updated</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for item in items %}
+      <tr class="border-t">
+        <td class="font-mono">{{ item.key }}</td>
+        <td>
+          <form method="post" action="{{ url_for('update_config_route', key=item.key) }}" class="flex items-center space-x-2">
+            {% if item.type in ('integer', 'number') %}
+              <input type="number" name="value" value="{{ item.value }}" class="border rounded px-2 py-1 text-sm flex-grow">
+            {% elif item.type == 'boolean' %}
+              <input type="hidden" name="value" value="0">
+              <input type="checkbox" name="value" value="1" {% if item.value in ('1', 1, True, 'true') %}checked{% endif %} class="mr-2">
+            {% elif item.type == 'date' %}
+              <input type="date" name="value" value="{{ item.value }}" class="border rounded px-2 py-1 text-sm flex-grow">
+            {% else %}
+              <input type="text" name="value" value="{{ item.value }}" class="border rounded px-2 py-1 text-sm flex-grow">
+            {% endif %}
+            <button type="submit" class="bg-blue-500 text-white px-3 py-1 rounded">Save</button>
+          </form>
+        </td>
+        <td>{{ item.description }}</td>
+        <td>{{ item.date_updated }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
 {% endfor %}
-
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `get_config_rows` helper for full config data
- group configs by their section in `config_page`
- show typed value inputs and metadata in `config_admin.html`
- refactor `get_all_config` to reuse `get_config_rows`

## Testing
- `python -m py_compile main.py db/*.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684804aaf2d883339592ef58629364d9