### PR TITLE
Fix dashboard modal initialization

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -827,7 +827,11 @@ function initDashboardModal() {
   updateTablePreview();
 }
 
-document.addEventListener('DOMContentLoaded', initDashboardModal);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initDashboardModal);
+} else {
+  initDashboardModal();
+}
 
 window.openDashboardModal = openDashboardModal;
 window.closeDashboardModal = closeDashboardModal;


### PR DESCRIPTION
## Summary
- ensure dashboard modal JS runs even if DOMContentLoaded already fired

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684afae76b3c8333955f5eafc2583e3c