### PR TITLE
Add table widget feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Automatic Dashboard Widget Placement:** New widgets are inserted at the next
   available row in the grid without specifying `row_start`.
 * **Dashboard Charts:** Pie, bar and line chart widgets leverage Flowbite Charts and auto-generate counts from a single field.
+* **Table Widget:** Displays simple tabular data such as base table record counts.
 * **Dashboard Grid Editing:** Widgets can be dragged, resized, and saved using `/dashboard/layout`.
 * **Numerical Summaries:** `/<table>/sum-field` returns the sum for numeric columns, used by dashboard charts.
 * **List API:** `/api/<table>/list` provides ID and label data for dropdowns.

--- a/db/dashboard.py
+++ b/db/dashboard.py
@@ -1,8 +1,10 @@
 import logging
 
+from flask import current_app
 from db.database import get_connection
 from db.schema import get_field_schema
 from db.validation import validate_table
+from db.records import count_records
 
 logger = logging.getLogger(__name__)
 
@@ -128,3 +130,17 @@ def update_widget_layout(layout_items: list[dict]) -> int:
         conn.commit()
 
     return updated
+
+
+def get_base_table_counts() -> list[dict]:
+    """Return record counts for each base table."""
+    base_tables = current_app.config.get("BASE_TABLES", [])
+    results: list[dict] = []
+    for table in base_tables:
+        try:
+            cnt = count_records(table)
+        except Exception as exc:
+            logger.warning("[get_base_table_counts] error for %s: %s", table, exc)
+            cnt = 0
+        results.append({"table": table, "count": cnt})
+    return results

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -42,6 +42,18 @@
       {% elif widget.widget_type == 'chart' %}
         <div class="font-semibold mb-2">{{ widget.title }}</div>
         <canvas></canvas>
+      {% elif widget.widget_type == 'table' %}
+        <div class="font-semibold mb-2">{{ widget.title }}</div>
+        <table class="min-w-full text-sm">
+          <thead>
+            <tr><th class="px-2 py-1 text-left">Table</th><th class="px-2 py-1 text-left">Count</th></tr>
+          </thead>
+          <tbody>
+          {% for row in widget.parsed.data if widget.parsed %}
+            <tr><td class="px-2 py-1">{{ row.table }}</td><td class="px-2 py-1">{{ row.count }}</td></tr>
+          {% endfor %}
+          </tbody>
+        </table>
       {% else %}
         <div class="text-gray-500">{{ widget.widget_type }} widget</div>
       {% endif %}

--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -89,7 +89,26 @@
       </form>
     </div>
     <div id="pane-table" class="hidden">
-      <p class="mb-4">Table tab content coming soon.</p>
+      <form id="tableWidgetForm" class="relative w-full" onsubmit="event.preventDefault();">
+        <div id="tableTypeSelect" class="flex gap-2 mb-4">
+          <label class="flex-1 cursor-pointer">
+            <input type="radio" name="tableType" value="base-count" class="sr-only peer" checked>
+            <div class="p-2 border rounded text-center peer-checked:bg-purple-500 peer-checked:text-white">
+              Base Count
+            </div>
+          </label>
+        </div>
+        <div id="tablePreview" class="mb-4 overflow-x-auto border rounded hidden">
+          <table class="min-w-full text-sm">
+            <thead>
+              <tr><th class="px-2 py-1 text-left">Table</th><th class="px-2 py-1 text-left">Count</th></tr>
+            </thead>
+            <tbody id="tablePreviewBody"></tbody>
+          </table>
+        </div>
+        <input id="tableTitleInput" type="text" placeholder="Widget Title" class="px-3 py-2 border rounded w-full mb-4 hidden" />
+        <button id="tableCreateBtn" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 block ml-auto hidden">Create</button>
+      </form>
     </div>
     <div id="pane-chart" class="hidden">
       <form id="chartWidgetForm" class="relative w-full" onsubmit="event.preventDefault();">


### PR DESCRIPTION
## Summary
- extend dashboard modal to allow creating table widgets and previewing base counts
- support table widgets in dashboard templates and rendering
- implement backend helpers to fetch base table counts
- expose `/dashboard/base-count` endpoint
- update documentation with table widget description

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ad41fff8c8333b5dde42ea6331969