### PR TITLE
Limit line chart fields

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -140,7 +140,8 @@ function updateChartUI() {
     chartOrientContainer.classList.remove('hidden');
   } else if (type === 'line') {
     chartXFieldLabel.textContent = 'Field';
-    populateFieldDropdown(chartXOptions, false, null, val => {
+    // Line charts only support sequential numeric or date fields
+    populateFieldDropdown(chartXOptions, false, ['number', 'date'], val => {
       chartXField = val;
       if (chartXLabel) {
         const [t,f] = val.split(':');


### PR DESCRIPTION
## Summary
- restrict line chart x-axis fields to numbers or dates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a8cd92f4c8333a50c8416895e725c