### PR TITLE
Add count widget support

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -64,20 +64,22 @@ function refreshColumnTags() {
 
 function updateValueResult() {
   if (!valueResultEl || !resultRowEl) return;
-  if (selectedOperation === 'sum' && selectedColumn) {
+  if ((selectedOperation === 'sum' || selectedOperation === 'count') && selectedColumn) {
     const [table, field] = selectedColumn.split(':');
+    const endpoint = selectedOperation === 'sum' ? 'sum-field' : 'count-nonnull';
+    const key = selectedOperation === 'sum' ? 'sum' : 'count';
     resultRowEl.classList.remove('hidden');
     if (titleInputEl) {
-      const defaultTitle = `Sum of ${field}`;
+      const defaultTitle = `${selectedOperation === 'sum' ? 'Sum' : 'Count'} of ${field}`;
       titleInputEl.placeholder = defaultTitle;
       titleInputEl.value = defaultTitle;
     }
     if (createBtnEl) createBtnEl.classList.remove('hidden');
     valueResultEl.textContent = 'Calculating…';
-    fetch(`/${table}/sum-field?field=${encodeURIComponent(field)}`)
+    fetch(`/${table}/${endpoint}?field=${encodeURIComponent(field)}`)
       .then(res => res.json())
       .then(data => {
-        valueResultEl.textContent = data.sum;
+        valueResultEl.textContent = data[key];
       })
       .catch(() => {
         valueResultEl.textContent = 'Error';
@@ -91,12 +93,13 @@ function updateValueResult() {
 
 function onCreateWidget(event) {
   if (event) event.preventDefault();
-  if (selectedOperation !== 'sum' || !selectedColumn) return;
+  if (!['sum', 'count'].includes(selectedOperation) || !selectedColumn) return;
   const [table, field] = selectedColumn.split(':');
-  const title = (titleInputEl && titleInputEl.value.trim()) || `Sum of ${field}`;
+  const defaultTitle = `${selectedOperation === 'sum' ? 'Sum' : 'Count'} of ${field}`;
+  const title = (titleInputEl && titleInputEl.value.trim()) || defaultTitle;
   const payload = {
     title: title,
-    content: JSON.stringify({ operation: 'sum', table, field }),
+    content: JSON.stringify({ operation: selectedOperation, table, field }),
     widget_type: 'value',
     col_start: 1,
     col_span: 4,
@@ -235,7 +238,7 @@ function initDashboardModal() {
   initOperationSelect();
   initColumnSelect();
   valueResultEl = document.getElementById('valueResult');
-  titleInputEl = document.getElementById('sumTitleInput');
+  titleInputEl = document.getElementById('valueTitleInput');
   resultRowEl = document.getElementById('resultRow');
   createBtnEl = document.getElementById('dashboardCreateBtn');
   if (createBtnEl) {

--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -33,7 +33,7 @@
         <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>
         <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
         <div id="resultRow" class="mt-4 flex items-center justify-center gap-2 hidden">
-          <input id="sumTitleInput" type="text" class="px-3 py-2 border rounded flex-grow" />
+          <input id="valueTitleInput" type="text" class="px-3 py-2 border rounded flex-grow" />
           <div id="valueResult" class="font-semibold"></div>
         </div>
         <button id="dashboardCreateBtn" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 hidden mt-4 block ml-auto">Create</button>


### PR DESCRIPTION
## Summary
- allow dashboard modal to create count widgets
- rename title input to valueTitleInput
- keep create button at bottom of modal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684937c29728833389c1a85c9ea07bae