### PR TITLE
Add initial setup wizard

### DIFF
--- a/templates/wizard_database.html
+++ b/templates/wizard_database.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Setup - Database{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Step 1: Choose or Create Database</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+  <div>
+    <label class="block mb-1">Upload Database File</label>
+    <input type="file" name="file" accept=".db" class="border rounded px-2 py-1">
+  </div>
+  <div>
+    <label class="block mb-1">Or create new database</label>
+    <input type="text" name="create_name" class="border rounded px-2 py-1" placeholder="name.db">
+  </div>
+  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Continue</button>
+</form>
+<p class="text-sm mt-4">Current path: {{ db_path }} ({{ db_status }})</p>
+{% endblock %}

--- a/templates/wizard_import.html
+++ b/templates/wizard_import.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Setup - Import Data{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Step 4: Import CSV Data (optional)</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+  <div>
+    <label class="block mb-1">Table</label>
+    <select name="table" class="border rounded px-2 py-1">
+      {% for t in base_tables %}
+      <option value="{{ t }}">{{ t }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div>
+    <label class="block mb-1">CSV File</label>
+    <input type="file" name="file" accept=".csv" class="border rounded px-2 py-1">
+  </div>
+  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Import</button>
+  <a href="{{ url_for('wizard.wizard_start') }}" class="ml-4 underline">Skip</a>
+</form>
+{% endblock %}

--- a/templates/wizard_settings.html
+++ b/templates/wizard_settings.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Setup - Settings{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Step 2: Configure Settings</h1>
+<form method="post" class="space-y-4">
+  <div>
+    <label class="block mb-1">Site Heading</label>
+    <input type="text" name="heading" value="{{ config.get('heading','') }}" class="border rounded px-2 py-1 w-full">
+  </div>
+  <div>
+    <label class="block mb-1">Logging Level</label>
+    <select name="log_level" class="border rounded px-2 py-1">
+      {% for lvl in ['DEBUG','INFO','WARNING','ERROR'] %}
+      <option value="{{ lvl }}" {% if config.get('log_level') == lvl %}selected{% endif %}>{{ lvl }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Continue</button>
+</form>
+{% endblock %}

--- a/templates/wizard_table.html
+++ b/templates/wizard_table.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Setup - Base Table{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Step 3: Create Base Table</h1>
+<form method="post" class="space-y-4">
+  <div>
+    <label class="block mb-1">Table Name</label>
+    <input type="text" name="table_name" class="border rounded px-2 py-1 w-full">
+  </div>
+  <div>
+    <label class="block mb-1">Description</label>
+    <input type="text" name="description" class="border rounded px-2 py-1 w-full">
+  </div>
+  <div>
+    <label class="block mb-1">Fields (one per line: name:type)</label>
+    <textarea name="fields" rows="4" class="border rounded px-2 py-1 w-full"></textarea>
+  </div>
+  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Continue</button>
+</form>
+{% endblock %}

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -1,0 +1,129 @@
+from flask import Blueprint, render_template, request, redirect, url_for, session, current_app
+from werkzeug.utils import secure_filename
+import os
+from db.database import DB_PATH, check_db_status
+from db.config import update_config, get_all_config
+from db.schema import create_base_table, refresh_card_cache
+from db.edit_fields import add_column_to_table, add_field_to_schema
+from imports.import_csv import parse_csv
+from db.records import create_record
+from views.admin import write_local_settings
+
+wizard_bp = Blueprint('wizard', __name__)
+
+
+def _next_step():
+    progress = session.get('wizard_progress', {})
+    if not progress.get('database'):
+        return 'wizard.database_step'
+    if not progress.get('settings'):
+        return 'wizard.settings_step'
+    if not progress.get('table'):
+        return 'wizard.table_step'
+    if not progress.get('import'):
+        return 'wizard.import_step'
+    return None
+
+
+@wizard_bp.route('/wizard/')
+def wizard_start():
+    next_ep = _next_step()
+    if next_ep:
+        return redirect(url_for(next_ep))
+    session['wizard_complete'] = True
+    session.pop('wizard_progress', None)
+    return redirect(url_for('home'))
+
+
+@wizard_bp.route('/wizard/database', methods=['GET', 'POST'])
+def database_step():
+    progress = session.setdefault('wizard_progress', {})
+    if request.method == 'POST':
+        if 'file' in request.files and request.files['file'].filename:
+            file = request.files['file']
+            filename = secure_filename(file.filename)
+            if filename.endswith('.db'):
+                save_path = os.path.join('data', filename)
+                file.save(save_path)
+                update_config('db_path', save_path)
+                write_local_settings(save_path)
+        name = request.form.get('create_name')
+        if name:
+            filename = secure_filename(name)
+            if not filename.endswith('.db'):
+                filename += '.db'
+            save_path = os.path.join('data', filename)
+            open(save_path, 'a').close()
+            update_config('db_path', save_path)
+            write_local_settings(save_path)
+        progress['database'] = True
+        session['wizard_progress'] = progress
+        return redirect(url_for('wizard.settings_step'))
+    status = check_db_status(DB_PATH)
+    return render_template('wizard_database.html', db_path=DB_PATH, db_status=status)
+
+
+@wizard_bp.route('/wizard/settings', methods=['GET', 'POST'])
+def settings_step():
+    progress = session.setdefault('wizard_progress', {})
+    config = get_all_config()
+    if request.method == 'POST':
+        heading = request.form.get('heading')
+        level = request.form.get('log_level')
+        if heading is not None:
+            update_config('heading', heading)
+        if level is not None:
+            update_config('log_level', level)
+        progress['settings'] = True
+        session['wizard_progress'] = progress
+        return redirect(url_for('wizard.table_step'))
+    return render_template('wizard_settings.html', config=config)
+
+
+@wizard_bp.route('/wizard/table', methods=['GET', 'POST'])
+def table_step():
+    progress = session.setdefault('wizard_progress', {})
+    if request.method == 'POST':
+        table_name = (request.form.get('table_name') or '').strip()
+        description = (request.form.get('description') or '').strip()
+        fields_text = request.form.get('fields', '')
+        if table_name:
+            if create_base_table(table_name, description):
+                for line in fields_text.splitlines():
+                    if ':' in line:
+                        name, ftype = [p.strip() for p in line.split(':', 1)]
+                        if name:
+                            try:
+                                add_column_to_table(table_name, name, ftype)
+                                add_field_to_schema(table_name, name, ftype)
+                            except Exception:
+                                current_app.logger.exception('Failed to add field %s', name)
+                card_info, base_tables = refresh_card_cache()
+                current_app.config['CARD_INFO'] = card_info
+                current_app.config['BASE_TABLES'] = base_tables
+                progress['table'] = True
+                session['wizard_progress'] = progress
+                return redirect(url_for('wizard.import_step'))
+    return render_template('wizard_table.html')
+
+
+@wizard_bp.route('/wizard/import', methods=['GET', 'POST'])
+def import_step():
+    progress = session.setdefault('wizard_progress', {})
+    base_tables = current_app.config.get('BASE_TABLES', [])
+    if request.method == 'POST':
+        table = request.form.get('table')
+        file = request.files.get('file')
+        if table and file and file.filename.endswith('.csv'):
+            headers, rows = parse_csv(file)
+            for row in rows:
+                try:
+                    create_record(table, row)
+                except Exception:
+                    current_app.logger.exception('Failed to import row')
+        progress['import'] = True
+        session['wizard_progress'] = progress
+        session['wizard_complete'] = True
+        session.pop('wizard_progress', None)
+        return redirect(url_for('home'))
+    return render_template('wizard_import.html', base_tables=base_tables)


### PR DESCRIPTION
## Summary
- register new `views.wizard` blueprint
- add wizard steps for database selection, settings, table creation and CSV import
- enforce wizard completion via session before main app access
- expose flag in `main.py` to run wizard when DB is freshly created or config missing
- create templates for each wizard step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bff5dab508333a78a884a7fff1c7d