### PR TITLE
Fix autosize-text height

### DIFF
--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -7,7 +7,7 @@
   </form>
 {%- endmacro %}
 {% macro render_editable_field(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
-  <div class="mt-2">
+  <div class="mt-2 h-full">
     {% if field_type == "textarea" %}
     <form method="POST"
           action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}"


### PR DESCRIPTION
## Summary
- make editable field wrapper inherit cell height
- confirm autosize text styling stays at height 100%

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a8ff687e8833396bb4587942647ef