### PR TITLE
Fix multi-select filter mode persistence

### DIFF
--- a/static/js/column_visibility.js
+++ b/static/js/column_visibility.js
@@ -11,7 +11,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     document.querySelectorAll("thead th").forEach((th) => {
       if (th.dataset.static !== undefined) return;
-      const field = th.textContent.trim().toLowerCase();
+      const field = th.textContent.trim();
       th.style.display = visible.has(field) ? "" : "none";
     });
 

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -67,7 +67,7 @@
     <div id="column-dropdown" class="absolute z-10 mt-2 bg-white border rounded shadow hidden p-2 space-y-1 w-48">
       {% for field in fields if not field.startswith('_') %}
         <label class="flex items-center space-x-2">
-          <input type="checkbox" class="column-toggle" value="{{ field|lower }}" checked>
+          <input type="checkbox" class="column-toggle" value="{{ field }}" checked>
           <span class="text-sm">{{ field }}</span>
         </label>
       {% endfor %}
@@ -98,7 +98,7 @@
         {% for record in records %}
         <tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location.href='/{{ table }}/{{ record.id }}'">
           {% for field in fields if not field.startswith('_') %}
-            <td class="px-4 py-2 whitespace-nowrap" data-field="{{ field|lower }}">
+            <td class="px-4 py-2 whitespace-nowrap" data-field="{{ field }}">
               {% if field_schema[table][field].type == "textarea" %}
                 {{ record[field]|striptags|truncate(100) }}
               {% else %}


### PR DESCRIPTION
## Summary
- ensure column dropdown and table cells keep original field names
- update column visibility script to use original case when matching fields

## Testing
- `python3 -m py_compile static/js/column_visibility.js` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_684a8ee40fc08333b10ab3a9e07c44ce