### PR TITLE
Add styling support when adding fields

### DIFF
--- a/db/edit_fields.py
+++ b/db/edit_fields.py
@@ -24,13 +24,22 @@ DEFAULT_FIELD_HEIGHT = {
 }
 
 
-def add_field_to_schema(table, field_name, field_type, field_options=None, foreign_key=None, layout=None):
+def add_field_to_schema(
+    table,
+    field_name,
+    field_type,
+    field_options=None,
+    foreign_key=None,
+    layout=None,
+    styling=None,
+):
     """Insert a new field into the field_schema table."""
     with get_connection() as conn:
         cur = conn.cursor()
 
         # 1) Serialize the list of options (if any) to JSON text
         options_str = json.dumps(field_options or [])
+        styling_str = json.dumps(styling) if styling else None
 
         # 2) Compute the new field's row_start by finding the current bottom edge
         cur.execute(
@@ -49,13 +58,13 @@ def add_field_to_schema(table, field_name, field_type, field_options=None, forei
         row_start = max_bottom
         row_span = height_map.get(field_type, 4)
 
-        # 4) Insert into field_schema with the nine real columns
+        # 4) Insert into field_schema including the styling column
         cur.execute(
             """
             INSERT INTO field_schema
               (table_name, field_name, field_type, field_options, foreign_key,
-               col_start, col_span, row_start, row_span)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+               col_start, col_span, row_start, row_span, styling)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 table,
@@ -67,6 +76,7 @@ def add_field_to_schema(table, field_name, field_type, field_options=None, forei
                 col_span,
                 row_start,
                 row_span,
+                styling_str,
             ),
         )
         conn.commit()

--- a/views/records.py
+++ b/views/records.py
@@ -1,3 +1,4 @@
+import json
 from flask import Blueprint, render_template, abort, request, redirect, url_for, jsonify, current_app
 from db.database import get_connection
 from db.validation import validate_table
@@ -143,7 +144,9 @@ def add_field_route(table, record_id):
         field_type = request.form['field_type']
         field_options_raw = request.form.get('field_options', '')
         foreign_key = request.form.get('foreign_key_target', None)
+        styling_raw = request.form.get('styling')
         field_options = [opt.strip() for opt in field_options_raw.split(',') if opt.strip()] if field_options_raw else []
+        styling = json.loads(styling_raw) if styling_raw else None
         add_column_to_table(table, field_name, field_type)
         current_app.logger.info('Returned from add_column_to_table for field %s', field_name)
         add_field_to_schema(
@@ -151,7 +154,8 @@ def add_field_route(table, record_id):
             field_name=field_name,
             field_type=field_type,
             field_options=field_options,
-            foreign_key=foreign_key
+            foreign_key=foreign_key,
+            styling=styling,
         )
         current_app.logger.info('Added column to %s: field=%r type=%r', table, field_name, field_type)
         return redirect(url_for('records.detail_view', table=table, record_id=record_id))


### PR DESCRIPTION
## Summary
- extend `add_field_to_schema` to accept optional styling info
- include styling column when inserting new rows
- pass styling from `add_field_route`

## Testing
- `python -m py_compile db/edit_fields.py views/records.py`

------
https://chatgpt.com/codex/tasks/task_e_684ad415be608333886254c88680d99d