### PR TITLE
Handle updated logging config keys

### DIFF
--- a/db/config.py
+++ b/db/config.py
@@ -23,23 +23,14 @@ def get_logging_config():
     conn = get_connection()
     cur = conn.cursor()
 
-    # Newer databases store logging keys without the "logging." prefix and use
-    # the section column for grouping. Look for those first.
     cur.execute("SELECT key, value FROM config WHERE section = 'logging'")
     rows = cur.fetchall()
-
-    # Fall back to the old key scheme where each key started with "logging.".
-    if not rows:
-        cur.execute("SELECT key, value FROM config WHERE key LIKE 'logging.%'")
-        rows = cur.fetchall()
 
     conn.close()
 
     config = {}
-    for full_key, val in rows:
-        # Older keys may still contain the 'logging.' prefix; strip it if present
-        subkey = full_key.split('.', 1)[-1]
-        config[subkey] = val
+    for key, val in rows:
+        config[key] = val
 
     return config
 

--- a/db/config.py
+++ b/db/config.py
@@ -22,15 +22,25 @@ def get_logging_config():
 
     conn = get_connection()
     cur = conn.cursor()
-    cur.execute("SELECT key, value FROM config WHERE key LIKE 'logging.%'")
+
+    # Newer databases store logging keys without the "logging." prefix and use
+    # the section column for grouping. Look for those first.
+    cur.execute("SELECT key, value FROM config WHERE section = 'logging'")
     rows = cur.fetchall()
+
+    # Fall back to the old key scheme where each key started with "logging.".
+    if not rows:
+        cur.execute("SELECT key, value FROM config WHERE key LIKE 'logging.%'")
+        rows = cur.fetchall()
+
     conn.close()
 
     config = {}
     for full_key, val in rows:
-        # full_key is like 'logging.log_level'; we want 'log_level'
-        subkey = full_key.split('.', 1)[1]
+        # Older keys may still contain the 'logging.' prefix; strip it if present
+        subkey = full_key.split('.', 1)[-1]
         config[subkey] = val
+
     return config
 
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import logging
 import time
 import json
 from logging_setup import configure_logging
-from db.config import get_config_rows, update_config
+from db.config import get_config_rows, update_config, get_logging_config
 from db.database import get_connection
 from db.schema import (
     load_field_schema,
@@ -125,7 +125,7 @@ def update_config_route(key):
     """Update a configuration key and optionally reload logging."""
     value = request.form.get("value", "")
     update_config(key, value)
-    if key.startswith("logging."):
+    if key in get_logging_config():
         configure_logging(app)
     return redirect(url_for("config_page"))
 


### PR DESCRIPTION
## Summary
- support logging config rows without the `logging.` prefix

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68483416b948833399a9cc557d1a4498