### PR TITLE
Fix duplicate sqlite3 import

### DIFF
--- a/db/edit_fields.py
+++ b/db/edit_fields.py
@@ -72,7 +72,6 @@ def add_field_to_schema(table, field_name, field_type, field_options=None, forei
         conn.commit()
 
 def add_column_to_table(table_name, field_name, field_type):
-    import sqlite3
     from db.database import get_connection
 
     # Map form types to SQL types


### PR DESCRIPTION
## Summary
- remove inline sqlite3 import inside `add_column_to_table`

## Testing
- `python -m py_compile db/edit_fields.py`


------
https://chatgpt.com/codex/tasks/task_e_68493be5c24c83339c5be2e08f2ac16e