### PR TITLE
Improve popover positioning

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -39,11 +39,15 @@ input[type=number] {
   cursor: pointer;
 }
 
-/* Constrain each multi-select chip’s popover */
+/* Constrain each multi-select chip’s popover
+   Default positioning opens to the right of the chip via left:0.
+   JS may set right:0 and clear left to open it to the left. */
 .multi-select-popover {
   width: 16rem !important;
   max-height: 15rem !important;
   overflow-y: auto !important;
+  left: 0;
+  right: auto;
 }
 
 /* Make all inputs/selects/textareas fill their .draggable-field parent */

--- a/static/js/filter_visibility.js
+++ b/static/js/filter_visibility.js
@@ -201,7 +201,21 @@ document.addEventListener("DOMContentLoaded", () => {
         // close others
         document.querySelectorAll(".multi-select-popover")
                 .forEach(p => p !== pop && p.classList.add("hidden"));
+
+        const wasHidden = pop.classList.contains("hidden");
         pop.classList.toggle("hidden");
+
+        if (wasHidden) {
+          const rect = btn.getBoundingClientRect();
+          const spaceRight = window.innerWidth - rect.right;
+          if (spaceRight < pop.offsetWidth) {
+            pop.style.right = "0";
+            pop.style.left = "";
+          } else {
+            pop.style.left = "0";
+            pop.style.right = "";
+          }
+        }
       });
 
       // prevent closing when interacting within the popover


### PR DESCRIPTION
## Summary
- adjust popover placement based on available viewport space
- describe left/right logic in CSS

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ad586c26083338971de4d98be3f1e