### PR TITLE
Fix pagination spacing

### DIFF
--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -106,10 +106,8 @@
       </tbody>
     </table>
   </div>
-  <div class="flex justify-between items-center mt-4 text-sm">
-    <div>
-      Page {{ page }} of {{ total_pages }}
-    </div>
+  <div class="flex items-center mt-4 text-sm space-x-4">
+    <div>Page {{ page }} of {{ total_pages }}</div>
     <div class="space-x-1">
       {% if page > 1 %}
         <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ page - 1 }}" class="px-2 py-1 bg-gray-200 rounded">Prev</a>


### PR DESCRIPTION
## Summary
- tweak pagination layout so page info sits next to the controls

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848421b7d188333aff691e4e2393432