### PR TITLE
Fix dashboard widget sizing and CSS

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -92,6 +92,18 @@ input[type=number] {
 #dashboard-grid .draggable-field textarea {
   height: 100% !important;
 }
+
+/* Dashboard grid defaults */
+#dashboard-grid .draggable-field {
+  padding: 0 !important;
+  /* …other reset rules… */
+}
+
+/* Re-apply Tailwind p-2 & proper box-sizing on widgets */
+#dashboard-grid .dashboard-widget {
+  padding: 0.5rem !important;   /* Tailwind p-2 */
+  box-sizing: border-box;       /* so h-full includes padding */
+}
 #dashboard-grid .resize-handle {
   position: absolute;
   width: 12px;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -31,7 +31,7 @@
       'rowStart': row_start,
       'rowSpan': row_span
     } }) %}
-    <div class="dashboard-widget draggable-field border p-2 rounded shadow bg-gray-50"
+    <div class="dashboard-widget draggable-field min-h-0 border p-2 rounded shadow bg-gray-50"
          data-widget="{{ widget.id }}"
          data-type="{{ widget.widget_type }}"
          {% if widget.widget_type == 'chart' %}data-config='{{ widget.content }}'{% endif %}
@@ -44,7 +44,7 @@
         <canvas></canvas>
         {% elif widget.widget_type == 'table' %}
         <div class="font-semibold mb-2">{{ widget.title }}</div>
-        <div class="overflow-auto max-h-64">
+        <div class="overflow-auto h-full box-border">
           <table class="min-w-full text-sm">
             <thead>
               {% if widget.parsed.type == 'select-count' %}


### PR DESCRIPTION
## Summary
- ensure dashboard widgets allow flexible height with `min-h-0`
- make table containers use `h-full` for scrolling
- re-apply Tailwind padding and box sizing in overrides.css

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b10899f908333a836b7008b90d5f2