### PR TITLE
Add endpoint to save dashboard layout

### DIFF
--- a/static/js/dashboard_grid.js
+++ b/static/js/dashboard_grid.js
@@ -56,6 +56,24 @@ function revertPosition(el) {
   widgetLayout[el.dataset.widget] = { ...prev };
 }
 
+function saveDashboardLayout() {
+  const layout = Object.entries(widgetLayout).map(([id, rect]) => ({
+    id: parseInt(id),
+    colStart: rect.colStart,
+    colSpan: rect.colSpan,
+    rowStart: rect.rowStart,
+    rowSpan: rect.rowSpan
+  }));
+  fetch('/dashboard/layout', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ layout })
+  })
+    .then(res => res.json())
+    .then(data => { console.debug('[dashboard] save layout', data); })
+    .catch(err => { console.error('[dashboard] save layout error', err); });
+}
+
 function enableDashboardDrag() {
   const grid = document.getElementById('dashboard-grid');
   let isDragging = false;
@@ -224,6 +242,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const saveBtn = document.getElementById('dashboard_save');
   if (saveBtn) {
     saveBtn.addEventListener('click', () => {
+      saveDashboardLayout();
       exitEditMode();
     });
   }

--- a/views/admin.py
+++ b/views/admin.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template, redirect, url_for, request, jsonify, current_app
 from logging_setup import configure_logging
 from db.config import get_config_rows, update_config, get_logging_config
-from db.dashboard import get_dashboard_widgets, create_widget
+from db.dashboard import get_dashboard_widgets, create_widget, update_widget_layout
 from db.schema import create_base_table, refresh_card_cache
 from imports.import_csv import parse_csv
 from utils.validation import validation_sorter
@@ -80,6 +80,16 @@ def dashboard_create_widget():
         return jsonify({'error': 'Failed to create widget'}), 500
 
     return jsonify({'success': True, 'id': widget_id})
+
+
+@admin_bp.route('/dashboard/layout', methods=['POST'])
+def dashboard_update_layout():
+    data = request.get_json(silent=True)
+    if not data or not isinstance(data.get('layout'), list):
+        return jsonify({'error': 'Invalid JSON or missing `layout`'}), 400
+    layout_items = data['layout']
+    updated = update_widget_layout(layout_items)
+    return jsonify({'success': True, 'updated': updated})
 
 @admin_bp.route('/add-table', methods=['POST'])
 def add_table():


### PR DESCRIPTION
## Summary
- allow dashboard widgets to store layout updates
- POST /dashboard/layout to persist positions
- wire up save button in dashboard grid JS

## Testing
- `python -m py_compile db/dashboard.py views/admin.py`

------
https://chatgpt.com/codex/tasks/task_e_6849aa8e0da483339045ca7aa1196fd7