### PR TITLE
Improve number filter labeling

### DIFF
--- a/templates/macros/filter_controls.html
+++ b/templates/macros/filter_controls.html
@@ -86,7 +86,10 @@
 {% endmacro %}
 
 {%- macro number_filter(field, min_val, max_val) -%}
-  <div class="filter-chip flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1 border border-gray-300">
+  <div class="filter-chip flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1 border border-gray-400">
+    <span class="text-xs border border-gray-400 rounded px-1 mr-1">
+      {{ field | replace('_',' ') | capitalize }}
+    </span>
     <input
       type="number"
       name="{{ field }}_min"


### PR DESCRIPTION
## Summary
- display field name on numeric filters
- add visible border around number filter containers

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a87d0494483339bd509705d0daca3