### PR TITLE
Add dashboard widget creation endpoint

### DIFF
--- a/db/dashboard.py
+++ b/db/dashboard.py
@@ -44,3 +44,33 @@ def get_dashboard_widgets() -> list[dict]:
         return []
     finally:
         conn.close()
+
+
+def create_widget(
+    title: str,
+    content: str,
+    widget_type: str,
+    col_start: int,
+    col_span: int,
+    row_start: int,
+    row_span: int,
+) -> int | None:
+    """Insert a new widget row and return its id."""
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            INSERT INTO dashboard_widget
+                (title, content, widget_type, col_start, col_span, row_start, row_span)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (title, content, widget_type, col_start, col_span, row_start, row_span),
+        )
+        conn.commit()
+        return cur.lastrowid
+    except Exception as exc:
+        logger.warning("[create_widget] SQL error: %s", exc)
+        return None
+    finally:
+        conn.close()

--- a/main.py
+++ b/main.py
@@ -295,6 +295,45 @@ def sum_field_route(table):
 
     return jsonify({"sum": result})
 
+
+@app.route("/dashboard/widget", methods=["POST"])
+def dashboard_create_widget():
+    """Create a new dashboard widget."""
+    data = request.get_json(silent=True) or {}
+    title = (data.get("title") or "").strip()
+    content = data.get("content", "")
+    widget_type = (data.get("widget_type") or "").strip()
+    try:
+        col_start = int(data.get("col_start", 1))
+        col_span = int(data.get("col_span", 1))
+        row_start = int(data.get("row_start", 1))
+        row_span = int(data.get("row_span", 1))
+    except (TypeError, ValueError):
+        return jsonify({"error": "Invalid layout values"}), 400
+
+    if not title or not widget_type:
+        return jsonify({"error": "Missing required fields"}), 400
+
+    if widget_type not in {"value", "table", "chart"}:
+        return jsonify({"error": "Invalid widget type"}), 400
+
+    from db.dashboard import create_widget as _create_widget
+
+    widget_id = _create_widget(
+        title,
+        content,
+        widget_type,
+        col_start,
+        col_span,
+        row_start,
+        row_span,
+    )
+
+    if not widget_id:
+        return jsonify({"error": "Failed to create widget"}), 500
+
+    return jsonify({"success": True, "id": widget_id})
+
 @app.route("/<table>/<int:record_id>/remove-field", methods=["POST"])
 def remove_field_route(table, record_id):
     field_name = request.form.get("field_name")

--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -87,6 +87,37 @@ function updateValueResult() {
   }
 }
 
+function onCreateWidget(event) {
+  if (event) event.preventDefault();
+  if (selectedOperation !== 'sum' || !selectedColumn) return;
+  const [table, field] = selectedColumn.split(':');
+  const title = (titleInputEl && titleInputEl.value.trim()) || `Sum of ${field}`;
+  const payload = {
+    title: title,
+    content: JSON.stringify({ operation: 'sum', table, field }),
+    widget_type: 'value',
+    col_start: 1,
+    col_span: 4,
+    row_start: 1,
+    row_span: 3
+  };
+  fetch('/dashboard/widget', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  })
+    .then(res => res.json())
+    .then(data => {
+      if (data.success) {
+        closeDashboardModal();
+        window.location.reload();
+      }
+    })
+    .catch(() => {
+      console.error('Failed to create widget');
+    });
+}
+
 function updateColumnOptions() {
   if (!columnDropdown || !columnToggleBtn) return;
 
@@ -205,6 +236,9 @@ function initDashboardModal() {
   titleInputEl = document.getElementById('sumTitleInput');
   resultRowEl = document.getElementById('resultRow');
   createBtnEl = document.getElementById('dashboardCreateBtn');
+  if (createBtnEl) {
+    createBtnEl.addEventListener('click', onCreateWidget);
+  }
 }
 
 document.addEventListener('DOMContentLoaded', initDashboardModal);


### PR DESCRIPTION
## Summary
- implement `create_widget` helper to insert dashboard widgets
- add `/dashboard/widget` POST route
- update dashboard modal JS to send POST when creating new widget

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849299424408333872c51b13df4fbfb