### PR TITLE
Expose text filter operator labels

### DIFF
--- a/static/js/filter_visibility.js
+++ b/static/js/filter_visibility.js
@@ -112,12 +112,17 @@ document.addEventListener("DOMContentLoaded", () => {
   }
   
     // Handle operator dropdown changes
+    function setOperatorTitle(sel) {
+      const opt = sel.options[sel.selectedIndex];
+      if (opt && opt.title) sel.title = opt.title;
+    }
+
     function onOperatorChange(e) {
       const sel = e.target;
       const params = new URLSearchParams(window.location.search);
       const field = sel.name.replace(/_op$/, '');
       const val   = params.get(field) || "";
-  
+
       params.set(sel.name, sel.value);
       params.set(field, val);
       window.location.search = params.toString();
@@ -126,7 +131,13 @@ document.addEventListener("DOMContentLoaded", () => {
     // Bind operator change listeners
     function bindOperatorListeners() {
       const ops = document.querySelectorAll("#filter-container select.operator-select");
-      ops.forEach(sel => sel.addEventListener("change", onOperatorChange));
+      ops.forEach(sel => {
+        setOperatorTitle(sel);
+        sel.addEventListener("change", e => {
+          setOperatorTitle(sel);
+          onOperatorChange(e);
+        });
+      });
     }
     // Bind change handlers for non-operator selects (i.e. our select filters)
     document.querySelectorAll("#filter-container select:not(.operator-select)")

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -28,7 +28,7 @@
     {# Right side: Active filters + Reset #}
     <div class="flex items-center space-x-4">
       {% set use_checkbox_filters = request.args.get('filter_style') == 'list' %}
-      <div id="filter-container" class="ml-4 flex flex-wrap gap-x-4 gap-y-2 max-h-16">
+      <div id="filter-container" class="ml-4 flex flex-wrap gap-x-4 gap-y-2">
         {% for field in fields if request.args.get(field) is not none %}
           {% set meta = field_schema[table][field] %}
           {% if meta.type == 'boolean' %}

--- a/templates/macros/filter_controls.html
+++ b/templates/macros/filter_controls.html
@@ -7,12 +7,12 @@
       class="operator-select appearance-none text-xs rounded-full border-0 bg-transparent text-center w-6"
       title="Operator"
     >
-      <option value="contains"    {% if operator=='contains'    %}selected{% endif %}>*</option>
-      <option value="equals"      {% if operator=='equals'      %}selected{% endif %}>=</option>
-      <option value="starts_with" {% if operator=='starts_with' %}selected{% endif %}>__*</option>
-      <option value="ends_with"   {% if operator=='ends_with'   %}selected{% endif %}>*__</option>
-      <option value="not_contains" {% if operator=='not_contains' %}selected{% endif %}>!*</option>
-      <option value="regex"       {% if operator=='regex'       %}selected{% endif %}>/~</option>
+      <option value="contains"    title="Contains"      {% if operator=='contains'    %}selected{% endif %}>*</option>
+      <option value="equals"      title="Equals"        {% if operator=='equals'      %}selected{% endif %}>=</option>
+      <option value="starts_with" title="Starts with"   {% if operator=='starts_with' %}selected{% endif %}>__*</option>
+      <option value="ends_with"   title="Ends with"     {% if operator=='ends_with'   %}selected{% endif %}>*__</option>
+      <option value="not_contains" title="Does not contain" {% if operator=='not_contains' %}selected{% endif %}>!*</option>
+      <option value="regex"       title="Regex"         {% if operator=='regex'       %}selected{% endif %}>/~</option>
     </select>
     <input
       type="text"


### PR DESCRIPTION
## Summary
- add titles for text filter operators so users see what each symbol means
- surface operator titles in JS so dropdown shows tooltip
- remove max height limit on filter container so chips stay visible

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684ac45af6e08333a5b2f790bb3400a0