### PR TITLE
Fix create button overlap in dashboard modal

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -49,7 +49,7 @@
           <input id="sumTitleInput" type="text" class="px-3 py-2 border rounded flex-grow" />
           <div id="valueResult" class="font-semibold"></div>
         </div>
-        <button id="dashboardCreateBtn" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 absolute bottom-4 right-4 hidden">Create</button>
+        <button id="dashboardCreateBtn" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 hidden mt-4 block ml-auto">Create</button>
       </form>
     </div>
     <div id="pane-table" class="hidden">


### PR DESCRIPTION
## Summary
- update `dashboardCreateBtn` styles so the modal can expand vertically

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848586973908333ab51fc2c51fdcb04