### PR TITLE
Unify label and value autosizing

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -166,7 +166,7 @@ input[type=number] {
 
 .autosize-text {
   width: 100%;
-  height: calc(100% - 1.5em); /* leave room for field label */
+  height: 100%; /* label is inside the element */
   display: flex;
   align-items: center;
   justify-content: center;

--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -35,7 +35,7 @@ export function fitText(el) {
 }
 
 function makeEditable(displayEl) {
-  const value = displayEl.textContent.trim();
+  const value = displayEl.dataset.rawValue || displayEl.textContent.trim();
   const form = document.createElement('form');
   form.method = 'POST';
   form.action = displayEl.dataset.updateUrl;
@@ -66,7 +66,9 @@ function makeEditable(displayEl) {
     newDiv.dataset.field = displayEl.dataset.field;
     newDiv.dataset.recordId = displayEl.dataset.recordId;
     newDiv.dataset.updateUrl = displayEl.dataset.updateUrl;
-    newDiv.textContent = input.value;
+    newDiv.dataset.label = displayEl.dataset.label;
+    newDiv.dataset.rawValue = input.value;
+    newDiv.innerHTML = `<b>${displayEl.dataset.label}:</b> ${input.value}`;
     form.replaceWith(newDiv);
     attach(newDiv);
   };

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -60,7 +60,9 @@
                  grid-column: {{ col_start }} / span {{ col_span }};
                  grid-row:    {{ row_start }} / span {{ row_span }};
                ">
+            {% if field_schema[table][field].type != 'text' %}
             <div class="text-sm font-bold capitalize mb-1">{{ field }}</div>
+            {% endif %}
             <div>
               {{ fields.render_editable_field(
                    field, value, record.id, request,

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -130,7 +130,14 @@
           <span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>
         </form>
         {% elif field_type == "text" %}
-        <div class="autosize-text" data-field="{{ field }}" data-record-id="{{ record_id }}" data-update-url="{{ url_for(update_endpoint, table=table, record_id=record_id) }}">{{ value }}</div>
+        <div class="autosize-text"
+             data-field="{{ field }}"
+             data-record-id="{{ record_id }}"
+             data-update-url="{{ url_for(update_endpoint, table=table, record_id=record_id) }}"
+             data-raw-value="{{ value }}"
+             data-label="{{ field|capitalize }}">
+          <b>{{ field|capitalize }}:</b> {{ value }}
+        </div>
       {% else %}
         <span class="ml-1">{{ value }}</span>
       {% endif %}


### PR DESCRIPTION
## Summary
- embed the field label inside autosized text blocks
- remove extra space in autosize CSS because the label is inside
- allow editing logic to read/write the label and value separately
- skip displaying a separate label for text fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a86ed3b3c8333aa4a0c3bb43185ab