### PR TITLE
Fix filter chips with AJAX list view

### DIFF
--- a/static/js/filter_visibility.js
+++ b/static/js/filter_visibility.js
@@ -19,6 +19,18 @@ document.addEventListener("DOMContentLoaded", () => {
           pagerWrap.innerHTML = data.pagination_html;
           const cnt = document.getElementById("record-count");
           if (cnt) cnt.outerHTML = data.count_html;
+          if (data.filters_html) {
+            const cur = document.getElementById("filter-container");
+            if (cur) {
+              cur.outerHTML = data.filters_html;
+              bindDebounceToFilters();
+              bindOperatorListeners();
+              bindNumberFilters();
+              bindDateFilters();
+              bindMultiSelectPopovers();
+              bindSelectMulti();
+            }
+          }
         })
         .catch(err => console.error("fetchRecords", err))
         .finally(() => loading.classList.add("hidden"));

--- a/templates/_filter_chips.html
+++ b/templates/_filter_chips.html
@@ -1,0 +1,24 @@
+{% import 'macros/filter_controls.html' as filters %}
+{% set use_checkbox_filters = request.args.get('filter_style') == 'list' %}
+<div id="filter-container" class="ml-4 flex flex-wrap gap-x-4 gap-y-2">
+  {% for field in fields if request.args.get(field) is not none %}
+    {% set meta = field_schema[table][field] %}
+    {% if meta.type == 'boolean' %}
+      {{ filters.boolean_filter(field, request.args.get(field,'')) }}
+    {% elif meta.type in ['multi_select','foreign_key'] %}
+      {{ filters.multi_select_popover(field, request.args.getlist(field), meta.options, request.args.get(field + '_mode', 'any')) }}
+    {% elif meta.type == 'select' %}
+      {% if use_checkbox_filters %}
+        {{ filters.select_multi_filter(field, request.args.getlist(field), meta.options) }}
+      {% else %}
+        {{ filters.select_filter(field, request.args.get(field,''), meta.options) }}
+      {% endif %}
+    {% elif meta.type == 'number' %}
+      {{ filters.number_filter(field, request.args.get(field + '_min',''), request.args.get(field + '_max','')) }}
+    {% elif meta.type == 'date' %}
+      {{ filters.date_filter(field, request.args.get(field + '_start',''), request.args.get(field + '_end','')) }}
+    {% else %}
+      {{ filters.text_filter(field, request.args.get(field,''), request.args.get(field + '_op','contains')) }}
+    {% endif %}
+  {% endfor %}
+</div>

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -28,29 +28,7 @@
   
     {# Right side: Active filters + Reset #}
     <div class="flex items-center space-x-4">
-      {% set use_checkbox_filters = request.args.get('filter_style') == 'list' %}
-      <div id="filter-container" class="ml-4 flex flex-wrap gap-x-4 gap-y-2">
-        {% for field in fields if request.args.get(field) is not none %}
-          {% set meta = field_schema[table][field] %}
-          {% if meta.type == 'boolean' %}
-            {{ filters.boolean_filter(field, request.args.get(field,'')) }}
-          {% elif meta.type in ['multi_select','foreign_key'] %}
-            {{ filters.multi_select_popover(field, request.args.getlist(field), meta.options, request.args.get(field + '_mode', 'any')) }}
-          {% elif meta.type == 'select' %}
-            {% if use_checkbox_filters %}
-              {{ filters.select_multi_filter(field, request.args.getlist(field), meta.options) }}
-            {% else %}
-              {{ filters.select_filter(field, request.args.get(field,''), meta.options) }}
-            {% endif %}
-          {% elif meta.type == 'number' %}
-            {{ filters.number_filter(field, request.args.get(field + '_min',''), request.args.get(field + '_max','')) }}
-          {% elif meta.type == 'date' %}
-            {{ filters.date_filter(field, request.args.get(field + '_start',''), request.args.get(field + '_end','')) }}
-          {% else %}
-            {{ filters.text_filter(field, request.args.get(field,''), request.args.get(field + '_op','contains')) }}
-          {% endif %}
-        {% endfor %}
-      </div>
+      {% include '_filter_chips.html' %}
       <button
         type="button"
         id="reset-filters"

--- a/views/records.py
+++ b/views/records.py
@@ -92,7 +92,9 @@ def list_view(table):
         rows = render_template('_record_rows.html', **ctx)
         pager = render_template('_pagination.html', **ctx)
         count = render_template('_record_count.html', **ctx)
-        ctx.update({'rows_html': rows, 'pagination_html': pager, 'count_html': count})
+        filters = render_template('_filter_chips.html', **ctx)
+        ctx.update({'rows_html': rows, 'pagination_html': pager,
+                    'count_html': count, 'filters_html': filters})
         return jsonify(ctx)
     return render_template('list_view.html', request=request, **ctx)
 
@@ -129,7 +131,9 @@ def api_records(table):
     rows = render_template('_record_rows.html', **ctx)
     pager = render_template('_pagination.html', **ctx)
     count = render_template('_record_count.html', **ctx)
-    ctx.update({'rows_html': rows, 'pagination_html': pager, 'count_html': count})
+    filters = render_template('_filter_chips.html', **ctx)
+    ctx.update({'rows_html': rows, 'pagination_html': pager,
+                'count_html': count, 'filters_html': filters})
     return jsonify(ctx)
 
 @records_bp.route('/<table>/<int:record_id>')


### PR DESCRIPTION
## Summary
- include filter chips via a new `_filter_chips.html` partial
- return active filter HTML from list endpoints
- refresh filter controls on AJAX fetch

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0d8debc483339c1d3a526b7194c6