### PR TITLE
Add not_contains and regex filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Navigation Bar:** A consistent top navigation (`base.html`) links to Home and all base table sections.
 * **Supported Field Types:** text, number, date, select, multi-select, foreign-key, boolean, and textarea, each rendered with the appropriate input control.
 * **Filter Macros:** Reusable Jinja macros for boolean, select, text, and multi-select filters (`templates/macros/filter_controls.html`).
+* **Text Filter Operators:** `contains`, `equals`, `starts_with`, `ends_with`, `not_contains`, and `regex` operators are available when filtering text fields. Regex matching requires database support and falls back to a normal `LIKE` search if unavailable.
 * **Field Schema Editing:** New endpoints allow adding or removing columns at runtime (`/<table>/<id>/add-field`, `/<table>/<id>/remove-field`) and counting non-null values (`/<table>/count-nonnull`).
 * **Admin Dashboard & Configuration:** The `/admin` section includes a configuration editor and placeholder pages for user management and automation.
 * **Layout Defaults from DB:** Field width and height defaults are loaded from the `config` table instead of being hardcoded.

--- a/db/database.py
+++ b/db/database.py
@@ -1,5 +1,15 @@
 import sqlite3
+import re
 from contextlib import contextmanager
+
+try:
+    _test = sqlite3.connect(":memory:")
+    _test.create_function("REGEXP", 2, lambda p, v: 1)
+    _test.execute("SELECT 'a' REGEXP 'a'")
+    _test.close()
+    SUPPORTS_REGEX = True
+except Exception:
+    SUPPORTS_REGEX = False
 
 DB_PATH = "data/crossbook.db"
 
@@ -8,6 +18,15 @@ DB_PATH = "data/crossbook.db"
 def get_connection():
     """Yield a SQLite connection that is automatically closed."""
     conn = sqlite3.connect(DB_PATH)
+    if SUPPORTS_REGEX:
+        try:
+            conn.create_function(
+                "REGEXP",
+                2,
+                lambda pattern, value: 1 if value is not None and re.search(pattern, str(value)) else 0,
+            )
+        except Exception:
+            pass
     try:
         yield conn
     finally:

--- a/db/records.py
+++ b/db/records.py
@@ -2,7 +2,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 import datetime
-from db.database import get_connection
+from db.database import get_connection, SUPPORTS_REGEX
 from db.schema import get_field_schema
 from db.validation import validate_table, validate_fields, validate_field
 
@@ -60,6 +60,16 @@ def _build_filters(table, search=None, filters=None, ops=None, modes=None):
                     elif op == "ends_with":
                         field_clauses.append(f"{fld} LIKE ?")
                         params.append(f"%{v}")
+                    elif op == "not_contains":
+                        field_clauses.append(f"{fld} NOT LIKE ?")
+                        params.append(f"%{v}%")
+                    elif op == "regex":
+                        if SUPPORTS_REGEX:
+                            field_clauses.append(f"{fld} REGEXP ?")
+                            params.append(v)
+                        else:
+                            field_clauses.append(f"{fld} LIKE ?")
+                            params.append(f"%{v}%")
                     else:  # contains
                         field_clauses.append(f"{fld} LIKE ?")
                         params.append(f"%{v}%")

--- a/templates/macros/filter_controls.html
+++ b/templates/macros/filter_controls.html
@@ -11,6 +11,8 @@
       <option value="equals"      {% if operator=='equals'      %}selected{% endif %}>=</option>
       <option value="starts_with" {% if operator=='starts_with' %}selected{% endif %}>__*</option>
       <option value="ends_with"   {% if operator=='ends_with'   %}selected{% endif %}>*__</option>
+      <option value="not_contains" {% if operator=='not_contains' %}selected{% endif %}>!*</option>
+      <option value="regex"       {% if operator=='regex'       %}selected{% endif %}>/~</option>
     </select>
     <input
       type="text"


### PR DESCRIPTION
## Summary
- support `not_contains` and `regex` operators in text filter dropdown
- register an SQLite `REGEXP` function for regex filtering
- update `_build_filters` with NOT LIKE and REGEXP logic
- document all text filter operators in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ac24c2e6483338a915ce1ff5a0419