### PR TITLE
Fix duplicate layout modal functions

### DIFF
--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -178,10 +178,6 @@
     document.getElementById("layoutModal").classList.add("hidden");
   };
 </script>
-<script type="module">
-  window.openLayoutModal = () => document.getElementById("layoutModal").classList.remove("hidden");
-  window.closeLayoutModal = () => document.getElementById("layoutModal").classList.add("hidden");
-</script>
 <script type="module" src="{{ url_for('static', filename='js/field_ajax.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/autosize_text.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/editor.js') }}"></script>


### PR DESCRIPTION
## Summary
- remove the extra script block in `detail_view.html` that redefined `openLayoutModal` and `closeLayoutModal`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68493cc23aa48333a5c196874b47b915