### PR TITLE
Implement Sum calculation in dashboard modal

### DIFF
--- a/db/dashboard.py
+++ b/db/dashboard.py
@@ -1,0 +1,27 @@
+import logging
+
+from db.database import get_connection
+from db.schema import get_field_schema
+from db.validation import validate_table
+
+logger = logging.getLogger(__name__)
+
+
+def sum_field(table: str, field: str) -> float:
+    """Return the sum of all values for a numeric field."""
+    validate_table(table)
+    fmeta = get_field_schema().get(table, {}).get(field)
+    if fmeta is None or fmeta.get("type") != "number":
+        raise ValueError(f"Invalid numeric field: {field}")
+    conn = get_connection()
+    cursor = conn.cursor()
+    try:
+        sql = f'SELECT SUM("{field}") FROM "{table}"'
+        cursor.execute(sql)
+        result = cursor.fetchone()[0]
+        return result or 0
+    except Exception as e:
+        logger.warning(f"[sum_field] SQL error for {table}.{field}: {e}")
+        return 0
+    finally:
+        conn.close()

--- a/db/records.py
+++ b/db/records.py
@@ -261,3 +261,5 @@ def count_nonnull(table: str, field: str) -> int:
         return 0
     finally:
         conn.close()
+
+

--- a/main.py
+++ b/main.py
@@ -286,6 +286,18 @@ def count_nonnull(table):
 
     return jsonify({"count": count})
 
+
+@app.route("/<table>/sum-field")
+def sum_field_route(table):
+    field = request.args.get("field")
+    try:
+        from db.dashboard import sum_field as _sum_field
+        result = _sum_field(table, field)
+    except ValueError:
+        return jsonify({"sum": 0}), 400
+
+    return jsonify({"sum": result})
+
 @app.route("/<table>/<int:record_id>/remove-field", methods=["POST"])
 def remove_field_route(table, record_id):
     field_name = request.form.get("field_name")

--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -8,7 +8,7 @@ export function closeDashboardModal() {
 
 let selectedOperation = null;
 let selectedColumn = null;
-let columnContainer, columnToggleBtn, columnDropdown;
+let columnContainer, columnToggleBtn, columnDropdown, valueResultEl;
 let activeTab = 'value';
 
 function setActiveTab(name) {
@@ -73,6 +73,27 @@ function refreshColumnTags() {
     span.appendChild(btn);
     columnContainer.appendChild(span);
   });
+  updateValueResult();
+}
+
+function updateValueResult() {
+  if (!valueResultEl) return;
+  if (selectedOperation === 'sum' && selectedColumn) {
+    const [table, field] = selectedColumn.split(':');
+    valueResultEl.classList.remove('hidden');
+    valueResultEl.textContent = 'Calculating…';
+    fetch(`/${table}/sum-field?field=${encodeURIComponent(field)}`)
+      .then(res => res.json())
+      .then(data => {
+        valueResultEl.textContent = `Sum: ${data.sum}`;
+      })
+      .catch(() => {
+        valueResultEl.textContent = 'Error';
+      });
+  } else {
+    valueResultEl.classList.add('hidden');
+    valueResultEl.textContent = '';
+  }
 }
 
 function updateColumnOptions() {
@@ -150,6 +171,7 @@ function updateColumnOptions() {
   });
 
   refreshColumnTags();
+  updateValueResult();
 }
 
 function initColumnSelect() {
@@ -187,6 +209,7 @@ function initDashboardModal() {
   initDashboardTabs();
   initOperationSelect();
   initColumnSelect();
+  valueResultEl = document.getElementById('valueResult');
 }
 
 document.addEventListener('DOMContentLoaded', initDashboardModal);

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -45,6 +45,7 @@
         <div id="selectedColumns" class="flex flex-wrap gap-1 mb-2"></div>
         <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden">Select Field</button>
         <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+        <div id="valueResult" class="mt-4 text-center font-semibold hidden"></div>
       </form>
     </div>
     <div id="pane-table" class="hidden">


### PR DESCRIPTION
## Summary
- add `sum_field` helper in `db/dashboard.py`
- expose `/ <table>/sum-field` endpoint in `main.py`
- display calculation result in dashboard modal
- update dashboard JS to fetch and show sum

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/js/dashboard_modal.js`


------
https://chatgpt.com/codex/tasks/task_e_68484b0c39f083339b90753ca8a1d957