### PR TITLE
Add undo ability for edit history

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Detail View & Inline Edit:** Displays all fields on the detail page with inline editing via text inputs, date pickers, checkboxes, or textareas. Numeric field changes now save via AJAX and append to the edit log without reloading the page.
 * **Relationship Management:** Displays related records and allows adding/removing relationships through a modal interface (+ to add, ✖ to remove), using AJAX to update join tables dynamically.
 * **Rich Text Support:** Textareas are enhanced with [Quill](https://quilljs.com/) for WYSIWYG editing.
-* **Edit History:** Tracks each record’s modifications in an `edit_log`, viewable via an expandable history section.
+* **Edit History:** Tracks each record’s modifications in an `edit_log`, viewable via an expandable history section. Individual entries now include an **Undo** link to revert that change.
 * **Navigation Bar:** A consistent top navigation (`base.html`) links to Home and all base table sections.
 * **Supported Field Types:** text, number, date, select, multi-select, foreign-key, boolean, and textarea, each rendered with the appropriate input control.
 * **Filter Macros:** Reusable Jinja macros for boolean, select, text, and multi-select filters (`templates/macros/filter_controls.html`).
@@ -350,7 +350,7 @@ Key features of the detail view:
     - For foreign key fields: currently just displays the value in italic blue text (as a visual cue that it’s a reference) – but it’s not a link. This is a placeholder for future functionality.
     - All other fields: displayed as plain text.
     - In all non-edit cases (except booleans which have their own form), an edit ✏️ icon link is provided next to the value. Clicking this link reloads the page with the `?edit=<fieldname>` query parameter, thus switching that field into edit mode.
-- **Edit Log:** If the `record.edit_log` field is present and not empty, the template shows an **Edit History** section below the fields table. This is implemented with a `<details>` element that can be expanded to reveal the full log (each entry on a new line, preserved with whitespace via `<pre>`). This allows developers to see all past changes to the record’s fields.
+- **Edit Log:** If the `record.edit_log` field is present and not empty, the template shows an **Edit History** section below the fields table. Each entry includes an **Undo** button which posts back to revert that particular change. The section is implemented with a `<details>` element containing a list of the past changes.
 - **Related Records (Right Panel):** On the right side, the template shows **Related Pages**:
   - It loops over the `related` dictionary (from `get_related_records`). Each entry corresponds to a related table, with a label (e.g., "Locations") and a list of related items.
   - For each related table section, it displays a heading (the label) and a **+ button**. The + button triggers the `openAddRelationModal(table, id, related_table)` JavaScript function (with the current record’s table and ID, and the target related table).

--- a/static/js/undo_edit.js
+++ b/static/js/undo_edit.js
@@ -1,0 +1,13 @@
+export function undoEdit(editId, table, recordId) {
+  fetch(`/${table}/${recordId}/undo/${editId}`, {
+    method: 'POST',
+    headers: { 'X-Requested-With': 'XMLHttpRequest' }
+  }).then(resp => {
+    if (resp.ok) {
+      location.reload();
+    } else {
+      alert('Undo failed');
+    }
+  });
+}
+window.undoEdit = undoEdit;

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -92,9 +92,14 @@
         <summary class="cursor-pointer font-medium text-blue-600">
           Edit History
         </summary>
-        <pre class="whitespace-pre-wrap mt-2">
-{% for row in edit_history %}[{{ row.timestamp }}] {{ row.field_name }}: {{ row.old_value }} → {{ row.new_value }}{% if row.actor %} ({{ row.actor }}){% endif %}
-{% endfor %}</pre>
+        <ul class="mt-2 space-y-1 text-blue-800">
+        {% for row in edit_history %}
+          <li>
+            [{{ row.timestamp }}] {{ row.field_name }}: {{ row.old_value }} → {{ row.new_value }}{% if row.actor %} ({{ row.actor }}){% endif %}
+            <button class="ml-2 text-sm text-blue-600 underline" onclick="undoEdit({{ row.id }}, '{{ table }}', {{ record.id }})">Undo</button>
+          </li>
+        {% endfor %}
+        </ul>
       </details>
     {% endif %}
   </div>
@@ -183,6 +188,7 @@
 <script type="module" src="{{ url_for('static', filename='js/field_ajax.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/autosize_text.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/editor.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/undo_edit.js') }}"></script>
 
 {% include "edit_fields_modal.html" %}
 

--- a/views/records.py
+++ b/views/records.py
@@ -11,6 +11,8 @@ from db.records import (
     count_records,
     append_edit_log,
     get_edit_history,
+    get_edit_entry,
+    revert_edit,
 )
 from db.relationships import get_related_records, add_relationship, remove_relationship
 from db.edit_fields import add_column_to_table, add_field_to_schema, drop_column_from_table, remove_field_from_schema
@@ -264,6 +266,17 @@ def delete_record_route(table, record_id):
     if not success:
         abort(500, 'Failed to delete record')
     return redirect(url_for('records.list_view', table=table))
+
+
+@records_bp.route('/<table>/<int:record_id>/undo/<int:edit_id>', methods=['POST'])
+def undo_edit_route(table, record_id, edit_id):
+    entry = get_edit_entry(edit_id)
+    if not entry or entry['table_name'] != table or entry['record_id'] != record_id:
+        abort(404)
+    success = revert_edit(entry)
+    if not success:
+        abort(500, 'Undo failed')
+    return jsonify({'success': True})
 
 @records_bp.route('/<table>/layout', methods=['POST'])
 def update_layout(table):


### PR DESCRIPTION
## Summary
- support fetching a single edit_history row
- add `revert_edit` helper to reverse edits
- expose `/undo/<edit_id>` route
- show an Undo button for each history line
- document edit history undo feature

## Testing
- `python -m py_compile db/records.py views/records.py`
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`
- `python - <<'PY'
from db.records import get_edit_history, get_edit_entry, revert_edit
history = get_edit_history('content', 1)
if history:
    entry = get_edit_entry(history[0]['id'])
    print('Fetched entry:', entry is not None)
    print('revertable?', revert_edit(entry))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6849b98933a08333879c61213626ccae