### PR TITLE
Add scrollbars to dashboard tables

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -42,18 +42,20 @@
       {% elif widget.widget_type == 'chart' %}
         <div class="font-semibold mb-2">{{ widget.title }}</div>
         <canvas></canvas>
-      {% elif widget.widget_type == 'table' %}
+        {% elif widget.widget_type == 'table' %}
         <div class="font-semibold mb-2">{{ widget.title }}</div>
-        <table class="min-w-full text-sm">
-          <thead>
-            <tr><th class="px-2 py-1 text-left">Table</th><th class="px-2 py-1 text-left">Count</th></tr>
-          </thead>
-          <tbody>
-          {% for row in widget.parsed.data if widget.parsed %}
-            <tr><td class="px-2 py-1">{{ row.table }}</td><td class="px-2 py-1">{{ row.count }}</td></tr>
-          {% endfor %}
-          </tbody>
-        </table>
+        <div class="overflow-auto max-h-64">
+          <table class="min-w-full text-sm">
+            <thead>
+              <tr><th class="px-2 py-1 text-left">Table</th><th class="px-2 py-1 text-left">Count</th></tr>
+            </thead>
+            <tbody>
+            {% for row in widget.parsed.data if widget.parsed %}
+              <tr><td class="px-2 py-1">{{ row.table }}</td><td class="px-2 py-1">{{ row.count }}</td></tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
       {% else %}
         <div class="text-gray-500">{{ widget.widget_type }} widget</div>
       {% endif %}

--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -98,7 +98,7 @@
             </div>
           </label>
         </div>
-        <div id="tablePreview" class="mb-4 overflow-x-auto border rounded hidden">
+        <div id="tablePreview" class="mb-4 overflow-x-auto max-h-64 overflow-y-auto border rounded hidden">
           <table class="min-w-full text-sm">
             <thead>
               <tr><th class="px-2 py-1 text-left">Table</th><th class="px-2 py-1 text-left">Count</th></tr>


### PR DESCRIPTION
## Summary
- update table preview container styles so large previews scroll
- wrap dashboard table widgets in scrolling divs

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684ad95da9008333abe713286f0f42e7