### PR TITLE
Improve wizard table step

### DIFF
--- a/static/js/wizard_table.js
+++ b/static/js/wizard_table.js
@@ -1,0 +1,65 @@
+let fields = [];
+
+function showAddFieldModal() {
+  document.getElementById('addFieldModal').classList.remove('hidden');
+}
+
+function hideAddFieldModal() {
+  document.getElementById('addFieldModal').classList.add('hidden');
+}
+
+function resetAddFieldForm() {
+  const form = document.getElementById('field-form');
+  form.reset();
+  const optionsContainer = document.getElementById('field-options-container');
+  const fkContainer = document.getElementById('fk-select-container');
+  if (optionsContainer) optionsContainer.classList.add('hidden');
+  if (fkContainer) fkContainer.classList.add('hidden');
+}
+
+function addField(e) {
+  e.preventDefault();
+  const form = e.target;
+  const name = form.field_name.value.trim();
+  const type = form.field_type.value;
+  if (!name || !type || type === 'Select type') return;
+
+  const optionsText = form.field_options ? form.field_options.value.trim() : '';
+  const options = optionsText ? optionsText.split(',').map(o => o.trim()).filter(o => o) : [];
+  const fk = form.foreign_key_target ? form.foreign_key_target.value : '';
+
+  fields.push({name, type, options, foreign_key: fk});
+  updateFieldList();
+  hideAddFieldModal();
+  resetAddFieldForm();
+}
+
+function removeField(index) {
+  fields.splice(index, 1);
+  updateFieldList();
+}
+
+function updateFieldList() {
+  const list = document.getElementById('fields-list');
+  list.innerHTML = '';
+  fields.forEach((f, idx) => {
+    const li = document.createElement('li');
+    li.className = 'flex justify-between items-center';
+    li.innerHTML = `<span>${f.name} (${f.type})</span>`;
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = '×';
+    btn.className = 'text-red-600 ml-2';
+    btn.onclick = () => removeField(idx);
+    li.appendChild(btn);
+    list.appendChild(li);
+  });
+  document.getElementById('fields_json').value = JSON.stringify(fields);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('field-form').addEventListener('submit', addField);
+});
+
+window.showAddFieldModal = showAddFieldModal;
+window.hideAddFieldModal = hideAddFieldModal;

--- a/templates/wizard_table.html
+++ b/templates/wizard_table.html
@@ -2,7 +2,7 @@
 {% block title %}Setup - Base Table{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">Step 3: Create Base Table</h1>
-<form method="post" class="space-y-4">
+<form method="post" id="table-form" class="space-y-4">
   <div>
     <label class="block mb-1">Table Name</label>
     <input type="text" name="table_name" class="border rounded px-2 py-1 w-full">
@@ -11,10 +11,63 @@
     <label class="block mb-1">Description</label>
     <input type="text" name="description" class="border rounded px-2 py-1 w-full">
   </div>
+  <input type="hidden" name="fields_json" id="fields_json">
   <div>
-    <label class="block mb-1">Fields (one per line: name:type)</label>
-    <textarea name="fields" rows="4" class="border rounded px-2 py-1 w-full"></textarea>
+    <h2 class="font-semibold mb-2">Fields</h2>
+    <ul id="fields-list" class="mb-2 list-disc pl-5"></ul>
+    <button type="button" onclick="showAddFieldModal()" class="bg-gray-200 px-2 py-1 rounded">Add Field</button>
   </div>
   <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Continue</button>
 </form>
+
+<!-- Add Field Modal -->
+<div id="addFieldModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50" onclick="if(event.target.id === 'addFieldModal') hideAddFieldModal()">
+  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+    <button type="button" onclick="hideAddFieldModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
+    <form id="field-form" class="space-y-4">
+      <div>
+        <label class="block mb-2 text-sm font-medium">Field Name</label>
+        <input name="field_name" type="text" class="w-full border px-3 py-2 rounded" required>
+      </div>
+      <div>
+        <label class="block mb-2 text-sm font-medium">Field Type</label>
+        {% set types_seen = [] %}
+        <select id="field_type" name="field_type" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200" required>
+          <option disabled selected>Select type</option>
+          {% for table_fields in field_schema.values() %}
+            {% for field, meta in table_fields.items() %}
+              {% if meta.type not in types_seen %}
+                {% do types_seen.append(meta.type) %}
+                <option value="{{ meta.type }}">{{ meta.type }}</option>
+              {% endif %}
+            {% endfor %}
+          {% endfor %}
+        </select>
+      </div>
+      <div id="field-options-container" class="hidden">
+        <label class="block mb-2 text-sm font-medium">Options (comma-separated)</label>
+        <textarea name="field_options" rows="3" class="w-full border px-3 py-2 rounded"></textarea>
+      </div>
+      <div id="fk-select-container" class="hidden">
+        <label class="block mb-2 text-sm font-medium">Select linked field</label>
+        <select name="foreign_key_target" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200">
+          <option value="" disabled selected>Select field</option>
+          {% for source_table, fields in field_schema.items() %}
+            {% for field, meta in fields.items() %}
+              {% if meta.type in ['select', 'multi_select'] %}
+                <option value="{{ source_table }}.{{ field }}">{{ source_table }} → {{ field }}</option>
+              {% endif %}
+            {% endfor %}
+          {% endfor %}
+        </select>
+      </div>
+      <div class="flex justify-end">
+        <button type="submit" class="px-4 py-2 rounded bg-green-500 text-white hover:bg-green-600">Add</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script src="{{ url_for('static', filename='js/edit_fields.js') }}"></script>
+<script src="{{ url_for('static', filename='js/wizard_table.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enhance wizard table step with dynamic field list
- add wizard_table.js for client-side field management
- parse fields_json on server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0cd54fe483339eb8aacb468a3cf9