### PR TITLE
Make Next button blue in list view

### DIFF
--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -118,7 +118,7 @@
         {% endif %}
       {% endfor %}
       {% if page < total_pages %}
-        <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ page + 1 }}" class="px-2 py-1 bg-gray-200 rounded">Next</a>
+        <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ page + 1 }}" class="px-2 py-1 bg-blue-500 text-white rounded">Next</a>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- tweak list view pagination styling so the "Next" link is blue

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684845423e0c83339c6b4a8a74d5f2e4