### PR TITLE
Improve new database workflow

### DIFF
--- a/static/js/config_admin.js
+++ b/static/js/config_admin.js
@@ -50,6 +50,10 @@ function initDatabaseControls() {
           return r.json();
         })
         .then(data => {
+          if (data.redirect) {
+            window.location.href = data.redirect;
+            return;
+          }
           if (data.db_path) {
             console.log('Database changed to', data.db_path);
             const disp = document.getElementById('db-path-display');
@@ -81,6 +85,10 @@ function initDatabaseControls() {
       fetch('/admin/config/db', { method: 'POST', body: fd, headers: { 'Accept': 'application/json' } })
         .then(r => r.json())
         .then(data => {
+          if (data.redirect) {
+            window.location.href = data.redirect;
+            return;
+          }
           if (data.db_path) {
             const disp = document.getElementById('db-path-display');
             if (disp) {

--- a/views/admin.py
+++ b/views/admin.py
@@ -6,6 +6,7 @@ from flask import (
     request,
     jsonify,
     current_app,
+    session,
 )
 import json
 import os
@@ -121,8 +122,16 @@ def update_database_file():
         open(save_path, 'a').close()
         update_config('db_path', save_path)
         write_local_settings(save_path)
+        session['wizard_progress'] = {'database': True, 'skip_import': True}
+        session.pop('wizard_complete', None)
+        current_app.config['WIZARD_REQUIRED'] = True
         if wants_json:
-            return jsonify({'db_path': save_path, 'status': check_db_status(save_path)})
+            return jsonify({
+                'db_path': save_path,
+                'status': check_db_status(save_path),
+                'redirect': url_for('wizard.wizard_start'),
+            })
+        return redirect(url_for('wizard.wizard_start'))
     if wants_json:
         return jsonify({'error': 'no_file'})
     return redirect(url_for('admin.config_page'))

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -1,4 +1,12 @@
-from flask import Blueprint, render_template, request, redirect, url_for, session, current_app
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    session,
+    current_app,
+)
 from werkzeug.utils import secure_filename
 import os
 from db.database import DB_PATH, check_db_status
@@ -20,7 +28,7 @@ def _next_step():
         return 'wizard.settings_step'
     if not progress.get('table'):
         return 'wizard.table_step'
-    if not progress.get('import'):
+    if not progress.get('skip_import') and not progress.get('import'):
         return 'wizard.import_step'
     return None
 
@@ -110,6 +118,13 @@ def table_step():
 @wizard_bp.route('/wizard/import', methods=['GET', 'POST'])
 def import_step():
     progress = session.setdefault('wizard_progress', {})
+    if progress.get('skip_import'):
+        progress['import'] = True
+        session['wizard_progress'] = progress
+        session['wizard_complete'] = True
+        session.pop('wizard_progress', None)
+        return redirect(url_for('home'))
+
     base_tables = current_app.config.get('BASE_TABLES', [])
     if request.method == 'POST':
         table = request.form.get('table')


### PR DESCRIPTION
## Summary
- skip import step for wizard when creating a database from config
- redirect straight to wizard when a new DB is created
- handle redirect in config admin JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c079ce1e0833390b3fa205d61470f