### PR TITLE
Increase default chart widget height

### DIFF
--- a/static/js/dashboard_grid.js
+++ b/static/js/dashboard_grid.js
@@ -7,7 +7,7 @@ const defaultWidgetWidth = {
 const defaultWidgetHeight = {
   value: 3,
   table: 8,
-  chart: 8
+  chart: 12
 };
 
 const widgetLayout = window.WIDGET_LAYOUT || {};

--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -291,7 +291,7 @@ function onCreateWidget(event) {
       col_start: 1,
       col_span: 10,
       row_start: 1,
-      row_span: 8
+      row_span: 12
     };
     fetch('/dashboard/widget', {
       method: 'POST',

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -16,7 +16,7 @@
      class="relative w-full grid"
      style="grid-template-columns: repeat(20, 1fr); grid-auto-rows: 1em;">
   {% set default_width = { 'value': 4, 'table': 10, 'chart': 10 } %}
-  {% set default_height = { 'value': 3, 'table': 8,  'chart': 8 } %}
+  {% set default_height = { 'value': 3, 'table': 8,  'chart': 12 } %}
   {% set widget_layout = {} %}
   {% for widget in widgets %}
     {% set col_start = widget.col_start or 1 %}


### PR DESCRIPTION
## Summary
- increase default chart widget height in template and scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a7495d75c8333aa4a9a046616a841