### PR TITLE
Add admin page with placeholders

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,13 +84,32 @@ def dashboard():
     return render_template("dashboard.html")
 
 
-@app.route("/admin.html")
+@app.route("/admin")
 def admin_page():
-    """Redirect old admin endpoint to config page."""
-    return redirect(url_for("config_page"))
+    """Display the admin landing page."""
+    return render_template("admin.html")
+
+
+@app.route("/admin/users")
+def admin_users():
+    """Placeholder user management page."""
+    return render_template("admin_users.html")
+
+
+@app.route("/admin/automation")
+def admin_automation():
+    """Placeholder automation page."""
+    return render_template("admin_automation.html")
+
+
+@app.route("/admin.html")
+def admin_html_redirect():
+    """Redirect legacy /admin.html to the admin page."""
+    return redirect(url_for("admin_page"))
 
 
 @app.route("/config")
+@app.route("/admin/config")
 def config_page():
     """Display all configuration values grouped by section."""
     configs = get_config_rows()
@@ -101,6 +120,7 @@ def config_page():
 
 
 @app.route("/config/<path:key>", methods=["POST"])
+@app.route("/admin/config/<path:key>", methods=["POST"])
 def update_config_route(key):
     """Update a configuration key and optionally reload logging."""
     value = request.form.get("value", "")

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -3,4 +3,19 @@
 {% block title %}Admin{% endblock %}
 
 {% block content %}
+<h1 class="text-3xl font-bold mb-6">Admin</h1>
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+  <a href="/admin/config" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
+    <h2 class="text-2xl font-bold mb-2">Configuration</h2>
+    <p class="text-gray-600">Manage application settings</p>
+  </a>
+  <a href="/admin/users" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
+    <h2 class="text-2xl font-bold mb-2">User Management</h2>
+    <p class="text-gray-600">Coming soon</p>
+  </a>
+  <a href="/admin/automation" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
+    <h2 class="text-2xl font-bold mb-2">Automation</h2>
+    <p class="text-gray-600">Coming soon</p>
+  </a>
+</div>
 {% endblock %}

--- a/templates/admin_automation.html
+++ b/templates/admin_automation.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block title %}Automation{% endblock %}
+
+{% block content %}
+<h1 class="text-3xl font-bold mb-4">Automation</h1>
+<p class="text-gray-600">This page is under construction.</p>
+{% endblock %}

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block title %}User Management{% endblock %}
+
+{% block content %}
+<h1 class="text-3xl font-bold mb-4">User Management</h1>
+<p class="text-gray-600">This page is under construction.</p>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
 
 {% block nav_buttons %}
 <a href="/import" class="bg-indigo-500 text-white px-3 py-1 rounded hover:bg-indigo-600">Import</a>
-<a href="/admin.html" class="bg-indigo-500 text-white px-3 py-1 rounded hover:bg-indigo-600">Admin</a>
+<a href="/admin" class="bg-indigo-500 text-white px-3 py-1 rounded hover:bg-indigo-600">Admin</a>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- link from index to `/admin`
- add admin landing page with links to configuration, user management and automation
- placeholder templates for user management and automation
- support new admin routes in `main.py`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68480d5107048333bd880737b5169538