### PR TITLE
Set default title for new sum widgets

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -68,7 +68,9 @@ function updateValueResult() {
     const [table, field] = selectedColumn.split(':');
     resultRowEl.classList.remove('hidden');
     if (titleInputEl) {
-      titleInputEl.placeholder = `Sum of ${field}`;
+      const defaultTitle = `Sum of ${field}`;
+      titleInputEl.placeholder = defaultTitle;
+      titleInputEl.value = defaultTitle;
     }
     if (createBtnEl) createBtnEl.classList.remove('hidden');
     valueResultEl.textContent = 'Calculating…';


### PR DESCRIPTION
## Summary
- prefill sum widget title with a default value when creating a value widget

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684930d35d148333859b2afaccee9e39