### PR TITLE
Add acknowledgements for Flowbite

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,3 +404,7 @@ By using this macro in `detail_view.html`, the template stays cleaner and any ch
 This software is provided for evaluation and internal use only.
 Modification, redistribution, or commercial deployment is prohibited without written permission.
 
+
+## Acknowledgements
+
+This project uses [Flowbite](https://github.com/themesberg/flowbite) and Flowbite Charts under the MIT License.


### PR DESCRIPTION
## Summary
- add an *Acknowledgements* section at the end of the README
- credit Flowbite and Flowbite Charts as MIT licensed dependencies with a link to the Flowbite repo

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849fef10054833383ab3466f2da32c2