### PR TITLE
Fix autosize-text height

### DIFF
--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -7,11 +7,17 @@ export function fitText(el) {
   }
   const ctx = measureCanvas.getContext('2d');
 
+  console.groupCollapsed('[autosize_text] fitText', el.dataset.field || el.textContent.trim());
+
   // Reset any previous inline size
   el.style.fontSize = '';
 
   const text = el.textContent.trim();
-  if (!text) return;
+  if (!text) {
+    console.warn('[autosize_text] empty text');
+    console.groupEnd();
+    return;
+  }
 
   const style = window.getComputedStyle(el);
   const fontFamily = style.fontFamily || 'sans-serif';
@@ -21,13 +27,20 @@ export function fitText(el) {
 
   const width = el.clientWidth;
   const height = el.clientHeight;
-  if (!width || !height) return;
+  if (!width || !height) {
+    console.warn('[autosize_text] zero size', width, height);
+    console.groupEnd();
+    return;
+  }
 
   const sizeByWidth = (width * 0.9 / metrics.width) * 10;
   const sizeByHeight = height * 0.9; // because metrics were for 10px height
   let newSize = Math.floor(Math.min(sizeByWidth, sizeByHeight));
   if (newSize < 4) newSize = 4;
+  console.debug('[autosize_text] metrics.width=', metrics.width, 'sizeByWidth=', sizeByWidth, 'sizeByHeight=', sizeByHeight, 'newSize=', newSize);
   el.style.fontSize = `${newSize}px`;
+  console.debug('[autosize_text] applied fontSize', el.style.fontSize);
+  console.groupEnd();
 }
 
 function makeEditable(displayEl) {

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -7,7 +7,7 @@
   </form>
 {%- endmacro %}
 {% macro render_editable_field(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
-  <div class="mt-2">
+  <div class="mt-2 h-full">
     {% if field_type == "textarea" %}
     <form method="POST"
           action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}"


### PR DESCRIPTION
## Summary
- make editable field wrapper inherit cell height
- add debug logging inside `fitText` to diagnose autosize issues
- confirm autosize text styling stays at height 100%

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684a8ff687e8833396bb4587942647ef