### PR TITLE
Fix column visibility with sorting

### DIFF
--- a/static/js/column_visibility.js
+++ b/static/js/column_visibility.js
@@ -11,7 +11,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
     document.querySelectorAll("thead th").forEach((th) => {
       if (th.dataset.static !== undefined) return;
-      const field = th.textContent.trim();
+      const span = th.querySelector("span");
+      const field = span ? span.textContent.trim() : th.textContent.trim();
       th.style.display = visible.has(field) ? "" : "none";
     });
 


### PR DESCRIPTION
## Summary
- fix column visibility logic so sorting arrows don't break header lookup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b15c370b48333956e8f63b6ae57a5