### PR TITLE
Remove layout edit check in fitText

### DIFF
--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -1,10 +1,6 @@
 let measureCanvas;
 
 export function fitText(el) {
-  // Skip resizing when layout grid is currently being edited
-  if (document.querySelector('#layout-grid.editing')) {
-    return;
-  }
 
   if (!measureCanvas) {
     measureCanvas = document.createElement('canvas');


### PR DESCRIPTION
## Summary
- allow text autosizing during layout edit mode by removing editing check

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8e4e14f08333a11c1d1549c79145