### PR TITLE
Fix layout of aggregation toggles

### DIFF
--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -37,14 +37,14 @@
             </button>
             <div id="mathSelect1Options" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
           </div>
-          <div id="aggToggle1" class="flex flex-col">
+          <div id="aggToggle1" class="flex">
             <label class="cursor-pointer">
               <input type="radio" name="agg1" value="sum" class="sr-only peer" checked>
-              <div class="p-1 border rounded-t text-center peer-checked:bg-blue-500 peer-checked:text-white">Sum</div>
+              <div class="p-1 border rounded-l text-center peer-checked:bg-blue-500 peer-checked:text-white">Sum</div>
             </label>
             <label class="cursor-pointer">
               <input type="radio" name="agg1" value="count" class="sr-only peer">
-              <div class="p-1 border border-t-0 rounded-b text-center peer-checked:bg-blue-500 peer-checked:text-white">Count</div>
+              <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-blue-500 peer-checked:text-white">Count</div>
             </label>
           </div>
         </div>
@@ -67,14 +67,14 @@
             </button>
             <div id="mathSelect2Options" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
           </div>
-          <div id="aggToggle2" class="flex flex-col">
+          <div id="aggToggle2" class="flex">
             <label class="cursor-pointer">
               <input type="radio" name="agg2" value="sum" class="sr-only peer" checked>
-              <div class="p-1 border rounded-t text-center peer-checked:bg-blue-500 peer-checked:text-white">Sum</div>
+              <div class="p-1 border rounded-l text-center peer-checked:bg-blue-500 peer-checked:text-white">Sum</div>
             </label>
             <label class="cursor-pointer">
               <input type="radio" name="agg2" value="count" class="sr-only peer">
-              <div class="p-1 border border-t-0 rounded-b text-center peer-checked:bg-blue-500 peer-checked:text-white">Count</div>
+              <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-blue-500 peer-checked:text-white">Count</div>
             </label>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- make Sum/Count buttons appear horizontally for both aggregation toggles

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68498494dcbc833396c667aa784b9b63