### PR TITLE
Use config value for homepage heading

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from db.schema import (
     load_base_tables,
     load_card_info,
 )
+from db.config import get_all_config
 from utils.flask_helpers import start_timer, log_request, log_exception
 
 app = Flask(__name__, static_url_path='/static')
@@ -42,7 +43,12 @@ def inject_field_schema():
 
 @app.route("/")
 def home():
-    return render_template("index.html", cards=current_app.config['CARD_INFO'])
+    heading = get_all_config().get('heading', 'Load the Glass Cannon')
+    return render_template(
+        "index.html",
+        cards=current_app.config['CARD_INFO'],
+        heading=heading,
+    )
 
 if __name__ == "__main__":
     update_foreign_field_options()

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<h1 class="text-4xl font-bold text-center mb-10">Load the Glass Cannon</h1>
+<h1 class="text-4xl font-bold text-center mb-10">{{ heading }}</h1>
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
   <a href="/dashboard" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
     <h2 class="text-2xl font-bold mb-2">Dashboard</h2>


### PR DESCRIPTION
## Summary
- fetch configuration from DB in `home()`
- show the configured `heading` on the index page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a8999ecc48333b4bc16ad006a3cd1