### PR TITLE
Add automatic placement for dashboard widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Field Schema Editing:** New endpoints allow adding or removing columns at runtime (`/<table>/<id>/add-field`, `/<table>/<id>/remove-field`) and counting non-null values (`/<table>/count-nonnull`).
 * **Admin Dashboard & Configuration:** The `/admin` section includes a configuration editor and placeholder pages for user management and automation.
 * **Layout Defaults from DB:** Field width and height defaults are loaded from the `config` table instead of being hardcoded.
+* **Automatic Dashboard Widget Placement:** New widgets are inserted at the next
+  available row in the grid without specifying `row_start`.
 * **CSV Import Workflow (Experimental):** The `/import` page lets you upload CSV files, match columns to fields, and validate data before import.
 
 ## Project Structure

--- a/db/dashboard.py
+++ b/db/dashboard.py
@@ -42,16 +42,30 @@ def get_dashboard_widgets() -> list[dict]:
             return []
 
 
+def get_next_row_start() -> int:
+    """Return the next available row_start value for a new widget."""
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT COALESCE(MAX(row_start + row_span), 0) FROM dashboard_widget"
+        )
+        result = cur.fetchone()
+        return int(result[0]) if result else 0
+
+
 def create_widget(
     title: str,
     content: str,
     widget_type: str,
     col_start: int,
     col_span: int,
-    row_start: int,
+    row_start: int | None,
     row_span: int,
 ) -> int | None:
     """Insert a new widget row and return its id."""
+    if row_start is None:
+        row_start = get_next_row_start()
+
     with get_connection() as conn:
         cur = conn.cursor()
         try:

--- a/views/admin.py
+++ b/views/admin.py
@@ -55,7 +55,6 @@ def dashboard_create_widget():
     try:
         col_start = int(data.get('col_start', 1))
         col_span = int(data.get('col_span', 1))
-        row_start = int(data.get('row_start', 1))
         row_span = int(data.get('row_span', 1))
     except (TypeError, ValueError):
         return jsonify({'error': 'Invalid layout values'}), 400
@@ -72,7 +71,7 @@ def dashboard_create_widget():
         widget_type,
         col_start,
         col_span,
-        row_start,
+        None,
         row_span,
     )
 


### PR DESCRIPTION
## Summary
- compute the next available `row_start` for dashboard widgets
- automatically populate `row_start` when creating a widget
- ignore client-provided `row_start` in `dashboard_create_widget`
- document automatic widget placement

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b99aadf883338df6a79597940564