### PR TITLE
Implement dashboard edit mode toggle

### DIFF
--- a/static/js/dashboard_grid.js
+++ b/static/js/dashboard_grid.js
@@ -12,6 +12,30 @@ const defaultWidgetHeight = {
 
 const widgetLayout = {};
 
+function enterEditMode() {
+  const grid = document.getElementById('dashboard-grid');
+  if (grid) {
+    grid.classList.add('editing');
+  }
+  document
+    .querySelectorAll('#dashboard-grid .resize-handle')
+    .forEach(h => h.classList.remove('hidden'));
+  const saveBtn = document.getElementById('dashboard_save');
+  if (saveBtn) saveBtn.classList.remove('hidden');
+}
+
+function exitEditMode() {
+  const grid = document.getElementById('dashboard-grid');
+  if (grid) {
+    grid.classList.remove('editing');
+  }
+  document
+    .querySelectorAll('#dashboard-grid .resize-handle')
+    .forEach(h => h.classList.add('hidden'));
+  const saveBtn = document.getElementById('dashboard_save');
+  if (saveBtn) saveBtn.classList.add('hidden');
+}
+
 function intersects(a, b) {
   return (
     a.colStart <  b.colStart + b.colSpan  &&
@@ -195,4 +219,12 @@ function enableDashboardResize() {
 document.addEventListener('DOMContentLoaded', () => {
   enableDashboardDrag();
   enableDashboardResize();
+  const editBtn = document.getElementById('dashboard_edit');
+  if (editBtn) editBtn.addEventListener('click', enterEditMode);
+  const saveBtn = document.getElementById('dashboard_save');
+  if (saveBtn) {
+    saveBtn.addEventListener('click', () => {
+      exitEditMode();
+    });
+  }
 });

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -5,6 +5,7 @@
 {% block nav_buttons %}
 <button id="dashboard_add" onclick="openDashboardModal()" class="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600">+ Add</button>
 <button id="dashboard_edit" class="bg-purple-500 text-white px-3 py-1 rounded hover:bg-purple-600">Edit</button>
+<button id="dashboard_save" class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 hidden">Save Layout</button>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- add Save Layout button to dashboard
- implement `enterEditMode` and `exitEditMode` in dashboard_grid.js
- wire up Edit and Save buttons to edit mode functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a4da35b4833398b4d41df8d36248