### PR TITLE
Filter text fields from bar chart dropdown

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -41,6 +41,14 @@ function isNumericField(val) {
   );
 }
 
+function getNonTextTypes() {
+  const types = new Set();
+  Object.values(FIELD_SCHEMA).forEach(tbl => {
+    Object.values(tbl).forEach(meta => types.add(meta.type));
+  });
+  return Array.from(types).filter(t => t !== 'text' && t !== 'textarea');
+}
+
 function toggleDisabled(label, input, disabled) {
   if (!label || !input) return;
   input.disabled = disabled;
@@ -130,7 +138,7 @@ function updateChartUI() {
     });
   } else if (type === 'bar') {
     chartXFieldLabel.textContent = 'Field';
-    populateFieldDropdown(chartXOptions, false, null, val => {
+    populateFieldDropdown(chartXOptions, false, getNonTextTypes(), val => {
       chartXField = val;
       if (chartXLabel) {
         const [t,f] = val.split(':');


### PR DESCRIPTION
## Summary
- prevent text and textarea fields from appearing in the bar chart field selector by using allowedTypes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684a8fb686348333baf02254e35ebe12