### PR TITLE
Fix boolean input on config page

### DIFF
--- a/templates/config_admin.html
+++ b/templates/config_admin.html
@@ -25,8 +25,8 @@
             {% if item.type in ('integer', 'number') %}
               <input type="number" name="value" value="{{ item.value }}" class="border rounded px-2 py-1 text-sm flex-grow">
             {% elif item.type == 'boolean' %}
-              <input type="hidden" name="value" value="0">
               <input type="checkbox" name="value" value="1" {% if item.value in ('1', 1, True, 'true') %}checked{% endif %} class="mr-2">
+              <input type="hidden" name="value" value="0">
             {% elif item.type == 'date' %}
               <input type="date" name="value" value="{{ item.value }}" class="border rounded px-2 py-1 text-sm flex-grow">
             {% else %}


### PR DESCRIPTION
## Summary
- fix the checkbox + hidden input ordering for boolean config values

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68481423a1148333a5ce257aba9451b0