### PR TITLE
Adjust popover positioning for list view

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -40,14 +40,19 @@ input[type=number] {
 }
 
 /* Constrain each multi-select chip’s popover
-   Default positioning opens to the right of the chip via left:0.
-   JS may set right:0 and clear left to open it to the left. */
+   Default positioning opens to the right of the chip via left:0. */
 .multi-select-popover {
   width: 16rem !important;
   max-height: 15rem !important;
   overflow-y: auto !important;
   left: 0;
   right: auto;
+}
+
+/* In list view pages, open the popover to the left */
+.list-view-page .multi-select-popover {
+  left: auto;
+  right: 0;
 }
 
 /* Make all inputs/selects/textareas fill their .draggable-field parent */

--- a/static/js/filter_visibility.js
+++ b/static/js/filter_visibility.js
@@ -203,18 +203,6 @@ document.addEventListener("DOMContentLoaded", () => {
                 .forEach(p => p !== pop && p.classList.add("hidden"));
 
         pop.classList.toggle("hidden");
-
-        if (!pop.classList.contains("hidden")) {
-          const rect = btn.getBoundingClientRect();
-          const spaceRight = window.innerWidth - rect.right;
-          if (spaceRight < pop.offsetWidth) {
-            pop.style.right = "0";
-            pop.style.left = "";
-          } else {
-            pop.style.left = "0";
-            pop.style.right = "";
-          }
-        }
       });
 
       // prevent closing when interacting within the popover

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
   <script src="{{ url_for('static', filename='js/flowbite-charts.min.js') }}"></script>
   <title>{% block title %}Crossbook{% endblock %}</title>
 </head>
-<body class="bg-white text-gray-900">
+<body class="bg-white text-gray-900 {% block body_class %}{% endblock %}">
     {% set segments = request.path.strip('/').split('/') %}
     {% set current_table = segments[0] %}
     {% set current_id = segments[1] if segments|length > 1 else None %}

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -2,6 +2,7 @@
 
 {% block title %}{{ table|capitalize }} List{% endblock %}
 {% import 'macros/filter_controls.html' as filters %}
+{% block body_class %}list-view-page{% endblock %}
 {% block nav_buttons %}
 <button id="bulk_edit" onclick="openBulkEditModal()" class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600">Bulk Edit</button>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `body_class` block in `base.html`
- tag list view pages with `list-view-page`
- remove inline left/right logic from `filter_visibility.js`
- style popovers to open left on list view pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af9388ebc83338fb85f6df51edcd4