### PR TITLE
Implement pagination and correct row counts

### DIFF
--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -74,7 +74,7 @@
   
   {% if records %}
   <div class="text-sm text-gray-600 mb-2">
-    {{ records|length }} record{{ 's' if records|length != 1 }} found
+    Showing {{ start }}-{{ end }} of {{ total_count }} record{{ 's' if total_count != 1 }}
   </div>
   <div class="overflow-x-auto rounded-lg border border-gray-200">
     <table class="min-w-full divide-y divide-gray-200 text-sm">
@@ -105,7 +105,27 @@
         {% endfor %}
       </tbody>
     </table>
-</div>
+  </div>
+  <div class="flex justify-between items-center mt-4 text-sm">
+    <div>
+      Page {{ page }} of {{ total_pages }}
+    </div>
+    <div class="space-x-1">
+      {% if page > 1 %}
+        <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ page - 1 }}" class="px-2 py-1 bg-gray-200 rounded">Prev</a>
+      {% endif %}
+      {% for p in range(1, total_pages + 1) %}
+        {% if p == page %}
+          <span class="px-2 py-1 bg-blue-500 text-white rounded">{{ p }}</span>
+        {% else %}
+          <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ p }}" class="px-2 py-1 bg-gray-200 rounded">{{ p }}</a>
+        {% endif %}
+      {% endfor %}
+      {% if page < total_pages %}
+        <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ page + 1 }}" class="px-2 py-1 bg-gray-200 rounded">Next</a>
+      {% endif %}
+    </div>
+  </div>
 {% else %}
   <p class="text-gray-600">No records found.</p>
 {% endif %}


### PR DESCRIPTION
## Summary
- support filtering & counting helper `_build_filters`
- implement `count_records` and update `get_all_records`
- add pagination logic in `list_view`
- show total record counts and pagination controls in templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684832357bc88333b0fb2ded253a5356