### PR TITLE
Modularize Flask request logging helpers

### DIFF
--- a/utils/flask_helpers.py
+++ b/utils/flask_helpers.py
@@ -1,0 +1,25 @@
+import time
+from flask import g, request, current_app
+
+
+def start_timer():
+    """Record the start time of the request and log the request start."""
+    g.start_time = time.time()
+    current_app.logger.info(f"[REQ] {request.method} {request.path} started")
+
+
+def log_request(response):
+    """Log the duration and status code of the completed request."""
+    duration = time.time() - g.get("start_time", time.time())
+    current_app.logger.info(
+        f"[REQ] {request.method} {request.path} completed in {duration:.3f}s with {response.status_code}"
+    )
+    return response
+
+
+def log_exception(exc):
+    """Log any exception raised during the request lifecycle."""
+    if exc:
+        current_app.logger.exception(
+            f"[ERROR] Unhandled exception during {request.method} {request.path}: {exc}"
+        )


### PR DESCRIPTION
## Summary
- move request logging helpers into `utils/flask_helpers.py`
- import and register helpers in `main.py`
- remove the now-unnecessary `utils/__init__.py`

## Testing
- `python -m py_compile main.py utils/flask_helpers.py`
- `python - <<'PY'
import main
app = main.app
with app.test_client() as c:
    resp = c.get('/')
    print('status', resp.status_code)
PY`

------
https://chatgpt.com/codex/tasks/task_e_684861ec97448333a43ec08fb99b38da