### PR TITLE
Expose widget layout for dashboard

### DIFF
--- a/static/js/dashboard_grid.js
+++ b/static/js/dashboard_grid.js
@@ -10,7 +10,7 @@ const defaultWidgetHeight = {
   chart: 8
 };
 
-const widgetLayout = {};
+const widgetLayout = window.WIDGET_LAYOUT || {};
 
 function enterEditMode() {
   const grid = document.getElementById('dashboard-grid');

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -17,11 +17,18 @@
      style="grid-template-columns: repeat(20, 1fr); grid-auto-rows: 1em;">
   {% set default_width = { 'value': 4, 'table': 10, 'chart': 10 } %}
   {% set default_height = { 'value': 3, 'table': 8,  'chart': 8 } %}
+  {% set widget_layout = {} %}
   {% for widget in widgets %}
     {% set col_start = widget.col_start or 1 %}
     {% set col_span  = widget.col_span  or default_width[widget.widget_type] %}
     {% set row_start = widget.row_start or 1 %}
     {% set row_span  = widget.row_span  or default_height[widget.widget_type] %}
+    {% set _ = widget_layout.update({ widget.id: {
+      'colStart': col_start,
+      'colSpan': col_span,
+      'rowStart': row_start,
+      'rowSpan': row_span
+    } }) %}
     <div class="dashboard-widget draggable-field border p-2 rounded shadow bg-gray-50"
          data-widget="{{ widget.id }}"
          data-type="{{ widget.widget_type }}"
@@ -47,6 +54,7 @@
 {% include "dashboard_modal.html" %}
 
 <script>const FIELD_SCHEMA = {{ field_schema | tojson }};</script>
+<script>window.WIDGET_LAYOUT = {{ widget_layout | tojson }};</script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_modal.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_grid.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- output `window.WIDGET_LAYOUT` with each widget's grid settings
- initialize `widgetLayout` in JS from that object

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849a8f6bd488333bb0363220286594c