### PR TITLE
Add sum title input and create button

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -8,7 +8,7 @@ export function closeDashboardModal() {
 
 let selectedOperation = null;
 let selectedColumn = null;
-let columnContainer, columnToggleBtn, columnDropdown, valueResultEl;
+let columnContainer, columnToggleBtn, columnDropdown, valueResultEl, titleInputEl, createBtnEl;
 let activeTab = 'value';
 
 function setActiveTab(name) {
@@ -81,6 +81,11 @@ function updateValueResult() {
   if (selectedOperation === 'sum' && selectedColumn) {
     const [table, field] = selectedColumn.split(':');
     valueResultEl.classList.remove('hidden');
+    if (titleInputEl) {
+      titleInputEl.placeholder = `Sum of ${field}`;
+      titleInputEl.classList.remove('hidden');
+    }
+    if (createBtnEl) createBtnEl.classList.remove('hidden');
     valueResultEl.textContent = 'Calculating…';
     fetch(`/${table}/sum-field?field=${encodeURIComponent(field)}`)
       .then(res => res.json())
@@ -93,6 +98,8 @@ function updateValueResult() {
   } else {
     valueResultEl.classList.add('hidden');
     valueResultEl.textContent = '';
+    if (titleInputEl) titleInputEl.classList.add('hidden');
+    if (createBtnEl) createBtnEl.classList.add('hidden');
   }
 }
 
@@ -210,6 +217,8 @@ function initDashboardModal() {
   initOperationSelect();
   initColumnSelect();
   valueResultEl = document.getElementById('valueResult');
+  titleInputEl = document.getElementById('sumTitleInput');
+  createBtnEl = document.getElementById('dashboardCreateBtn');
 }
 
 document.addEventListener('DOMContentLoaded', initDashboardModal);

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -46,6 +46,8 @@
         <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden">Select Field</button>
         <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
         <div id="valueResult" class="mt-4 text-center font-semibold hidden"></div>
+        <input id="sumTitleInput" type="text" class="w-full px-3 py-2 border rounded mt-2 hidden" />
+        <button id="dashboardCreateBtn" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 absolute bottom-4 right-4 hidden">Create</button>
       </form>
     </div>
     <div id="pane-table" class="hidden">


### PR DESCRIPTION
## Summary
- add a text input for naming sum results
- show a Create button when the sum field is selected
- update dashboard modal JS to manage the new elements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684851c71d788333b17f1cc820273544