### PR TITLE
Remove # column from list view

### DIFF
--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -80,7 +80,6 @@
     <table class="min-w-full divide-y divide-gray-200 text-sm">
       <thead class="bg-gray-50">
         <tr>
-          <th scope="col" class="px-4 py-2 text-left text-xs font-medium text-gray-700 uppercase tracking-wider" data-static>#</th>
           {% for field in fields if not field.startswith('_') %}
             <th scope="col" class="px-4 py-2 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">{{ field }}</th>
           {% endfor %}
@@ -89,7 +88,6 @@
       <tbody class="divide-y divide-gray-200">
         {% for record in records %}
         <tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location.href='/{{ table }}/{{ record.id }}'">
-          <td class="px-4 py-2 whitespace-nowrap" data-static>{{ loop.index }}</td>
           {% for field in fields if not field.startswith('_') %}
             <td class="px-4 py-2 whitespace-nowrap" data-field="{{ field|lower }}">
               {% if field_schema[table][field].type == "textarea" %}


### PR DESCRIPTION
## Summary
- clean up list views by dropping the page-local row number column

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684840d0c84c8333b40b734e76685291