### PR TITLE
Fix database picker and add status display

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -67,3 +67,22 @@ def get_connection():
         yield conn
     finally:
         conn.close()
+
+
+def check_db_status(path: str) -> str:
+    """Return 'valid', 'locked', 'corrupted', or 'missing' for a database file."""
+    if not path or not os.path.exists(path):
+        return 'missing'
+    try:
+        with sqlite3.connect(path) as conn:
+            cur = conn.execute('PRAGMA integrity_check')
+            row = cur.fetchone()
+            if row and row[0] == 'ok':
+                return 'valid'
+            return 'corrupted'
+    except sqlite3.OperationalError as exc:
+        if 'locked' in str(exc).lower():
+            return 'locked'
+        return 'corrupted'
+    except Exception:
+        return 'corrupted'

--- a/static/js/config_admin.js
+++ b/static/js/config_admin.js
@@ -29,8 +29,21 @@ function initDatabaseControls() {
       const fd = new FormData(uploadForm);
       fetch('/admin/config/db', {
         method: 'POST',
-        body: fd
-      }).then(() => window.location.reload());
+        body: fd,
+        headers: { 'Accept': 'application/json' }
+      })
+        .then(r => r.json())
+        .then(data => {
+          if (data.db_path) {
+            const disp = document.getElementById('db-path-display');
+            if (disp) {
+              disp.textContent = data.db_path;
+              disp.classList.remove('text-red-600', 'text-green-600');
+              const color = data.status === 'valid' ? 'text-green-600' : 'text-red-600';
+              disp.classList.add(color);
+            }
+          }
+        });
     });
   }
 
@@ -41,8 +54,19 @@ function initDatabaseControls() {
       if (!name) return;
       const fd = new FormData();
       fd.append('create_name', name);
-      fetch('/admin/config/db', { method: 'POST', body: fd })
-        .then(() => window.location.reload());
+      fetch('/admin/config/db', { method: 'POST', body: fd, headers: { 'Accept': 'application/json' } })
+        .then(r => r.json())
+        .then(data => {
+          if (data.db_path) {
+            const disp = document.getElementById('db-path-display');
+            if (disp) {
+              disp.textContent = data.db_path;
+              disp.classList.remove('text-red-600', 'text-green-600');
+              const color = data.status === 'valid' ? 'text-green-600' : 'text-red-600';
+              disp.classList.add(color);
+            }
+          }
+        });
     });
   }
 }

--- a/templates/config_admin.html
+++ b/templates/config_admin.html
@@ -11,10 +11,10 @@
       Database
     </summary>
     <div class="p-4 space-y-4">
-      <input type="text" id="db-path-display" value="{{ db_path }}" readonly class="border border-gray-300 rounded px-2 py-1 text-sm w-full" />
+      <div id="db-path-display" class="px-2 py-1 text-sm font-mono rounded {{ 'text-green-600' if db_status == 'valid' else 'text-red-600' }}">{{ db_path }}</div>
       <form id="db-upload-form" class="flex items-center space-x-2" enctype="multipart/form-data">
         <input type="file" name="file" accept=".db" class="text-sm border border-gray-300 rounded" />
-        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Use DB</button>
+        <button type="submit" class="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded border border-white hover:border-transparent">Change Database</button>
       </form>
       <button id="create-db-btn" type="button" class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded">Create New DB</button>
     </div>


### PR DESCRIPTION
## Summary
- improve db path status with helper `check_db_status`
- colorize status in config page and rename button
- return JSON when uploading/creating DB and update page dynamically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bf7344fd08333b2bd63727ca9822c