### PR TITLE
Hide hidden fields in dashboard modal

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -201,9 +201,11 @@ function populateFieldDropdown(dropdown, restrictNumeric, callback) {
   dropdown.appendChild(search);
 
   Object.keys(FIELD_SCHEMA).forEach(table => {
-    const fields = FIELD_SCHEMA[table] ? Object.keys(FIELD_SCHEMA[table]) : [];
+    const tableSchema = FIELD_SCHEMA[table] || {};
+    const fields = Object.keys(tableSchema);
     fields.forEach(field => {
-      const type = FIELD_SCHEMA[table] && FIELD_SCHEMA[table][field] ? FIELD_SCHEMA[table][field].type : '';
+      const type = tableSchema[field] ? tableSchema[field].type : '';
+      if (type === 'hidden') return;
       if (restrictNumeric && type !== 'number') return;
       const val = `${table}:${field}`;
       const label = document.createElement('label');


### PR DESCRIPTION
## Summary
- filter out hidden fields from dropdowns in the dashboard modal

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68499dfccf788333b45d0d401f47611e