### PR TITLE
Add console logs for database upload

### DIFF
--- a/static/js/config_admin.js
+++ b/static/js/config_admin.js
@@ -24,17 +24,34 @@ function initLayoutDefaultsForms() {
 function initDatabaseControls() {
   const uploadForm = document.getElementById('db-upload-form');
   if (uploadForm) {
+    const fileInput = uploadForm.querySelector('input[type="file"]');
+    if (fileInput) {
+      fileInput.addEventListener('change', () => {
+        if (fileInput.files && fileInput.files.length > 0) {
+          console.log('File chosen:', fileInput.files[0].name);
+        } else {
+          console.log('File input cleared');
+        }
+      });
+    }
     uploadForm.addEventListener('submit', e => {
       e.preventDefault();
+      console.log('Change Database button clicked');
       const fd = new FormData(uploadForm);
       fetch('/admin/config/db', {
         method: 'POST',
         body: fd,
         headers: { 'Accept': 'application/json' }
       })
-        .then(r => r.json())
+        .then(r => {
+          if (!r.ok) {
+            throw new Error('Server responded with status ' + r.status);
+          }
+          return r.json();
+        })
         .then(data => {
           if (data.db_path) {
+            console.log('Database changed to', data.db_path);
             const disp = document.getElementById('db-path-display');
             if (disp) {
               disp.textContent = data.db_path;
@@ -42,7 +59,14 @@ function initDatabaseControls() {
               const color = data.status === 'valid' ? 'text-green-600' : 'text-red-600';
               disp.classList.add(color);
             }
+          } else if (data.error) {
+            console.error('Failed to change database:', data.error);
+          } else {
+            console.error('Failed to change database: no db_path returned');
           }
+        })
+        .catch(err => {
+          console.error('Failed to change database:', err);
         });
     });
   }


### PR DESCRIPTION
## Summary
- log when a database file is chosen
- log when the Change Database button is clicked
- log successes and failures returned from the server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bf99932b883339c56ac2683fbd191