### PR TITLE
Add select count table widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
   available row in the grid without specifying `row_start`.
 * **Dashboard Charts:** Pie, bar and line chart widgets leverage Flowbite Charts and auto-generate counts from a single field.
 * **Table Widget:** Displays simple tabular data such as base table record counts.
+* **Select Value Counts:** Table widget option that shows counts of each choice for a select or multi-select field.
 * **Dashboard Grid Editing:** Widgets can be dragged, resized, and saved using `/dashboard/layout`.
 * **Numerical Summaries:** `/<table>/sum-field` returns the sum for numeric columns, used by dashboard charts.
 * **List API:** `/api/<table>/list` provides ID and label data for dropdowns.

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -45,15 +45,24 @@
         {% elif widget.widget_type == 'table' %}
         <div class="font-semibold mb-2">{{ widget.title }}</div>
         <div class="overflow-auto max-h-64">
-
           <table class="min-w-full text-sm">
             <thead>
+              {% if widget.parsed.type == 'select-count' %}
+              <tr><th class="px-2 py-1 text-left">Value</th><th class="px-2 py-1 text-left">Count</th></tr>
+              {% else %}
               <tr><th class="px-2 py-1 text-left">Table</th><th class="px-2 py-1 text-left">Count</th></tr>
+              {% endif %}
             </thead>
             <tbody>
-            {% for row in widget.parsed.data if widget.parsed %}
-              <tr><td class="px-2 py-1">{{ row.table }}</td><td class="px-2 py-1">{{ row.count }}</td></tr>
-            {% endfor %}
+            {% if widget.parsed.type == 'select-count' %}
+              {% for row in widget.parsed.data if widget.parsed %}
+                <tr><td class="px-2 py-1">{{ row.value }}</td><td class="px-2 py-1">{{ row.count }}</td></tr>
+              {% endfor %}
+            {% else %}
+              {% for row in widget.parsed.data if widget.parsed %}
+                <tr><td class="px-2 py-1">{{ row.table }}</td><td class="px-2 py-1">{{ row.count }}</td></tr>
+              {% endfor %}
+            {% endif %}
             </tbody>
           </table>
         </div>

--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -97,11 +97,25 @@
               Base Count
             </div>
           </label>
+          <label class="flex-1 cursor-pointer">
+            <input type="radio" name="tableType" value="select-count" class="sr-only peer">
+            <div class="p-2 border rounded text-center peer-checked:bg-purple-500 peer-checked:text-white">
+              Select Value Counts
+            </div>
+          </label>
+        </div>
+        <div id="selectCountFieldContainer" class="mb-4 hidden">
+          <div class="relative">
+            <button id="selectCountFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left flex items-center justify-between">
+              <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
+            </button>
+            <div id="selectCountFieldOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+          </div>
         </div>
         <div id="tablePreview" class="mb-4 max-h-64 overflow-y-auto border rounded hidden">
           <table class="min-w-full text-sm">
             <thead>
-              <tr><th class="px-2 py-1 text-left">Table</th><th class="px-2 py-1 text-left">Count</th></tr>
+              <tr id="tablePreviewHeader"><th class="px-2 py-1 text-left">Table</th><th class="px-2 py-1 text-left">Count</th></tr>
             </thead>
             <tbody id="tablePreviewBody"></tbody>
           </table>


### PR DESCRIPTION
## Summary
- support new Select Value Counts table widget
- implement dropdown to pick select/multi-select field
- show value/count preview and save widget config
- render select-count widget type on the dashboard
- document new feature in README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684af968cb908333aa44d80cb533cc04