### PR TITLE
Add row count and row numbers to list view

### DIFF
--- a/static/js/column_visibility.js
+++ b/static/js/column_visibility.js
@@ -10,12 +10,14 @@ document.addEventListener("DOMContentLoaded", () => {
     const visible = new Set(getSelectedFields());
 
     document.querySelectorAll("thead th").forEach((th) => {
+      if (th.dataset.static !== undefined) return;
       const field = th.textContent.trim().toLowerCase();
       th.style.display = visible.has(field) ? "" : "none";
     });
 
     document.querySelectorAll("tbody tr").forEach(row => {
       row.querySelectorAll("td").forEach(td => {
+        if (td.dataset.static !== undefined) return;
         const field = td.dataset.field;
         td.style.display = visible.has(field) ? "" : "none";
       });

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -73,10 +73,14 @@
   </div>
   
   {% if records %}
+  <div class="text-sm text-gray-600 mb-2">
+    {{ records|length }} record{{ 's' if records|length != 1 }} found
+  </div>
   <div class="overflow-x-auto rounded-lg border border-gray-200">
     <table class="min-w-full divide-y divide-gray-200 text-sm">
       <thead class="bg-gray-50">
         <tr>
+          <th scope="col" class="px-4 py-2 text-left text-xs font-medium text-gray-700 uppercase tracking-wider" data-static>#</th>
           {% for field in fields if not field.startswith('_') %}
             <th scope="col" class="px-4 py-2 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">{{ field }}</th>
           {% endfor %}
@@ -85,6 +89,7 @@
       <tbody class="divide-y divide-gray-200">
         {% for record in records %}
         <tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location.href='/{{ table }}/{{ record.id }}'">
+          <td class="px-4 py-2 whitespace-nowrap" data-static>{{ loop.index }}</td>
           {% for field in fields if not field.startswith('_') %}
             <td class="px-4 py-2 whitespace-nowrap" data-field="{{ field|lower }}">
               {% if field_schema[table][field].type == "textarea" %}


### PR DESCRIPTION
## Summary
- show the number of rows returned in list views
- add a numbering column and keep it visible when hiding columns
- update column visibility script to ignore static columns

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68481f3806d883339254188a3d7991a6