### PR TITLE
Add math options in dashboard widget builder

### DIFF
--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -32,6 +32,17 @@
 
         <div id="mathTagsContainer" class="flex flex-wrap gap-1 mb-2 hidden"></div>
 
+        <div id="mathOperationContainer" class="flex gap-2 mb-2 hidden">
+          {% for op in ['Add', 'Subtract', 'Multiply', 'Divide'] %}
+          <label class="flex-1 cursor-pointer">
+            <input type="radio" name="mathOperation" value="{{ op|lower }}" class="sr-only peer">
+            <div class="p-2 border rounded text-center peer-checked:bg-blue-500 peer-checked:text-white">
+              {{ op }}
+            </div>
+          </label>
+          {% endfor %}
+        </div>
+
         <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>
         <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
         <div id="resultRow" class="mt-4 flex items-center justify-center gap-2 hidden">


### PR DESCRIPTION
## Summary
- extend dashboard widget modal to support math operations
- show UI to pick Add/Subtract/Multiply/Divide
- compute and preview result when fields and operator are selected
- allow saving the new widget with math configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68493b8b77148333a237449b3bc1beb3