### PR TITLE
Add validation calls to DB utilities

### DIFF
--- a/db/edit_fields.py
+++ b/db/edit_fields.py
@@ -2,6 +2,7 @@ import sqlite3
 import json
 from db.database import get_connection
 from db.config import get_layout_defaults
+from db.validation import validate_table, validate_field
 
 DEFAULT_FIELD_WIDTH = {
     "textarea":   12,
@@ -34,6 +35,7 @@ def add_field_to_schema(
     styling=None,
 ):
     """Insert a new field into the field_schema table."""
+    validate_table(table)
     with get_connection() as conn:
         cur = conn.cursor()
 
@@ -84,6 +86,8 @@ def add_field_to_schema(
 def add_column_to_table(table_name, field_name, field_type):
     from db.database import get_connection
 
+    validate_table(table_name)
+
     # Map form types to SQL types
     SQL_TYPE_MAP = {
         "text": "TEXT",
@@ -112,6 +116,8 @@ def add_column_to_table(table_name, field_name, field_type):
         conn.commit()
 
 def drop_column_from_table(table, field_name):
+    validate_table(table)
+    validate_field(table, field_name)
     with get_connection() as conn:
         cur = conn.cursor()
 
@@ -135,6 +141,8 @@ def drop_column_from_table(table, field_name):
         conn.commit()
 
 def remove_field_from_schema(table, field_name):
+    validate_table(table)
+    validate_field(table, field_name)
     with get_connection() as conn:
         cur = conn.cursor()
         cur.execute(

--- a/db/records.py
+++ b/db/records.py
@@ -161,6 +161,7 @@ def count_records(table, search=None, filters=None, ops=None, modes=None):
             return 0
 
 def get_record_by_id(table, record_id):
+    validate_table(table)
     with get_connection() as conn:
         cursor = conn.cursor()
         cursor.execute(f"PRAGMA table_info({table})")

--- a/db/schema.py
+++ b/db/schema.py
@@ -3,6 +3,7 @@ import json
 import logging
 
 from db.database import get_connection
+from db.validation import validate_table, validate_field
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +158,7 @@ def refresh_card_cache():
     return card_info, base_tables
 
 def update_layout(table: str, layout_items: list[dict]) -> int:
+    validate_table(table)
     current_schema = load_field_schema()
 
     if table not in current_schema:
@@ -171,6 +173,7 @@ def update_layout(table: str, layout_items: list[dict]) -> int:
             if not field:
                 # Skip items without a "field" key
                 continue
+            validate_field(table, field)
 
             # Safely parse numeric layout values (defaults to 0.0)
             try:
@@ -223,6 +226,8 @@ def update_field_styling(table: str, field: str, styling_dict: dict) -> bool:
             cannot be serialized to JSON.
     """
 
+    validate_table(table)
+    validate_field(table, field)
     current_schema = load_field_schema()
     if table not in current_schema or field not in current_schema[table]:
         raise ValueError(f"Unknown table/field: {table}.{field}")


### PR DESCRIPTION
## Summary
- ensure database operations validate table and field names

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afc52f6c08333bdd7402889999140