### PR TITLE
Implement dashboard chart rendering

### DIFF
--- a/static/js/dashboard_charts.js
+++ b/static/js/dashboard_charts.js
@@ -1,0 +1,51 @@
+// Dashboard chart rendering
+
+document.addEventListener('DOMContentLoaded', () => {
+  const chartWidgets = document.querySelectorAll('[data-type="chart"]');
+  chartWidgets.forEach(async widget => {
+    const cfgText = widget.dataset.config;
+    if (!cfgText) return;
+    let cfg;
+    try {
+      cfg = JSON.parse(cfgText);
+    } catch (err) {
+      console.error('[dashboard_charts] Invalid config', err);
+      return;
+    }
+    const { chart_type: type = 'bar', x_field, y_field, aggregation } = cfg;
+    if (!x_field || !y_field || !aggregation) return;
+
+    const fetchVal = spec => {
+      const [table, field] = spec.split(':');
+      const endpoint = aggregation === 'sum' ? 'sum-field' : 'count-nonnull';
+      const key = aggregation === 'sum' ? 'sum' : 'count';
+      return fetch(`/${table}/${endpoint}?field=${encodeURIComponent(field)}`)
+        .then(r => r.json())
+        .then(d => d[key] || 0)
+        .catch(() => 0);
+    };
+
+    const values = await Promise.all([fetchVal(x_field), fetchVal(y_field)]);
+    const labels = [x_field.split(':')[1], y_field.split(':')[1]];
+
+    const canvas = widget.querySelector('canvas') || document.createElement('canvas');
+    if (!canvas.parentElement) widget.appendChild(canvas);
+
+    new Chart(canvas, {
+      type: type,
+      data: {
+        labels: labels,
+        datasets: [{
+          label: aggregation === 'count' ? 'Count' : 'Sum',
+          data: values,
+          backgroundColor: ['#3b82f6', '#d946ef']
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } }
+      }
+    });
+  });
+});

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -32,10 +32,14 @@
     <div class="dashboard-widget draggable-field border p-2 rounded shadow bg-gray-50"
          data-widget="{{ widget.id }}"
          data-type="{{ widget.widget_type }}"
+         {% if widget.widget_type == 'chart' %}data-config='{{ widget.content }}'{% endif %}
          style="grid-column: {{ col_start }} / span {{ col_span }}; grid-row: {{ row_start }} / span {{ row_span }};">
       {% if widget.widget_type == 'value' %}
         <div class="font-semibold">{{ widget.title }}</div>
         <div>{{ widget.content }}</div>
+      {% elif widget.widget_type == 'chart' %}
+        <div class="font-semibold mb-2">{{ widget.title }}</div>
+        <canvas></canvas>
       {% else %}
         <div class="text-gray-500">{{ widget.widget_type }} widget</div>
       {% endif %}
@@ -57,4 +61,5 @@
 <script>window.WIDGET_LAYOUT = {{ widget_layout | tojson }};</script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_modal.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_grid.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/dashboard_charts.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- display chart widgets on dashboard
- load Chart.js module to render data

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849f6bbfc708333ac5bf1671c863a24