### PR TITLE
Remove wizard enforcement

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,23 +47,12 @@ with get_connection() as conn:
     app.config['CARD_INFO'] = load_card_info(conn)
     app.config['BASE_TABLES'] = load_base_tables(conn)
 
-config_values = get_all_config()
-wizard_required = needs_init or not config_values.get('heading')
-app.config['WIZARD_REQUIRED'] = wizard_required
-
 configure_logging(app)
 
 werk_logger = logging.getLogger("werkzeug")
 werk_logger.disabled = True
 
 app.before_request(start_timer)
-
-
-@app.before_request
-def enforce_wizard():
-    if current_app.config.get('WIZARD_REQUIRED') and not session.get('wizard_complete'):
-        if request.blueprint != 'wizard' and not request.path.startswith('/static'):
-            return redirect(url_for('wizard.wizard_start'))
 
 app.after_request(log_request)
 app.teardown_request(log_exception)

--- a/views/admin.py
+++ b/views/admin.py
@@ -124,7 +124,6 @@ def update_database_file():
         write_local_settings(save_path)
         session['wizard_progress'] = {'database': True, 'skip_import': True}
         session.pop('wizard_complete', None)
-        current_app.config['WIZARD_REQUIRED'] = True
         if wants_json:
             return jsonify({
                 'db_path': save_path,


### PR DESCRIPTION
## Summary
- eliminate the WIZARD_REQUIRED setting
- drop the `enforce_wizard` redirect middleware
- keep wizard progress but stop forcing the flow when creating a new DB

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c2d0e37008333adc5d4fd147daff5