### PR TITLE
Fix dashboard modal width

### DIFF
--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -1,7 +1,7 @@
 <!-- Dashboard Add Modal -->
 <div id="dashboardModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
      onclick="if(event.target.id === 'dashboardModal') closeDashboardModal()">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+  <div class="bg-white p-6 rounded-lg shadow-lg w-fit min-w-[24rem] max-w-full relative">
     <button onclick="closeDashboardModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <div class="mb-4">
       <ul class="flex border-b border-gray-200">


### PR DESCRIPTION
## Summary
- allow dashboard modal width to expand with content

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68497b4423248333a3fce8e70866a6ce