### PR TITLE
Add colorful line and bar charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Layout Defaults from DB:** Field width and height defaults are loaded from the `config` table instead of being hardcoded.
 * **Automatic Dashboard Widget Placement:** New widgets are inserted at the next
   available row in the grid without specifying `row_start`.
+* **Dashboard Charts:** Pie, bar and line chart widgets leverage Flowbite Charts
+  and auto-generate counts from a single field.
 * **CSV Import Workflow (Experimental):** The `/import` page lets you upload CSV files, match columns to fields, and validate data before import.
 
 ## Project Structure

--- a/static/js/dashboard_charts.js
+++ b/static/js/dashboard_charts.js
@@ -1,6 +1,15 @@
 // Dashboard chart rendering
 
 document.addEventListener('DOMContentLoaded', () => {
+  const FLOWBITE_COLORS = [
+    '#2563eb', // blue-600
+    '#db2777', // pink-600
+    '#059669', // emerald-600
+    '#f59e0b', // amber-500
+    '#8b5cf6', // violet-500
+    '#ef4444'  // red-500
+  ];
+
   const chartWidgets = document.querySelectorAll('[data-type="chart"]');
   chartWidgets.forEach(async widget => {
     const cfgText = widget.dataset.config;
@@ -44,13 +53,32 @@ document.addEventListener('DOMContentLoaded', () => {
         const data = await res.json();
         const labels = Object.keys(data);
         const values = Object.values(data);
+        const colors = labels.map((_, i) => FLOWBITE_COLORS[i % FLOWBITE_COLORS.length]);
         new Chart(canvas, {
           type: 'bar',
-          data: { labels, datasets: [{ data: values, backgroundColor: '#3b82f6' }] },
+          data: { labels, datasets: [{ data: values, backgroundColor: colors }] },
           options: { responsive: true, maintainAspectRatio: false, indexAxis: orientation === 'y' ? 'y' : 'x', plugins: { legend: { display: false } } }
         });
       } catch (err) {
         console.error('[dashboard_charts] bar data fetch error', err);
+      }
+      return;
+    }
+
+    if (type === 'line' && field) {
+      const [table, fld] = field.split(':');
+      try {
+        const res = await fetch(`/${table}/field-distribution?field=${encodeURIComponent(fld)}`);
+        const data = await res.json();
+        const labels = Object.keys(data);
+        const values = Object.values(data);
+        new Chart(canvas, {
+          type: 'line',
+          data: { labels, datasets: [{ data: values, borderColor: FLOWBITE_COLORS[0], backgroundColor: 'rgba(37,99,235,0.2)', fill: false }] },
+          options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } } }
+        });
+      } catch (err) {
+        console.error('[dashboard_charts] line data fetch error', err);
       }
       return;
     }

--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -138,6 +138,15 @@ function updateChartUI() {
       }
     });
     chartOrientContainer.classList.remove('hidden');
+  } else if (type === 'line') {
+    chartXFieldLabel.textContent = 'Field';
+    populateFieldDropdown(chartXOptions, false, null, val => {
+      chartXField = val;
+      if (chartXLabel) {
+        const [t,f] = val.split(':');
+        chartXLabel.textContent = `${t}: ${f}`;
+      }
+    });
   } else {
     chartXFieldLabel.textContent = 'X Field';
     populateFieldDropdown(chartXOptions, false, null, val => {
@@ -292,6 +301,12 @@ function onCreateWidget(event) {
         chart_type: chartType,
         field: chartXField,
         orientation: chartOrient
+      };
+    } else if (chartType === 'line') {
+      if (!chartXField) return;
+      payloadContent = {
+        chart_type: chartType,
+        field: chartXField
       };
     } else {
       if (!chartXField || !chartYField) return;


### PR DESCRIPTION
## Summary
- style dashboard charts with Flowbite colors
- allow single-field line charts like bar chart widgets
- expose chart creation form controls for line charts
- document new chart capabilities

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a81270dc48333933b78565d612995