### PR TITLE
Restore hidden fields to dashboard dropdown

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -262,7 +262,6 @@ function populateFieldDropdown(dropdown, restrictNumeric, callback) {
     const fields = Object.keys(tableSchema);
     fields.forEach(field => {
       const type = tableSchema[field] ? tableSchema[field].type : '';
-      if (type === 'hidden') return;
       if (restrictNumeric && type !== 'number') return;
       const val = `${table}:${field}`;
       const label = document.createElement('label');


### PR DESCRIPTION
## Summary
- show fields marked as `hidden` in the dashboard modal dropdown

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849a2d3f3488333aaf6adfba5c09c4b