### PR TITLE
Initialize uploaded database and reload path

### DIFF
--- a/db/config.py
+++ b/db/config.py
@@ -87,7 +87,7 @@ def update_config(key: str, value: str) -> int:
         # use the newly configured location.
         from db.database import init_db_path
 
-        init_db_path()
+        init_db_path(value)
 
     return affected
 

--- a/db/database.py
+++ b/db/database.py
@@ -25,12 +25,25 @@ DB_PATH = os.path.abspath(
 )
 
 
-def init_db_path() -> None:
-    """Override DB_PATH using database config if available."""
-    global DB_PATH
+def init_db_path(path: str | None = None) -> None:
+    """Set DB_PATH from arguments, environment, local settings or database config."""
+    global DB_PATH, LOCAL_DB_PATH
+    if path:
+        DB_PATH = os.path.abspath(path)
+        return
+
     env_path = os.environ.get("CROSSBOOK_DB_PATH")
     if env_path:
         env_path = os.path.abspath(env_path)
+
+    try:
+        import importlib
+        ls = importlib.import_module("local_settings")
+        importlib.reload(ls)
+        LOCAL_DB_PATH = getattr(ls, "CROSSBOOK_DB_PATH", None)
+    except Exception:
+        LOCAL_DB_PATH = None
+
     local_path = LOCAL_DB_PATH
     if local_path:
         local_path = os.path.abspath(local_path)

--- a/tests/test_wizard_database.py
+++ b/tests/test_wizard_database.py
@@ -1,0 +1,38 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from main import app
+import db.database as db_database
+from db.config import get_all_config
+
+app.testing = True
+client = app.test_client()
+
+
+def test_settings_step_after_db_creation():
+    new_name = 'test_created.db'
+    orig_settings = ''
+    if os.path.exists('local_settings.py'):
+        with open('local_settings.py') as fh:
+            orig_settings = fh.read()
+    # ensure file removed if exists from prior runs
+    try:
+        os.remove(os.path.join('data', new_name))
+    except FileNotFoundError:
+        pass
+
+    resp = client.post('/wizard/database', data={'create_name': new_name}, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'Step 2' in resp.data
+    assert os.path.abspath(os.path.join('data', new_name)) == db_database.DB_PATH
+
+    config = get_all_config()
+    assert config.get('db_path')
+    assert 'heading' in config
+
+    # restore original test database
+    from db.database import init_db_path
+    init_db_path('data/crossbook.db')
+    if orig_settings:
+        with open('local_settings.py', 'w') as fh:
+            fh.write(orig_settings)

--- a/views/admin.py
+++ b/views/admin.py
@@ -25,7 +25,8 @@ from db.schema import create_base_table, refresh_card_cache
 from imports.import_csv import parse_csv
 from utils.validation import validation_sorter
 from db.schema import get_field_schema
-from db.database import get_connection, check_db_status
+from db.database import get_connection, check_db_status, init_db_path
+from db.bootstrap import initialize_database
 from imports.tasks import huey, process_import, init_import_table
 
 admin_bp = Blueprint('admin', __name__)
@@ -115,6 +116,8 @@ def update_database_file():
             return redirect(url_for('admin.database_page'))
         save_path = os.path.join('data', filename)
         file.save(save_path)
+        initialize_database(save_path)
+        init_db_path(save_path)
         update_config('db_path', save_path)
         write_local_settings(save_path)
         if wants_json:
@@ -128,6 +131,8 @@ def update_database_file():
             filename += '.db'
         save_path = os.path.join('data', filename)
         open(save_path, 'a').close()
+        initialize_database(save_path)
+        init_db_path(save_path)
         update_config('db_path', save_path)
         write_local_settings(save_path)
         session['wizard_progress'] = {'database': True, 'skip_import': True}

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -10,7 +10,8 @@ from flask import (
 from werkzeug.utils import secure_filename
 import os
 import json
-from db.database import DB_PATH, check_db_status
+from db.database import DB_PATH, check_db_status, init_db_path
+from db.bootstrap import initialize_database
 from db.config import update_config, get_all_config
 from db.schema import create_base_table, refresh_card_cache
 from db.edit_fields import add_column_to_table, add_field_to_schema
@@ -62,6 +63,8 @@ def database_step():
             if filename.endswith('.db'):
                 save_path = os.path.join('data', filename)
                 file.save(save_path)
+                initialize_database(save_path)
+                init_db_path(save_path)
                 update_config('db_path', save_path)
                 write_local_settings(save_path)
         name = request.form.get('create_name')
@@ -71,6 +74,8 @@ def database_step():
                 filename += '.db'
             save_path = os.path.join('data', filename)
             open(save_path, 'a').close()
+            initialize_database(save_path)
+            init_db_path(save_path)
             update_config('db_path', save_path)
             write_local_settings(save_path)
         progress['database'] = True


### PR DESCRIPTION
## Summary
- allow `init_db_path` to accept a path and reload local settings
- update config writes to refresh DB path
- initialize new databases when uploaded or created
- reload db path immediately after uploading/creating database
- test that wizard can read from new database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c341019dc8333af2ede41271f2819