### PR TITLE
Improve bulk edit modal options

### DIFF
--- a/templates/bulk_edit_modal.html
+++ b/templates/bulk_edit_modal.html
@@ -8,7 +8,7 @@
         <label for="bulk-field" class="block text-sm font-medium text-gray-700 mb-1">Field</label>
         <select id="bulk-field" class="w-full border px-2 py-1 rounded">
           {% for field, meta in field_schema[table].items() if not field.startswith('_') %}
-            <option value="{{ field }}" data-type="{{ meta.type }}">{{ field }}</option>
+            <option value="{{ field }}" data-type="{{ meta.type }}" data-options='{{ meta.options | tojson | e }}'>{{ field }}</option>
           {% endfor %}
         </select>
       </div>

--- a/views/records.py
+++ b/views/records.py
@@ -381,6 +381,11 @@ def bulk_update(table):
             value = int(value)
         except (TypeError, ValueError):
             value = 0
+    elif ftype in ('multi_select', 'foreign_key'):
+        if isinstance(value, list):
+            value = ', '.join([str(v) for v in value])
+        elif value is None:
+            value = ''
     elif ftype == 'textarea':
         from utils.html_sanitizer import sanitize_html
         value = sanitize_html(value or '')


### PR DESCRIPTION
## Summary
- include field options in bulk edit modal
- support select and multi-select in bulk edit JS
- handle multi-select arrays on bulk update endpoint
- test bulk updating multi-select fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bdbb4edac8333a7d5e7f105991052