### PR TITLE
Implement dashboard grid

### DIFF
--- a/db/dashboard.py
+++ b/db/dashboard.py
@@ -25,3 +25,22 @@ def sum_field(table: str, field: str) -> float:
         return 0
     finally:
         conn.close()
+
+
+def get_dashboard_widgets() -> list[dict]:
+    """Return all dashboard widgets ordered by id."""
+    conn = get_connection()
+    cursor = conn.cursor()
+    try:
+        cursor.execute(
+            "SELECT id, title, content, widget_type, col_start, col_span, row_start, row_span"
+            " FROM dashboard_widget ORDER BY id"
+        )
+        rows = cursor.fetchall()
+        cols = [d[0] for d in cursor.description]
+        return [dict(zip(cols, r)) for r in rows]
+    except Exception as e:
+        logger.warning("[get_dashboard_widgets] SQL error: %s", e)
+        return []
+    finally:
+        conn.close()

--- a/main.py
+++ b/main.py
@@ -77,7 +77,9 @@ def home():
 @app.route("/dashboard")
 def dashboard():
     """Render the dashboard page."""
-    return render_template("dashboard.html")
+    from db.dashboard import get_dashboard_widgets
+    widgets = get_dashboard_widgets()
+    return render_template("dashboard.html", widgets=widgets)
 
 
 @app.route("/admin")

--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -53,6 +53,65 @@ input[type=number] {
   height: 100% !important;
 }
 
+/* Dashboard grid defaults */
+#dashboard-grid .draggable-field {
+  border: none !important;
+  box-shadow: none !important;
+  background-color: transparent !important;
+  padding: 0 !important;
+}
+#dashboard-grid.editing .draggable-field {
+  padding: 0;
+}
+#dashboard-grid.editing .draggable-field {
+  border: 1px blue dashed !important;
+  box-shadow: 0 0 0 2px rgba(0,0,0,0.1) !important;
+  background-color: #fafafa !important;
+}
+#dashboard-grid .draggable-field input,
+#dashboard-grid .draggable-field select,
+#dashboard-grid .draggable-field textarea {
+  width: 100% !important;
+  box-sizing: border-box !important;
+}
+#dashboard-grid .draggable-field textarea {
+  height: 100% !important;
+}
+#dashboard-grid .resize-handle {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: rgba(0,0,255,0.5);
+  z-index: 10;
+}
+#dashboard-grid.editing .resize-handle {
+  display: block;
+}
+#dashboard-grid.editing .resize-handle.top-left { top:0; left:0; cursor:nwse-resize !important; }
+#dashboard-grid.editing .resize-handle.top-right { top:0; right:0; cursor:nesw-resize !important; }
+#dashboard-grid.editing .resize-handle.bottom-left { bottom:0; left:0; cursor:nesw-resize !important; }
+#dashboard-grid.editing .resize-handle.bottom-right { bottom:0; right:0; cursor:nwse-resize !important; }
+#dashboard-grid.editing .draggable-field > *:not(.resize-handle):not(.ui-resizable-handle) {
+  pointer-events: none;
+}
+#dashboard-grid.editing .ui-resizable-handle,
+#dashboard-grid.editing .draggable-field {
+  position: relative;
+}
+#dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(20, 1fr);
+  grid-auto-rows: 1em;
+  position: relative;
+}
+#dashboard-grid.editing {
+  background-image:
+    linear-gradient(to right, rgba(0, 0, 0, 0.1) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.1) 1px, transparent 1px);
+  background-size: 5% 100%, 100% 1em;
+  background-repeat: repeat, repeat;
+}
+
 /* handles hidden by default */
  #layout-grid .resize-handle {
    position: absolute;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -10,8 +10,22 @@
 <h1 class="text-3xl font-bold mb-4">Dashboard</h1>
 <p class="text-gray-600">This page is under construction.</p>
 
+<div id="dashboard-grid"
+     class="relative w-full grid"
+     style="grid-template-columns: repeat(20, 1fr); grid-auto-rows: 1em;">
+  {% for w in widgets %}
+    <div class="draggable-field border p-2 rounded shadow bg-gray-50"
+         data-widget="{{ w.id }}"
+         data-type="{{ w.widget_type }}"
+         style="grid-column: {{ w.col_start }} / span {{ w.col_span }}; grid-row: {{ w.row_start }} / span {{ w.row_span }};">
+      {{ w.title }}
+    </div>
+  {% endfor %}
+</div>
+
 {% include "dashboard_modal.html" %}
 
 <script>const FIELD_SCHEMA = {{ field_schema | tojson }};</script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_modal.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/dashboard_grid.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- create draggable dashboard grid and style rules
- fetch dashboard widgets and pass to template
- wire up the new dashboard grid JS script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684927d3444083338f34ec0eccd7bf15