### PR TITLE
Add resize handles to dashboard widgets

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -31,6 +31,14 @@
       {% else %}
         <div class="text-gray-500">{{ widget.widget_type }} widget</div>
       {% endif %}
+      <span class="resize-handle hidden top-left"
+            style="position:absolute; top:0; left:0; width:8px; height:8px; background:#333; cursor:nwse-resize; "></span>
+      <span class="resize-handle hidden top-right"
+            style="position:absolute; top:0; right:0; width:8px; height:8px; background:#333; cursor:nwse-resize; "></span>
+      <span class="resize-handle hidden bottom-left"
+            style="position:absolute; bottom:0; left:0; width:8px; height:8px; background:#333; cursor:nwse-resize; "></span>
+      <span class="resize-handle hidden bottom-right"
+            style="position:absolute; bottom:0; right:0; width:8px; height:8px; background:#333; cursor:nwse-resize; "></span>
     </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- add the same four resize handles used in detail view to each dashboard widget

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6849a31823348333b64b67c7549acdbb