### PR TITLE
Update dashboard math controls

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -9,7 +9,15 @@ export function closeDashboardModal() {
 let selectedOperation = null;
 let selectedColumn = null;
 let mathOperation = null;
-let columnToggleBtn, columnToggleLabel, columnDropdown, valueResultEl, titleInputEl, resultRowEl, createBtnEl, mathTagsContainer, mathOpContainer;
+let mathField1 = null;
+let mathField2 = null;
+let agg1 = 'sum';
+let agg2 = 'sum';
+let columnToggleBtn, columnToggleLabel, columnDropdown;
+let mathSelect1Btn, mathSelect1Label, mathSelect1Options;
+let mathSelect2Btn, mathSelect2Label, mathSelect2Options;
+let aggToggle1El, aggToggle2El;
+let valueResultEl, titleInputEl, resultRowEl, createBtnEl, mathOpContainer;
 let activeTab = 'value';
 
 function setActiveTab(name) {
@@ -48,44 +56,14 @@ function initDashboardTabs() {
 
 function refreshColumnTags() {
   if (!columnToggleBtn) return;
-  if (!selectedColumn || (Array.isArray(selectedColumn) && selectedColumn.length === 0)) {
+  if (!selectedColumn) {
     if (columnToggleLabel) columnToggleLabel.textContent = 'Select Field';
-    if (mathTagsContainer) mathTagsContainer.innerHTML = '';
     updateValueResult();
     return;
   }
 
-  const values = Array.isArray(selectedColumn) ? selectedColumn : [selectedColumn];
-  const labels = values.map(val => {
-    const [table, field] = val.split(':');
-    return `${table}: ${field}`;
-  });
-
-  if (columnToggleLabel) columnToggleLabel.textContent = labels.join(', ');
-
-  if (selectedOperation === 'math' && mathTagsContainer) {
-    mathTagsContainer.innerHTML = '';
-    values.forEach(val => {
-      const [table, field] = val.split(':');
-      const tag = document.createElement('span');
-      tag.className = 'inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full';
-      tag.textContent = `${table}: ${field}`;
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'ml-1 text-blue-500 hover:text-red-500';
-      btn.textContent = '×';
-      btn.onclick = () => {
-        selectedColumn = selectedColumn.filter(v => v !== val);
-        const cb = columnDropdown.querySelector(`input[value="${val}"]`);
-        if (cb) cb.checked = false;
-        refreshColumnTags();
-      };
-      tag.appendChild(btn);
-      mathTagsContainer.appendChild(tag);
-    });
-  } else if (mathTagsContainer) {
-    mathTagsContainer.innerHTML = '';
-  }
+  const [table, field] = selectedColumn.split(':');
+  if (columnToggleLabel) columnToggleLabel.textContent = `${table}: ${field}`;
 
   updateValueResult();
 }
@@ -112,37 +90,48 @@ function updateValueResult() {
       .catch(() => {
         valueResultEl.textContent = 'Error';
       });
-  } else if (selectedOperation === 'math' && Array.isArray(selectedColumn) && selectedColumn.length >= 2 && mathOperation) {
+  } else if (selectedOperation === 'math' && mathField1 && mathOperation && (mathOperation === 'average' || mathField2)) {
     resultRowEl.classList.remove('hidden');
     if (createBtnEl) createBtnEl.classList.remove('hidden');
-    const labels = selectedColumn.map(val => val.split(':')[1]);
+    const labels = [mathField1, mathOperation !== 'average' ? mathField2 : null].filter(Boolean).map(v => v.split(':')[1]);
     const defaultTitle = `${mathOperation.charAt(0).toUpperCase() + mathOperation.slice(1)} of ${labels.join(', ')}`;
     if (titleInputEl) {
       titleInputEl.placeholder = defaultTitle;
       titleInputEl.value = defaultTitle;
     }
     valueResultEl.textContent = 'Calculating…';
-    Promise.all(selectedColumn.map(val => {
-      const [table, field] = val.split(':');
-      return fetch(`/${table}/sum-field?field=${encodeURIComponent(field)}`)
-        .then(res => res.json())
-        .then(d => d.sum || 0)
-        .catch(() => 0);
-    }))
-    .then(nums => {
-      let result = nums[0] || 0;
-      for (let i = 1; i < nums.length; i++) {
-        const n = nums[i] || 0;
-        if (mathOperation === 'add') result += n;
-        else if (mathOperation === 'subtract') result -= n;
-        else if (mathOperation === 'multiply') result *= n;
-        else if (mathOperation === 'divide') result /= n || 1;
-      }
-      valueResultEl.textContent = result;
-    })
-    .catch(() => {
-      valueResultEl.textContent = 'Error';
-    });
+    if (mathOperation === 'average') {
+      const [table, field] = mathField1.split(':');
+      Promise.all([
+        fetch(`/${table}/sum-field?field=${encodeURIComponent(field)}`).then(r => r.json()).then(d => d.sum || 0).catch(() => 0),
+        fetch(`/${table}/count-nonnull?field=${encodeURIComponent(field)}`).then(r => r.json()).then(d => d.count || 1).catch(() => 1)
+      ])
+      .then(([s, c]) => { valueResultEl.textContent = c ? s / c : 0; })
+      .catch(() => { valueResultEl.textContent = 'Error'; });
+    } else {
+      const fields = [
+        { val: mathField1, mode: agg1 },
+        { val: mathField2, mode: agg2 }
+      ];
+      Promise.all(fields.map(f => {
+        const [table, field] = f.val.split(':');
+        const endpoint = f.mode === 'sum' ? 'sum-field' : 'count-nonnull';
+        const key = f.mode === 'sum' ? 'sum' : 'count';
+        return fetch(`/${table}/${endpoint}?field=${encodeURIComponent(field)}`)
+          .then(res => res.json())
+          .then(d => d[key] || 0)
+          .catch(() => 0);
+      }))
+      .then(nums => {
+        let result = 0;
+        if (mathOperation === 'add') result = nums[0] + nums[1];
+        else if (mathOperation === 'subtract') result = nums[0] - nums[1];
+        else if (mathOperation === 'multiply') result = nums[0] * nums[1];
+        else if (mathOperation === 'divide') result = nums[0] / (nums[1] || 1);
+        valueResultEl.textContent = result;
+      })
+      .catch(() => { valueResultEl.textContent = 'Error'; });
+    }
   } else {
     resultRowEl.classList.add('hidden');
     valueResultEl.textContent = '';
@@ -153,7 +142,7 @@ function updateValueResult() {
 function onCreateWidget(event) {
   if (event) event.preventDefault();
   if (selectedOperation === 'math') {
-    if (!Array.isArray(selectedColumn) || selectedColumn.length < 2 || !mathOperation) return;
+    if (!mathField1 || !mathOperation || (mathOperation !== 'average' && !mathField2)) return;
   } else if (!['sum', 'count'].includes(selectedOperation) || !selectedColumn) {
     return;
   }
@@ -162,9 +151,9 @@ function onCreateWidget(event) {
   let payloadContent;
 
   if (selectedOperation === 'math') {
-    const labels = selectedColumn.map(val => val.split(':')[1]);
+    const labels = [mathField1, mathOperation !== 'average' ? mathField2 : null].filter(Boolean).map(v => v.split(':')[1]);
     defaultTitle = `${mathOperation.charAt(0).toUpperCase() + mathOperation.slice(1)} of ${labels.join(', ')}`;
-    payloadContent = { operation: 'math', math_operation: mathOperation, columns: selectedColumn };
+    payloadContent = { operation: 'math', math_operation: mathOperation, field1: mathField1, field2: mathField2, agg1, agg2 };
   } else {
     const [table, field] = selectedColumn.split(':');
     defaultTitle = `${selectedOperation === 'sum' ? 'Sum' : 'Count'} of ${field}`;
@@ -198,107 +187,93 @@ function onCreateWidget(event) {
     });
 }
 
-function updateColumnOptions() {
-  if (!columnDropdown || !columnToggleBtn) return;
-
-  if (!selectedOperation) {
-    columnToggleBtn.classList.add('hidden');
-    columnDropdown.classList.add('hidden');
-    selectedColumn = null;
-    if (mathTagsContainer) {
-      mathTagsContainer.classList.add('hidden');
-      mathTagsContainer.innerHTML = '';
-    }
-    if (mathOpContainer) {
-      mathOpContainer.classList.add('hidden');
-      const checked = mathOpContainer.querySelector('input[name="mathOperation"]:checked');
-      if (checked) checked.checked = false;
-      mathOperation = null;
-    }
-    refreshColumnTags();
-    return;
-  }
-
-  columnToggleBtn.classList.remove('hidden');
-  columnDropdown.innerHTML = '';
-  if (mathTagsContainer) {
-    if (selectedOperation === 'math') {
-      mathTagsContainer.classList.remove('hidden');
-      if (mathOpContainer) mathOpContainer.classList.remove('hidden');
-    } else {
-      mathTagsContainer.classList.add('hidden');
-      mathTagsContainer.innerHTML = '';
-      if (mathOpContainer) {
-        mathOpContainer.classList.add('hidden');
-        const checked = mathOpContainer.querySelector('input[name="mathOperation"]:checked');
-        if (checked) checked.checked = false;
-        mathOperation = null;
-      }
-    }
-  }
-
-  const inputType = selectedOperation === 'math' ? 'checkbox' : 'radio';
-
-  if (selectedOperation === 'math' && !Array.isArray(selectedColumn)) {
-    selectedColumn = [];
-  }
-  if (selectedOperation !== 'math' && Array.isArray(selectedColumn)) {
-    selectedColumn = selectedColumn[0] || null;
-  }
-
+function populateFieldDropdown(dropdown, restrictNumeric, callback) {
+  if (!dropdown) return;
+  dropdown.innerHTML = '';
   const search = document.createElement('input');
   search.type = 'text';
   search.placeholder = 'Search...';
   search.className = 'w-full px-2 py-1 border rounded text-sm mb-2';
   search.addEventListener('input', function() {
     const v = this.value.toLowerCase();
-    [...columnDropdown.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)));
+    [...dropdown.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)));
   });
-  columnDropdown.appendChild(search);
+  dropdown.appendChild(search);
 
   Object.keys(FIELD_SCHEMA).forEach(table => {
     const fields = FIELD_SCHEMA[table] ? Object.keys(FIELD_SCHEMA[table]) : [];
     fields.forEach(field => {
       const type = FIELD_SCHEMA[table] && FIELD_SCHEMA[table][field] ? FIELD_SCHEMA[table][field].type : '';
-      if (selectedOperation === 'sum' && type !== 'number') return;
+      if (restrictNumeric && type !== 'number') return;
       const val = `${table}:${field}`;
       const label = document.createElement('label');
       label.className = 'flex items-center space-x-2';
       const input = document.createElement('input');
-      input.type = inputType;
-      input.name = 'columnSelect';
+      input.type = 'radio';
+      input.name = 'fieldSelect';
       input.value = val;
       input.className = 'rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500';
-
-      if (inputType === 'checkbox') {
-        if (selectedColumn.includes(val)) input.checked = true;
-        input.addEventListener('change', () => {
-          if (input.checked) {
-            if (!selectedColumn.includes(val)) selectedColumn.push(val);
-          } else {
-            selectedColumn = selectedColumn.filter(v => v !== val);
-          }
-          refreshColumnTags();
-        });
-      } else {
-        if (selectedColumn === val) input.checked = true;
-        input.addEventListener('change', () => {
-          selectedColumn = val;
-          refreshColumnTags();
-          columnDropdown.classList.add('hidden');
-        });
-      }
-
+      input.addEventListener('change', () => {
+        callback(val);
+        dropdown.classList.add('hidden');
+      });
       const span = document.createElement('span');
       span.className = 'text-sm';
       span.innerHTML = `<strong>${table}</strong>: ${field} <span class="text-blue-600 text-xs">(${type})</span>`;
       label.appendChild(input);
       label.appendChild(span);
-      columnDropdown.appendChild(label);
+      dropdown.appendChild(label);
     });
   });
+}
 
-  refreshColumnTags();
+function updateColumnOptions() {
+  if (!columnToggleBtn || !columnDropdown) return;
+
+  // hide everything first
+  columnToggleBtn.classList.add('hidden');
+  columnDropdown.classList.add('hidden');
+  if (mathSelect1Btn) mathSelect1Btn.parentElement.parentElement.classList.add('hidden');
+  if (mathSelect2Btn) mathSelect2Btn.parentElement.parentElement.classList.add('hidden');
+  if (mathOpContainer) mathOpContainer.classList.add('hidden');
+
+  if (!selectedOperation) {
+    selectedColumn = null;
+    mathField1 = null;
+    mathField2 = null;
+    mathOperation = null;
+    updateValueResult();
+    return;
+  }
+
+  if (selectedOperation === 'sum' || selectedOperation === 'count') {
+    columnToggleBtn.classList.remove('hidden');
+    populateFieldDropdown(columnDropdown, selectedOperation === 'sum', val => {
+      selectedColumn = val;
+      refreshColumnTags();
+    });
+    refreshColumnTags();
+  } else if (selectedOperation === 'math') {
+    if (mathSelect1Btn) mathSelect1Btn.parentElement.parentElement.classList.remove('hidden');
+    if (mathOpContainer) mathOpContainer.classList.remove('hidden');
+    populateFieldDropdown(mathSelect1Options, false, val => {
+      mathField1 = val;
+      if (mathSelect1Label) {
+        const [t,f] = val.split(':');
+        mathSelect1Label.textContent = `${t}: ${f}`;
+      }
+      updateValueResult();
+    });
+    populateFieldDropdown(mathSelect2Options, false, val => {
+      mathField2 = val;
+      if (mathSelect2Label) {
+        const [t,f] = val.split(':');
+        mathSelect2Label.textContent = `${t}: ${f}`;
+      }
+      updateValueResult();
+    });
+  }
+
   updateValueResult();
 }
 
@@ -328,7 +303,10 @@ function initOperationSelect() {
   opSelect.addEventListener('change', () => {
     const checked = opSelect.querySelector('input[name="dashboardOperation"]:checked');
     selectedOperation = checked ? checked.value : null;
-    selectedColumn = selectedOperation === 'math' ? [] : null;
+    selectedColumn = null;
+    mathField1 = null;
+    mathField2 = null;
+    mathOperation = null;
     updateColumnOptions();
   });
 }
@@ -337,16 +315,51 @@ function initDashboardModal() {
   initDashboardTabs();
   initOperationSelect();
   initColumnSelect();
+  mathSelect1Btn = document.getElementById('mathSelect1Toggle');
+  mathSelect1Label = mathSelect1Btn ? mathSelect1Btn.querySelector('.selected-label') : null;
+  mathSelect1Options = document.getElementById('mathSelect1Options');
+  mathSelect2Btn = document.getElementById('mathSelect2Toggle');
+  mathSelect2Label = mathSelect2Btn ? mathSelect2Btn.querySelector('.selected-label') : null;
+  mathSelect2Options = document.getElementById('mathSelect2Options');
+  aggToggle1El = document.getElementById('aggToggle1');
+  aggToggle2El = document.getElementById('aggToggle2');
   valueResultEl = document.getElementById('valueResult');
   titleInputEl = document.getElementById('valueTitleInput');
   resultRowEl = document.getElementById('resultRow');
   createBtnEl = document.getElementById('dashboardCreateBtn');
-  mathTagsContainer = document.getElementById('mathTagsContainer');
   mathOpContainer = document.getElementById('mathOperationContainer');
   if (mathOpContainer) {
     mathOpContainer.addEventListener('change', () => {
       const checked = mathOpContainer.querySelector('input[name="mathOperation"]:checked');
       mathOperation = checked ? checked.value : null;
+      updateValueResult();
+    });
+  }
+  if (mathSelect1Btn && mathSelect1Options) {
+    mathSelect1Btn.addEventListener('click', e => { e.stopPropagation(); mathSelect1Options.classList.toggle('hidden'); });
+    document.addEventListener('click', e => {
+      if (!mathSelect1Options.contains(e.target) && e.target !== mathSelect1Btn) mathSelect1Options.classList.add('hidden');
+    });
+    mathSelect1Options.addEventListener('click', e => e.stopPropagation());
+  }
+  if (mathSelect2Btn && mathSelect2Options) {
+    mathSelect2Btn.addEventListener('click', e => { e.stopPropagation(); mathSelect2Options.classList.toggle('hidden'); });
+    document.addEventListener('click', e => {
+      if (!mathSelect2Options.contains(e.target) && e.target !== mathSelect2Btn) mathSelect2Options.classList.add('hidden');
+    });
+    mathSelect2Options.addEventListener('click', e => e.stopPropagation());
+  }
+  if (aggToggle1El) {
+    aggToggle1El.addEventListener('change', () => {
+      const checked = aggToggle1El.querySelector('input[name="agg1"]:checked');
+      agg1 = checked ? checked.value : 'sum';
+      updateValueResult();
+    });
+  }
+  if (aggToggle2El) {
+    aggToggle2El.addEventListener('change', () => {
+      const checked = aggToggle2El.querySelector('input[name="agg2"]:checked');
+      agg2 = checked ? checked.value : 'sum';
       updateValueResult();
     });
   }

--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -30,10 +30,27 @@
           {% endfor %}
         </div>
 
-        <div id="mathTagsContainer" class="flex flex-wrap gap-1 mb-2 hidden"></div>
+        <div id="mathField1" class="flex items-start gap-2 mb-2 hidden">
+          <div class="relative flex-grow">
+            <button id="mathSelect1Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left flex items-center justify-between">
+              <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
+            </button>
+            <div id="mathSelect1Options" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+          </div>
+          <div id="aggToggle1" class="flex flex-col">
+            <label class="cursor-pointer">
+              <input type="radio" name="agg1" value="sum" class="sr-only peer" checked>
+              <div class="p-1 border rounded-t text-center peer-checked:bg-blue-500 peer-checked:text-white">Sum</div>
+            </label>
+            <label class="cursor-pointer">
+              <input type="radio" name="agg1" value="count" class="sr-only peer">
+              <div class="p-1 border border-t-0 rounded-b text-center peer-checked:bg-blue-500 peer-checked:text-white">Count</div>
+            </label>
+          </div>
+        </div>
 
         <div id="mathOperationContainer" class="flex gap-2 mb-2 hidden">
-          {% for op in ['Add', 'Subtract', 'Multiply', 'Divide'] %}
+          {% for op in ['Add', 'Subtract', 'Multiply', 'Divide', 'Average'] %}
           <label class="flex-1 cursor-pointer">
             <input type="radio" name="mathOperation" value="{{ op|lower }}" class="sr-only peer">
             <div class="p-2 border rounded text-center peer-checked:bg-blue-500 peer-checked:text-white">
@@ -41,6 +58,25 @@
             </div>
           </label>
           {% endfor %}
+        </div>
+
+        <div id="mathField2" class="flex items-start gap-2 mb-2 hidden">
+          <div class="relative flex-grow">
+            <button id="mathSelect2Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left flex items-center justify-between">
+              <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
+            </button>
+            <div id="mathSelect2Options" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+          </div>
+          <div id="aggToggle2" class="flex flex-col">
+            <label class="cursor-pointer">
+              <input type="radio" name="agg2" value="sum" class="sr-only peer" checked>
+              <div class="p-1 border rounded-t text-center peer-checked:bg-blue-500 peer-checked:text-white">Sum</div>
+            </label>
+            <label class="cursor-pointer">
+              <input type="radio" name="agg2" value="count" class="sr-only peer">
+              <div class="p-1 border border-t-0 rounded-b text-center peer-checked:bg-blue-500 peer-checked:text-white">Count</div>
+            </label>
+          </div>
         </div>
 
         <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>


### PR DESCRIPTION
## Summary
- simplify math field selection in dashboard modal
- add per-field sum/count toggles
- support Add/Subtract/Multiply/Divide/Average with single selects

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849749fa75083339c43c5288afb320c