### PR TITLE
Inject layout defaults from registry

### DIFF
--- a/static/js/layout_editor.js
+++ b/static/js/layout_editor.js
@@ -1,26 +1,15 @@
 const PCT_SNAP = 5;                // snap to 5% steps
 let CONTAINER_WIDTH;
 
-const defaultFieldWidth = {
-  textarea:  12,
-  select: 5,
-  text: 12,
-  foreign_key: 5,
-  boolean: 3,
-  number: 4,
-  multi_select: 6,
-  url: 12
-};
-const defaultFieldHeight = {
-  textarea:  18,
-  select: 4,
-  text: 4,
-  foreign_key: 10,
-  boolean: 7,
-  number: 3,
-  multi_select: 8,
-  url: 4
-};
+const defaultFieldWidth = {};
+const defaultFieldHeight = {};
+if (window.FIELD_LAYOUT_DEFAULTS) {
+  for (const [type, sizes] of Object.entries(window.FIELD_LAYOUT_DEFAULTS)) {
+    const [w, h] = sizes;
+    defaultFieldWidth[type] = w;
+    defaultFieldHeight[type] = h;
+  }
+}
 
 function initLayout() {
   const layoutGrid = document.getElementById('layout-grid');

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -167,6 +167,7 @@
 </div>
 
 <script>const layoutCache = {{ field_schema_layout | tojson }};</script>
+<script>window.FIELD_LAYOUT_DEFAULTS = {{ field_layout_defaults | tojson }};</script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.draggable-field').forEach(el => {

--- a/utils/field_registry.py
+++ b/utils/field_registry.py
@@ -16,3 +16,11 @@ def register_type(name, sql_type='TEXT', validator=None, default_width=6, defaul
 def get_field_type(name):
     return FIELD_TYPES.get(name)
 
+
+def get_type_size_map():
+    """Return mapping of field type -> (default_width, default_height)."""
+    return {
+        name: (ft.default_width, ft.default_height)
+        for name, ft in FIELD_TYPES.items()
+    }
+


### PR DESCRIPTION
## Summary
- centralize default field size lookup in `get_type_size_map`
- use registry helper in `add_field_to_schema`
- expose defaults to the frontend via `detail_view.html`
- read defaults from `window.FIELD_LAYOUT_DEFAULTS` in the layout editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c33259db48333a596f463a1a83b2d