### PR TITLE
Add skip-import wizard route

### DIFF
--- a/templates/wizard_import.html
+++ b/templates/wizard_import.html
@@ -16,6 +16,6 @@
     <input type="file" name="file" accept=".csv" class="border rounded px-2 py-1">
   </div>
   <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Import</button>
-  <a href="{{ url_for('wizard.wizard_start') }}" class="ml-4 underline">Skip</a>
+  <a href="{{ url_for('wizard.skip_import') }}" class="ml-4 underline">Skip</a>
 </form>
 {% endblock %}

--- a/tests/test_wizard_skip.py
+++ b/tests/test_wizard_skip.py
@@ -1,0 +1,17 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from main import app
+
+app.testing = True
+client = app.test_client()
+
+
+def test_skip_import_route():
+    with client.session_transaction() as sess:
+        sess['wizard_progress'] = {'database': True, 'settings': True, 'table': True}
+    resp = client.get('/wizard/skip-import', follow_redirects=True)
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess.get('wizard_complete') is True
+        assert 'wizard_progress' not in sess

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -44,6 +44,14 @@ def wizard_start():
     return redirect(url_for('home'))
 
 
+@wizard_bp.route('/wizard/skip-import')
+def skip_import():
+    progress = session.setdefault('wizard_progress', {})
+    progress['skip_import'] = True
+    session['wizard_progress'] = progress
+    return redirect(url_for('wizard.wizard_start'))
+
+
 @wizard_bp.route('/wizard/database', methods=['GET', 'POST'])
 def database_step():
     progress = session.setdefault('wizard_progress', {})


### PR DESCRIPTION
## Summary
- add a dedicated `/wizard/skip-import` route
- update the skip link in the wizard import template
- test that skipping import completes the wizard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3312e47083338aa54e56ed63760b