### PR TITLE
Fix root logger handlers and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 
 * **Templating & Macros:** Jinja2 templates in `templates/` include the core pages (`base.html`, `index.html`, `list_view.html`, `detail_view.html`, `new_record.html`, `dashboard.html`) plus admin and import views. Partial templates like `edit_fields_modal.html` and `bulk_edit_modal.html` are used for modals. Reusable macros live in `templates/macros/fields.html` and `filter_controls.html`.
 
-* **Logging & Monitoring:** Logging is configured via `logging_setup.py` and values stored in the database. A rotating or timed file handler uses the configured level, while console output shows only errors. Werkzeug request logs are disabled. Logs capture errors and user actions.
+* **Logging & Monitoring:** Logging is configured via `logging_setup.py` and values stored in the database. Both Flask and root handlers are cleared, then a rotating or timed file handler is attached. Only error-level messages appear in the console. Werkzeug request logs are disabled. Logs capture errors and user actions.
 * **Utility Helpers:** Generic helper code lives in `utils/`. The `validation.py` module powers CSV import validation and can be reused across routes.
 
 * **Data Directory:** Runtime files under `data/`: `crossbook.db` (primary database) and `huey.db` (task queue store).

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -59,8 +59,10 @@ def configure_logging(app):
     app.logger.addHandler(file_handler)
 
     root_logger = logging.getLogger()
+    root_logger.handlers.clear()
     root_logger.setLevel(level)
     root_logger.addHandler(file_handler)
+    root_logger.propagate = False
 
     app.logger.addHandler(console_handler)
     app.logger.propagate = False


### PR DESCRIPTION
## Summary
- clear root logger handlers in `logging_setup.configure_logging`
- attach the file handler to the root logger and disable propagation
- document root logger clearing in README

## Testing
- `python -m py_compile logging_setup.py main.py db/*.py utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684977cb430c83339be0cde15b9692b6