### PR TITLE
Update sum input placement in dashboard modal

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -8,7 +8,7 @@ export function closeDashboardModal() {
 
 let selectedOperation = null;
 let selectedColumn = null;
-let columnContainer, columnToggleBtn, columnDropdown, valueResultEl, titleInputEl, createBtnEl;
+let columnContainer, columnToggleBtn, columnDropdown, valueResultEl, titleInputEl, resultRowEl, createBtnEl;
 let activeTab = 'value';
 
 function setActiveTab(name) {
@@ -77,28 +77,26 @@ function refreshColumnTags() {
 }
 
 function updateValueResult() {
-  if (!valueResultEl) return;
+  if (!valueResultEl || !resultRowEl) return;
   if (selectedOperation === 'sum' && selectedColumn) {
     const [table, field] = selectedColumn.split(':');
-    valueResultEl.classList.remove('hidden');
+    resultRowEl.classList.remove('hidden');
     if (titleInputEl) {
       titleInputEl.placeholder = `Sum of ${field}`;
-      titleInputEl.classList.remove('hidden');
     }
     if (createBtnEl) createBtnEl.classList.remove('hidden');
     valueResultEl.textContent = 'Calculating…';
     fetch(`/${table}/sum-field?field=${encodeURIComponent(field)}`)
       .then(res => res.json())
       .then(data => {
-        valueResultEl.textContent = `Sum: ${data.sum}`;
+        valueResultEl.textContent = data.sum;
       })
       .catch(() => {
         valueResultEl.textContent = 'Error';
       });
   } else {
-    valueResultEl.classList.add('hidden');
+    resultRowEl.classList.add('hidden');
     valueResultEl.textContent = '';
-    if (titleInputEl) titleInputEl.classList.add('hidden');
     if (createBtnEl) createBtnEl.classList.add('hidden');
   }
 }
@@ -218,6 +216,7 @@ function initDashboardModal() {
   initColumnSelect();
   valueResultEl = document.getElementById('valueResult');
   titleInputEl = document.getElementById('sumTitleInput');
+  resultRowEl = document.getElementById('resultRow');
   createBtnEl = document.getElementById('dashboardCreateBtn');
 }
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -45,8 +45,10 @@
         <div id="selectedColumns" class="flex flex-wrap gap-1 mb-2"></div>
         <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden">Select Field</button>
         <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
-        <div id="valueResult" class="mt-4 text-center font-semibold hidden"></div>
-        <input id="sumTitleInput" type="text" class="w-full px-3 py-2 border rounded mt-2 hidden" />
+        <div id="resultRow" class="mt-4 flex items-center justify-center gap-2 hidden">
+          <input id="sumTitleInput" type="text" class="px-3 py-2 border rounded flex-grow" />
+          <div id="valueResult" class="font-semibold"></div>
+        </div>
         <button id="dashboardCreateBtn" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 absolute bottom-4 right-4 hidden">Create</button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- refine layout of value/sum input in dashboard modal

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68485699c11c833395a68e27d70811f6