### PR TITLE
Adjust popover side logic

### DIFF
--- a/static/js/filter_visibility.js
+++ b/static/js/filter_visibility.js
@@ -202,10 +202,9 @@ document.addEventListener("DOMContentLoaded", () => {
         document.querySelectorAll(".multi-select-popover")
                 .forEach(p => p !== pop && p.classList.add("hidden"));
 
-        const wasHidden = pop.classList.contains("hidden");
         pop.classList.toggle("hidden");
 
-        if (wasHidden) {
+        if (!pop.classList.contains("hidden")) {
           const rect = btn.getBoundingClientRect();
           const spaceRight = window.innerWidth - rect.right;
           if (spaceRight < pop.offsetWidth) {


### PR DESCRIPTION
## Summary
- toggle multi-select popover and compute available space
- document default popover positioning in CSS

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684af3b683ac83338ca131acfdd3ca5c