### PR TITLE
Use DB layout defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Filter Macros:** Reusable Jinja macros for boolean, select, text, and multi-select filters (`templates/macros/filter_controls.html`).
 * **Field Schema Editing:** New endpoints allow adding or removing columns at runtime (`/<table>/<id>/add-field`, `/<table>/<id>/remove-field`) and counting non-null values (`/<table>/count-nonnull`).
 * **Admin Dashboard & Configuration:** The `/admin` section includes a configuration editor and placeholder pages for user management and automation.
+* **Layout Defaults from DB:** Field width and height defaults are loaded from the `config` table instead of being hardcoded.
 * **CSV Import Workflow (Experimental):** The `/import` page lets you upload CSV files, match columns to fields, and validate data before import.
 
 ## Project Structure

--- a/db/config.py
+++ b/db/config.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from db.database import get_connection
+import json
 
 
 def get_config_rows():
@@ -36,6 +37,21 @@ def get_all_config():
     """Return the entire config table as a simple key/value dict."""
 
     return {row["key"]: row["value"] for row in get_config_rows()}
+
+
+def get_layout_defaults() -> dict:
+    """Return layout width/height defaults from the config table."""
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT value FROM config WHERE key = 'layout_defaults'")
+        row = cur.fetchone()
+
+    if not row:
+        return {}
+    try:
+        return json.loads(row[0])
+    except Exception:
+        return {}
 
 
 def update_config(key: str, value: str) -> int:

--- a/db/edit_fields.py
+++ b/db/edit_fields.py
@@ -1,6 +1,7 @@
 import sqlite3
 import json
 from db.database import get_connection
+from db.config import get_layout_defaults
 
 DEFAULT_FIELD_WIDTH = {
     "textarea":   12,
@@ -38,11 +39,15 @@ def add_field_to_schema(table, field_name, field_type, field_options=None, forei
         )
         max_bottom = cur.fetchone()[0]  # if no rows yet, that's 0
 
-        # 3) Determine col_start, col_span, row_start, row_span from defaults
+        # 3) Determine col_start, col_span, row_start, row_span
+        defaults = get_layout_defaults() or {}
+        width_map = defaults.get('width', DEFAULT_FIELD_WIDTH)
+        height_map = defaults.get('height', DEFAULT_FIELD_HEIGHT)
+
         col_start = 0
-        col_span = DEFAULT_FIELD_WIDTH.get(field_type, 6)
+        col_span = width_map.get(field_type, 6)
         row_start = max_bottom
-        row_span = DEFAULT_FIELD_HEIGHT.get(field_type, 4)
+        row_span = height_map.get(field_type, 4)
 
         # 4) Insert into field_schema with the nine real columns
         cur.execute(


### PR DESCRIPTION
## Summary
- fetch default width/height values from the config table
- apply these defaults when adding new fields
- document loading layout defaults in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68493812c4488333bb43cf81d74bbde6