### PR TITLE
Add dashboard top/bottom numeric widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Dashboard Charts:** Pie, bar and line chart widgets leverage Flowbite Charts and auto-generate counts from a single field.
 * **Table Widget:** Displays simple tabular data such as base table record counts.
 * **Select Value Counts:** Table widget option that shows counts of each choice for a select or multi-select field.
+* **Top/Bottom Numeric:** Table widget listing records with the highest or lowest values for a numeric field.
 * **Dashboard Grid Editing:** Widgets can be dragged, resized, and saved using `/dashboard/layout`.
 * **Numerical Summaries:** `/<table>/sum-field` returns the sum for numeric columns, used by dashboard charts.
 * **List API:** `/api/<table>/list` provides ID and label data for dropdowns.

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -49,6 +49,8 @@
             <thead>
               {% if widget.parsed.type == 'select-count' %}
               <tr><th class="px-2 py-1 text-left">Value</th><th class="px-2 py-1 text-left">Count</th></tr>
+              {% elif widget.parsed.type == 'top-numeric' %}
+              <tr><th class="px-2 py-1 text-left">ID</th><th class="px-2 py-1 text-left">Value</th></tr>
               {% else %}
               <tr><th class="px-2 py-1 text-left">Table</th><th class="px-2 py-1 text-left">Count</th></tr>
               {% endif %}
@@ -57,6 +59,11 @@
             {% if widget.parsed.type == 'select-count' %}
               {% for row in widget.parsed.data if widget.parsed %}
                 <tr><td class="px-2 py-1">{{ row.value }}</td><td class="px-2 py-1">{{ row.count }}</td></tr>
+              {% endfor %}
+            {% elif widget.parsed.type == 'top-numeric' %}
+              {% set tbl = widget.parsed.table %}
+              {% for row in widget.parsed.data if widget.parsed %}
+                <tr><td class="px-2 py-1"><a href="/{{ tbl }}/{{ row.id }}" class="text-blue-600 underline">{{ row.id }}</a></td><td class="px-2 py-1">{{ row.value }}</td></tr>
               {% endfor %}
             {% else %}
               {% for row in widget.parsed.data if widget.parsed %}

--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -103,6 +103,12 @@
               Select Value Counts
             </div>
           </label>
+          <label class="flex-1 cursor-pointer">
+            <input type="radio" name="tableType" value="top-numeric" class="sr-only peer">
+            <div class="p-2 border rounded text-center peer-checked:bg-purple-500 peer-checked:text-white">
+              Top/Bottom Numeric
+            </div>
+          </label>
         </div>
         <div id="selectCountFieldContainer" class="mb-4 hidden">
           <div class="relative">
@@ -111,6 +117,24 @@
             </button>
             <div id="selectCountFieldOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
           </div>
+        </div>
+        <div id="topNumericFieldContainer" class="mb-4 hidden">
+          <div class="relative">
+            <button id="topNumericFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left flex items-center justify-between">
+              <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
+            </button>
+            <div id="topNumericFieldOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+          </div>
+        </div>
+        <div id="topNumericDirection" class="flex gap-2 mb-4 hidden">
+          <label class="cursor-pointer">
+            <input type="radio" name="topDirection" value="desc" class="sr-only peer" checked>
+            <div class="p-1 border rounded-l text-center peer-checked:bg-purple-500 peer-checked:text-white">Top</div>
+          </label>
+          <label class="cursor-pointer">
+            <input type="radio" name="topDirection" value="asc" class="sr-only peer">
+            <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-purple-500 peer-checked:text-white">Bottom</div>
+          </label>
         </div>
         <div id="tablePreview" class="mb-4 max-h-64 overflow-y-auto border rounded hidden">
           <table class="min-w-full text-sm">

--- a/views/admin.py
+++ b/views/admin.py
@@ -15,6 +15,7 @@ from db.dashboard import (
     create_widget,
     update_widget_layout,
     get_base_table_counts,
+    get_top_numeric_values,
 )
 from db.schema import create_base_table, refresh_card_cache
 from imports.import_csv import parse_csv
@@ -141,6 +142,28 @@ def dashboard_update_layout():
 def dashboard_base_count():
     """Return counts for all base tables."""
     data = get_base_table_counts()
+    return jsonify(data)
+
+
+@admin_bp.route('/dashboard/top-numeric')
+def dashboard_top_numeric():
+    """Return top or bottom numeric values from a table."""
+    table = request.args.get('table')
+    field = request.args.get('field')
+    try:
+        limit = int(request.args.get('limit', 10))
+    except (TypeError, ValueError):
+        limit = 10
+    direction = request.args.get('direction', 'desc')
+    try:
+        data = get_top_numeric_values(
+            table,
+            field,
+            limit=limit,
+            ascending=(direction == 'asc'),
+        )
+    except ValueError:
+        return jsonify([]), 400
     return jsonify(data)
 
 @admin_bp.route('/add-table', methods=['POST'])


### PR DESCRIPTION
## Summary
- support fetching top/bottom numeric values
- expose `/dashboard/top-numeric` endpoint
- allow top-numeric table widgets in dashboard modal
- preview and create top-numeric widgets via JS
- render new widget type on dashboard
- document numeric widget option

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b12cfeff88333a58b7c374f0809f8