### PR TITLE
Validate table before detail retrieval

### DIFF
--- a/views/records.py
+++ b/views/records.py
@@ -116,6 +116,11 @@ def api_list(table):
 
 @records_bp.route('/<table>/<int:record_id>')
 def detail_view(table, record_id):
+    try:
+        validate_table(table)
+    except ValueError:
+        abort(404)
+
     record = get_record_by_id(table, record_id)
     if not record:
         abort(404)


### PR DESCRIPTION
## Summary
- validate the table name in `detail_view` to avoid invalid table lookups

## Testing
- `python -m py_compile views/records.py`

------
https://chatgpt.com/codex/tasks/task_e_684afb5463c48333b418da85c83c7f7f