### PR TITLE
Add checkbox multi-select filter

### DIFF
--- a/db/records.py
+++ b/db/records.py
@@ -48,6 +48,11 @@ def _build_filters(table, search=None, filters=None, ops=None):
                 date_ends[base] = clean_values[0]
             else:
                 op = (ops or {}).get(fld, "contains")
+                if op == "equals" and len(clean_values) > 1:
+                    clause = "(" + " OR ".join([f"{fld} = ?" for _ in clean_values]) + ")"
+                    clauses.append(clause)
+                    params.extend(clean_values)
+                    continue
                 field_clauses = []
                 for v in clean_values:
                     if op == "equals":

--- a/static/js/filter_visibility.js
+++ b/static/js/filter_visibility.js
@@ -211,3 +211,29 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // call it after your other binds
   bindMultiSelectPopovers();
+
+  function updateSelectMulti(field, values) {
+    const params = new URLSearchParams(window.location.search);
+    params.delete(field);
+    params.delete(field + "_op");
+    values.forEach(v => params.append(field, v));
+    if (values.length) params.set(field + "_op", "equals");
+    window.location.search = params.toString();
+  }
+
+  function bindSelectMulti() {
+    document.querySelectorAll(".select-multi-filter").forEach(div => {
+      const field = div.dataset.field;
+      const boxes = div.querySelectorAll(".select-multi-option");
+      boxes.forEach(cb =>
+        cb.addEventListener("change", () => {
+          const selected = Array.from(boxes)
+            .filter(b => b.checked)
+            .map(b => b.value);
+          updateSelectMulti(field, selected);
+        })
+      );
+    });
+  }
+
+  bindSelectMulti();

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -27,6 +27,7 @@
   
     {# Right side: Active filters + Reset #}
     <div class="flex items-center space-x-4">
+      {% set use_checkbox_filters = request.args.get('filter_style') == 'list' %}
       <div id="filter-container" class="ml-4 flex flex-wrap gap-x-4 gap-y-2 max-h-16">
         {% for field in fields if request.args.get(field) is not none %}
           {% set meta = field_schema[table][field] %}
@@ -35,7 +36,11 @@
           {% elif meta.type in ['multi_select','foreign_key'] %}
             {{ filters.multi_select_popover(field, request.args.getlist(field), meta.options) }}
           {% elif meta.type == 'select' %}
-            {{ filters.select_filter(field, request.args.get(field,''), meta.options) }}
+            {% if use_checkbox_filters %}
+              {{ filters.select_multi_filter(field, request.args.getlist(field), meta.options) }}
+            {% else %}
+              {{ filters.select_filter(field, request.args.get(field,''), meta.options) }}
+            {% endif %}
           {% elif meta.type == 'number' %}
             {{ filters.number_filter(field, request.args.get(field + '_min',''), request.args.get(field + '_max','')) }}
           {% elif meta.type == 'date' %}

--- a/templates/macros/filter_controls.html
+++ b/templates/macros/filter_controls.html
@@ -70,6 +70,22 @@
 </div>
 {%- endmacro -%}
 
+{%- macro select_multi_filter(field, selected, options) -%}
+  {% set actual = selected | reject('equalto', '') | list %}
+  <div class="filter-chip select-multi-filter flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1 border border-gray-300" data-field="{{ field }}">
+    <span class="text-xs border border-gray-400 rounded px-1 mr-1">{{ field | replace('_',' ') | capitalize }}</span>
+    <div class="flex flex-col max-h-32 overflow-y-auto">
+      {% for opt in options %}
+        <label class="flex items-center space-x-1">
+          <input type="checkbox" class="select-multi-option" value="{{ opt }}" {% if opt in actual %}checked{% endif %}>
+          <span class="text-sm">{{ opt }}</span>
+        </label>
+      {% endfor %}
+    </div>
+    <input type="hidden" name="{{ field }}_op" value="equals" />
+  </div>
+{%- endmacro -%}
+
 {% macro boolean_filter(field, value) %}
   <div class="filter-chip flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1 border border-gray-300">
     <select


### PR DESCRIPTION
## Summary
- create `select_multi_filter` for multiple select values
- optionally render the filter with checkboxes when `filter_style=list`
- build SQL OR clauses for multiple equals values
- support new filter type in `filter_visibility.js`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a8aecf6408333a7c874f75a85f1c7