### PR TITLE
Include Flowbite Charts

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,8 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
   <link rel="stylesheet" href="https://cdn.quilljs.com/1.3.7/quill.snow.css">
   <script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flowbite-charts/dist/flowbite-charts.min.js"></script>
   <title>{% block title %}Crossbook{% endblock %}</title>
 </head>
 <body class="bg-white text-gray-900">


### PR DESCRIPTION
## Summary
- add CDN links for Chart.js and Flowbite Charts after Quill scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849eaff27dc8333bece31969a1cdc08