### PR TITLE
Add CSV export route

### DIFF
--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -36,8 +36,14 @@
       >
         Reset Filters
       </button>
+      <a
+        href="{{ url_for('records.export_csv', table=table) }}{{ '?' if base_qs else '' }}{{ base_qs }}"
+        class="text-sm bg-green-500 text-white px-2 py-1 rounded"
+      >
+        Export CSV
+      </a>
     </div>
-  </form>  
+  </form>
   <!-- Visibility control -->
   <div class="relative inline-block text-left mb-4" id="column-visibility-wrapper">
     <button id="toggle-columns" type="button" class="px-2 py-1 bg-gray-200 rounded">


### PR DESCRIPTION
## Summary
- centralize query parsing in `_parse_list_params`
- add `/<table>/export` route to stream filtered CSV
- link new export endpoint from list page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b547ea7748333bc23c21cf4b24129