### PR TITLE
Fix autosize cap

### DIFF
--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -27,8 +27,8 @@ export function fitText(el) {
   const height = el.clientHeight;
   if (!width || !height) return;
 
-  const sizeByWidth = (width * 0.9 / metrics.width) * 10;
-  const sizeByHeight = height * 0.9; // because metrics were for 10px height
+  const sizeByWidth = (width / metrics.width) * 10;
+  const sizeByHeight = height; // metrics based on 10px font
   let newSize = Math.floor(Math.min(sizeByWidth, sizeByHeight));
   if (newSize < 4) newSize = 4;
   el.style.fontSize = `${newSize}px`;


### PR DESCRIPTION
## Summary
- allow autosize text to use full available space instead of capping at 90%

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a8a6ed8d48333a559fc4890e731a6