### PR TITLE
Add field styling integration

### DIFF
--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -47,20 +47,23 @@
       {% for field, value in record.items() %}
         {% if field_schema[table][field].type != 'hidden' %}
           {% set layout     = field_schema_layout[field] %}
+          {% set styling    = field_schema[table][field].styling or {} %}
           {# Compute 1-based start lines and spans using PCT_SNAP #}
           {% set col_start = layout.colStart or 1 %}
           {% set col_span  = layout.colSpan  or 1 %}
           {% set row_start = layout.rowStart or 1 %}
           {% set row_span  = layout.rowSpan  or 1 %}
-          <div class="draggable-field border p-2 rounded shadow bg-gray-50"
+          <div class="draggable-field border p-2 rounded shadow bg-gray-50{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }}"
                data-field="{{ field }}"
                data-type="{{ field_schema[table][field].type }}"
+               data-styling='{{ styling | tojson }}'
                style="
                 position: relative;
                  grid-column: {{ col_start }} / span {{ col_span }};
                  grid-row:    {{ row_start }} / span {{ row_span }};
+                 {% if styling.color %}color: {{ styling.color }};{% endif %}
                ">
-            {% if field_schema[table][field].type != 'text' %}
+            {% if field_schema[table][field].type != 'text' and not styling.hideName %}
             <div class="text-sm font-bold capitalize mb-1">{{ field }}</div>
             {% endif %}
             {{ fields.render_editable_field(
@@ -164,6 +167,21 @@
 </div>
 
 <script>const layoutCache = {{ field_schema_layout | tojson }};</script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.draggable-field').forEach(el => {
+      let data = el.dataset.styling;
+      try {
+        el._styling = data ? JSON.parse(data) : {};
+      } catch (e) {
+        el._styling = {};
+      }
+      if (window.applyFieldStyling) {
+        window.applyFieldStyling(el, el._styling);
+      }
+    });
+  });
+</script>
 <script src="{{ url_for('static', filename='js/layout_editor.js') }}"></script>
 <script src="{{ url_for('static', filename='js/field_styling.js') }}"></script>
 

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -7,7 +7,10 @@
   </form>
 {%- endmacro %}
 {% macro render_editable_field(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
-  <div class="mt-2 h-full">
+  {% set styling = field_schema[table][field].styling or {} %}
+  <div class="mt-2 h-full{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }}"
+       {% if styling.color %}style="color: {{ styling.color }}"{% endif %}
+       data-styling='{{ styling | tojson }}'>
     {% if field_type == "textarea" %}
     <form method="POST"
           action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}"


### PR DESCRIPTION
## Summary
- pull styling options from field schema when rendering
- attach styling JSON to draggable fields in detail view
- apply initial styling on page load

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684af1a99fbc8333b40f09769b776fd6