### PR TITLE
Add outline style for dashboard widgets

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -40,7 +40,12 @@
 }
 
 #available-fields-list .matched-valid {
-  background-color: #dcfce7;  
-  border-color:     #86efac;  
+  background-color: #dcfce7;
+  border-color:     #86efac;
+}
+
+/* Add a subtle outline around dashboard widgets */
+.dashboard-widget {
+  outline: 1px solid #e5e7eb; /* tailwind gray-200 */
 }
 


### PR DESCRIPTION
## Summary
- add CSS rule for `.dashboard-widget` outline

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6849b0dc58108333954db03524d79523