### PR TITLE
Adjust console logging to only show errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 
 * **Templating & Macros:** Jinja2 templates in `templates/` include the core pages (`base.html`, `index.html`, `list_view.html`, `detail_view.html`, `new_record.html`, `dashboard.html`) plus admin and import views. Partial templates like `edit_fields_modal.html` and `bulk_edit_modal.html` are used for modals. Reusable macros live in `templates/macros/fields.html` and `filter_controls.html`.
 
-* **Logging & Monitoring:** Logging is configured via `logging_setup.py` and values stored in the database. A rotating or timed file handler uses the configured level, while console output logs only warnings and above. Werkzeug request logs are disabled. Logs capture errors and user actions.
+* **Logging & Monitoring:** Logging is configured via `logging_setup.py` and values stored in the database. A rotating or timed file handler uses the configured level, while console output shows only errors. Werkzeug request logs are disabled. Logs capture errors and user actions.
 * **Utility Helpers:** Generic helper code lives in `utils/`. The `validation.py` module powers CSV import validation and can be reused across routes.
 
 * **Data Directory:** Runtime files under `data/`: `crossbook.db` (primary database) and `huey.db` (task queue store).

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -52,7 +52,8 @@ def configure_logging(app):
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)
-    console_handler.setLevel(logging.WARNING)
+    # Only show errors in the console but keep all logs in the file
+    console_handler.setLevel(logging.ERROR)
 
     app.logger.setLevel(level)
     app.logger.addHandler(file_handler)


### PR DESCRIPTION
## Summary
- limit console handler to ERROR level in `logging_setup.py`
- update README to describe new behavior

## Testing
- `python -m py_compile logging_setup.py main.py db/*.py utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6849752f21588333b075b096c432bfe1