### PR TITLE
Implement sortable list view

### DIFF
--- a/db/records.py
+++ b/db/records.py
@@ -112,6 +112,8 @@ def get_all_records(
     filters=None,
     ops=None,
     modes=None,
+    sort_field=None,
+    direction="asc",
     limit=None,
     offset=0,
 ):
@@ -127,6 +129,15 @@ def get_all_records(
             sql = f"SELECT * FROM {table}"
             if clauses:
                 sql += " WHERE " + " AND ".join(clauses)
+
+            if sort_field:
+                try:
+                    validate_field(table, sort_field)
+                    dir_sql = "DESC" if str(direction).lower() == "desc" else "ASC"
+                    sql += f" ORDER BY {sort_field} {dir_sql}"
+                except Exception:
+                    logger.warning("Invalid sort field: %s", sort_field)
+
             if limit is not None:
                 sql += f" LIMIT {int(limit)} OFFSET {int(offset)}"
 

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -69,7 +69,20 @@
       <thead class="bg-gray-50">
         <tr>
           {% for field in fields if not field.startswith('_') %}
-            <th scope="col" class="px-4 py-2 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">{{ field }}</th>
+            {% set is_current = sort_field == field %}
+            {% set new_dir = 'desc' if is_current and direction == 'asc' else 'asc' %}
+            <th scope="col" class="px-4 py-2 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+              <a href="?{{ base_qs_no_sort }}{{ '&' if base_qs_no_sort else '' }}sort={{ field }}&dir={{ new_dir }}" class="flex items-center space-x-1">
+                <span>{{ field }}</span>
+                {% if is_current %}
+                  {% if direction == 'asc' %}
+                    <span>&#9650;</span>
+                  {% else %}
+                    <span>&#9660;</span>
+                  {% endif %}
+                {% endif %}
+              </a>
+            </th>
           {% endfor %}
         </tr>
       </thead>


### PR DESCRIPTION
## Summary
- allow sorting in `get_all_records`
- propagate sort parameters in list view context
- add sortable headers with sort direction arrows in list template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b12b0b4348333ba595fcebb07845d