### PR TITLE
Fix dropdown staying open in dashboard modal

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -149,6 +149,7 @@ function updateColumnOptions() {
         input.addEventListener('change', () => {
           selectedColumn = val;
           refreshColumnTags();
+          columnDropdown.classList.add('hidden');
         });
       }
 


### PR DESCRIPTION
## Summary
- hide column dropdown after choosing a field so it behaves like a normal select

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684861df715c83339f5ce3e7eda7723e