### PR TITLE
Add database configuration controls

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -1,6 +1,11 @@
 import sqlite3
 import re
 import os
+
+try:
+    from local_settings import CROSSBOOK_DB_PATH as LOCAL_DB_PATH
+except Exception:
+    LOCAL_DB_PATH = None
 from contextlib import contextmanager
 
 try:
@@ -12,13 +17,14 @@ try:
 except Exception:
     SUPPORTS_REGEX = False
 
-DB_PATH = os.environ.get("CROSSBOOK_DB_PATH", "data/crossbook.db")
+DB_PATH = os.environ.get("CROSSBOOK_DB_PATH", LOCAL_DB_PATH or "data/crossbook.db")
 
 
 def init_db_path() -> None:
     """Override DB_PATH using database config if available."""
     global DB_PATH
     env_path = os.environ.get("CROSSBOOK_DB_PATH")
+    local_path = LOCAL_DB_PATH
     cfg_path = None
     try:
         from db.config import get_database_config
@@ -38,6 +44,8 @@ def init_db_path() -> None:
 
     if env_path:
         DB_PATH = env_path
+    elif local_path:
+        DB_PATH = local_path
     elif cfg_path:
         DB_PATH = cfg_path
 

--- a/static/js/config_admin.js
+++ b/static/js/config_admin.js
@@ -21,5 +21,34 @@ function initLayoutDefaultsForms() {
   });
 }
 
-document.addEventListener('DOMContentLoaded', initLayoutDefaultsForms);
+function initDatabaseControls() {
+  const uploadForm = document.getElementById('db-upload-form');
+  if (uploadForm) {
+    uploadForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const fd = new FormData(uploadForm);
+      fetch('/admin/config/db', {
+        method: 'POST',
+        body: fd
+      }).then(() => window.location.reload());
+    });
+  }
+
+  const createBtn = document.getElementById('create-db-btn');
+  if (createBtn) {
+    createBtn.addEventListener('click', () => {
+      const name = prompt('Filename for new database (.db):');
+      if (!name) return;
+      const fd = new FormData();
+      fd.append('create_name', name);
+      fetch('/admin/config/db', { method: 'POST', body: fd })
+        .then(() => window.location.reload());
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initLayoutDefaultsForms();
+  initDatabaseControls();
+});
 

--- a/templates/config_admin.html
+++ b/templates/config_admin.html
@@ -6,7 +6,20 @@
 <h1 class="text-2xl font-bold mb-6">Configuration</h1>
 
 <div class="mx-auto w-11/12 max-w-screen-2xl space-y-6">
-{% for section, items in sections.items() %}
+  <details class="bg-white rounded shadow" open>
+    <summary class="cursor-pointer px-4 py-2 bg-gray-100 rounded-t font-semibold text-lg">
+      Database
+    </summary>
+    <div class="p-4 space-y-4">
+      <input type="text" id="db-path-display" value="{{ db_path }}" readonly class="border border-gray-300 rounded px-2 py-1 text-sm w-full" />
+      <form id="db-upload-form" class="flex items-center space-x-2" enctype="multipart/form-data">
+        <input type="file" name="file" accept=".db" class="text-sm border border-gray-300 rounded" />
+        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Use DB</button>
+      </form>
+      <button id="create-db-btn" type="button" class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded">Create New DB</button>
+    </div>
+  </details>
+  {% for section, items in sections.items() %}
   <details class="bg-white rounded shadow" {% if loop.first %}open{% endif %}>
     <summary class="cursor-pointer px-4 py-2 bg-gray-100 rounded-t font-semibold text-lg">
       {{ section|capitalize }}


### PR DESCRIPTION
## Summary
- add function to persist DB path and expose new `/admin/config/db` route
- allow local `local_settings.py` override during DB initialization
- extend admin UI with database management controls
- wire up JS handlers for upload and creation actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bf0232a2083338533bc49f65c3a66