### PR TITLE
Enable scrollable tables in dashboard

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -44,7 +44,7 @@
         <canvas></canvas>
         {% elif widget.widget_type == 'table' %}
         <div class="font-semibold mb-2">{{ widget.title }}</div>
-        <div class="overflow-x-auto overflow-y-auto max-h-64">
+        <div class="overflow-auto max-h-64">
 
           <table class="min-w-full text-sm">
             <thead>

--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -98,7 +98,7 @@
             </div>
           </label>
         </div>
-        <div id="tablePreview" class="mb-4 overflow-x-auto max-h-64 overflow-y-auto border rounded hidden">
+        <div id="tablePreview" class="mb-4 max-h-64 overflow-y-auto border rounded hidden">
           <table class="min-w-full text-sm">
             <thead>
               <tr><th class="px-2 py-1 text-left">Table</th><th class="px-2 py-1 text-left">Count</th></tr>


### PR DESCRIPTION
## Summary
- make dashboard table widgets scrollable
- allow table preview in modal to scroll as well

## Testing
- `pip install -r requirements.txt`
- `flask --app main run -p 8000` *(fails: Address already in use)*


------
https://chatgpt.com/codex/tasks/task_e_684af405d4d08333bb771e1a27f7b656