### PR TITLE
Fix multi-select popover closing on mode change

### DIFF
--- a/static/js/filter_visibility.js
+++ b/static/js/filter_visibility.js
@@ -193,6 +193,9 @@ document.addEventListener("DOMContentLoaded", () => {
         pop.classList.toggle("hidden");
       });
 
+      // prevent closing when interacting within the popover
+      pop.addEventListener("click", e => e.stopPropagation());
+
       const modeSel = pop.querySelector(".multi-select-mode");
 
       function handleChange() {


### PR DESCRIPTION
## Summary
- prevent clicks inside multi-select filter popovers from closing them

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a8e0fa9508333b29b7deb447dd0e6