### PR TITLE
Replace edit_log text field with edit_history table

### DIFF
--- a/db/schema.py
+++ b/db/schema.py
@@ -228,18 +228,10 @@ def create_base_table(table_name: str, description: str) -> bool:
                 """
             )
 
-            # Always ensure the edit_log column exists
-            try:
-                cur.execute(f"ALTER TABLE {table_name} ADD COLUMN edit_log TEXT")
-            except sqlite3.OperationalError as exc:
-                if "duplicate column name" not in str(exc).lower():
-                    raise
-
             # Insert default field schema rows
             defaults = [
                 (table_name, "id", "hidden", None, None, 0, 0, 0, 0),
                 (table_name, table_name, "text", None, None, 0, 0, 0, 0),
-                (table_name, "edit_log", "hidden", None, None, 0, 0, 0, 0),
             ]
             cur.executemany(
                 """

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -87,12 +87,14 @@
 
     </div>
 
-    {% if record.edit_log %}
+    {% if edit_history %}
       <details class="mt-6 text-sm text-gray-600">
         <summary class="cursor-pointer font-medium text-blue-600">
           Edit History
         </summary>
-        <pre class="whitespace-pre-wrap mt-2">{{ record.edit_log }}</pre>
+        <pre class="whitespace-pre-wrap mt-2">
+{% for row in edit_history %}[{{ row.timestamp }}] {{ row.field_name }}: {{ row.old_value }} → {{ row.new_value }}{% if row.actor %} ({{ row.actor }}){% endif %}
+{% endfor %}</pre>
       </details>
     {% endif %}
   </div>

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -92,8 +92,6 @@
             <td class="px-4 py-2 whitespace-nowrap" data-field="{{ field|lower }}">
               {% if field_schema[table][field].type == "textarea" %}
                 {{ record[field]|striptags|truncate(100) }}
-              {% elif field == "edit_log" %}
-                {{ record[field].split('\n')[0] if record[field] }}
               {% else %}
                 {{ record[field] }}
               {% endif %}

--- a/templates/new_record.html
+++ b/templates/new_record.html
@@ -6,7 +6,7 @@
 
 <form method="post" class="space-y-4">
   {% for field, ftype in fields.items() %}
-    {% if field != "id" and field != "edit_log" and ftype != "hidden" %}
+    {% if field != "id" and ftype != "hidden" %}
       <div>
         <label class="block text-sm font-medium capitalize mb-1">{{ field }}</label>
         {% if ftype == "textarea" %}


### PR DESCRIPTION
## Summary
- insert edit history via a new `edit_history` table
- drop `edit_log` column creation in schema
- ignore `edit_log` in form generation
- log updates and relationship changes using structured info
- show edit history in detail view using new helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849b6f7aa0c833380af1e64d58e236f