### PR TITLE
Implement huey-based CSV import

### DIFF
--- a/imports/tasks.py
+++ b/imports/tasks.py
@@ -1,5 +1,8 @@
 import os
+import json
 from huey import SqliteHuey
+from db.database import get_connection
+from db.records import create_record
 
 # Huey queue for background imports
 huey = SqliteHuey(
@@ -9,3 +12,43 @@ huey = SqliteHuey(
                           'huey.db'),
     store_none=False                            # don’t clutter the DB with None results
 )
+
+
+def init_import_table():
+    """Ensure the import_status table exists."""
+    with get_connection() as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS import_status (\n"
+            "  id INTEGER PRIMARY KEY AUTOINCREMENT,\n"
+            "  status TEXT,\n"
+            "  total_rows INTEGER,\n"
+            "  imported_rows INTEGER,\n"
+            "  errors TEXT\n"
+            ")"
+        )
+        conn.commit()
+
+
+def _update_import_status(job_id, **kwargs):
+    """Update fields for a given import job."""
+    if not kwargs:
+        return
+    fields = ", ".join(f"{k} = ?" for k in kwargs)
+    params = list(kwargs.values()) + [job_id]
+    with get_connection() as conn:
+        conn.execute(f"UPDATE import_status SET {fields} WHERE id = ?", params)
+        conn.commit()
+
+
+@huey.task()
+def process_import(job_id, table, rows):
+    """Background task to create records from parsed CSV rows."""
+    _update_import_status(job_id, status="in_progress", total_rows=len(rows))
+    errors = []
+    for idx, row in enumerate(rows, start=1):
+        if create_record(table, row) is None:
+            errors.append({"row": idx, "message": "Failed to create"})
+        _update_import_status(job_id, imported_rows=idx, errors=json.dumps(errors))
+    _update_import_status(job_id, status="complete")
+    return {"imported": len(rows) - len(errors), "errors": errors}
+

--- a/tests/test_import_jobs.py
+++ b/tests/test_import_jobs.py
@@ -1,0 +1,29 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from main import app
+from imports import tasks as import_tasks
+
+app.testing = True
+client = app.test_client()
+
+
+def test_import_start_and_status():
+    import_tasks.huey.immediate = True
+    payload = {
+        'table': 'character',
+        'rows': [
+            {'character': 'Test Character'}
+        ]
+    }
+    resp = client.post('/import-start', json=payload)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'importId' in data
+    import_id = data['importId']
+
+    status_resp = client.get('/import-status', query_string={'importId': import_id})
+    assert status_resp.status_code == 200
+    status = status_resp.get_json()
+    assert status['status'] == 'complete'
+    assert status['importedRows'] == len(payload['rows'])


### PR DESCRIPTION
## Summary
- add Huey task and helpers in `imports/tasks.py`
- create `/import-start` and `/import-status` routes
- allow `progress_bar.js` to send JSON payloads
- test CSV import job completion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd98513ac833388ddcde16f48ba03