### PR TITLE
Update dashboard dropdown arrow style

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -8,7 +8,7 @@ export function closeDashboardModal() {
 
 let selectedOperation = null;
 let selectedColumn = null;
-let columnToggleBtn, columnDropdown, valueResultEl, titleInputEl, resultRowEl, createBtnEl;
+let columnToggleBtn, columnToggleLabel, columnDropdown, valueResultEl, titleInputEl, resultRowEl, createBtnEl;
 let activeTab = 'value';
 
 function setActiveTab(name) {
@@ -48,7 +48,7 @@ function initDashboardTabs() {
 function refreshColumnTags() {
   if (!columnToggleBtn) return;
   if (!selectedColumn || (Array.isArray(selectedColumn) && selectedColumn.length === 0)) {
-    columnToggleBtn.textContent = 'Select Field \u25BE';
+    if (columnToggleLabel) columnToggleLabel.textContent = 'Select Field';
     updateValueResult();
     return;
   }
@@ -58,7 +58,7 @@ function refreshColumnTags() {
     const [table, field] = val.split(':');
     return `${table}: ${field}`;
   });
-  columnToggleBtn.textContent = labels.join(', ') + ' \u25BE';
+  if (columnToggleLabel) columnToggleLabel.textContent = labels.join(', ');
   updateValueResult();
 }
 
@@ -167,6 +167,7 @@ function updateColumnOptions() {
 
 function initColumnSelect() {
   columnToggleBtn = document.getElementById('columnSelectDashboardToggle');
+  columnToggleLabel = columnToggleBtn ? columnToggleBtn.querySelector('.selected-label') : null;
   columnDropdown = document.getElementById('columnSelectDashboardOptions');
   if (!columnToggleBtn || !columnDropdown) return;
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -42,7 +42,7 @@
           {% endfor %}
         </div>
 
-        <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden">Select Field ▾</button>
+        <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>
         <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
         <div id="resultRow" class="mt-4 flex items-center justify-center gap-2 hidden">
           <input id="sumTitleInput" type="text" class="px-3 py-2 border rounded flex-grow" />


### PR DESCRIPTION
## Summary
- adjust dashboard field dropdown markup
- tweak dashboard modal JS to update dropdown text via inner span

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684860470a788333b3bcc79f7df9e2a3