### PR TITLE
Fix unmatched closing div in edit_fields_modal

### DIFF
--- a/templates/edit_fields_modal.html
+++ b/templates/edit_fields_modal.html
@@ -104,6 +104,5 @@
         </div>
       </form>
     </div>
-   </div>
  </div>
 </div>


### PR DESCRIPTION
## Summary
- remove stray closing `</div>` in `edit_fields_modal.html`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684af62575688333bd5d21359a849b06