### PR TITLE
Add field type API and dynamic dropdowns

### DIFF
--- a/static/js/edit_fields.js
+++ b/static/js/edit_fields.js
@@ -2,9 +2,21 @@ document.addEventListener("DOMContentLoaded", () => {
     const fieldTypeSelect = document.getElementById("field_type");
     const optionsContainer = document.getElementById("field-options-container");
     const fkSelectContainer = document.getElementById("fk-select-container");
-  
+
     if (!fieldTypeSelect) return;
-  
+
+    fetch('/api/field-types')
+      .then(res => res.json())
+      .then(types => {
+        types.forEach(t => {
+          const opt = document.createElement('option');
+          opt.value = t;
+          opt.textContent = t;
+          fieldTypeSelect.appendChild(opt);
+        });
+      })
+      .catch(() => {});
+
     fieldTypeSelect.addEventListener("change", () => {
       const type = fieldTypeSelect.value;
   

--- a/static/js/wizard_table.js
+++ b/static/js/wizard_table.js
@@ -58,6 +58,41 @@ function updateFieldList() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  const select = document.getElementById('field_type');
+  if (select) {
+    fetch('/api/field-types')
+      .then(res => res.json())
+      .then(types => {
+        types.forEach(t => {
+          const opt = document.createElement('option');
+          opt.value = t;
+          opt.textContent = t;
+          select.appendChild(opt);
+        });
+      })
+      .catch(() => {});
+
+    select.addEventListener('change', () => {
+      const type = select.value;
+      const optionsContainer = document.getElementById('field-options-container');
+      const fkContainer = document.getElementById('fk-select-container');
+      if (optionsContainer) {
+        if (type === 'select' || type === 'multi_select') {
+          optionsContainer.classList.remove('hidden');
+        } else {
+          optionsContainer.classList.add('hidden');
+        }
+      }
+      if (fkContainer) {
+        if (type === 'foreign_key') {
+          fkContainer.classList.remove('hidden');
+        } else {
+          fkContainer.classList.add('hidden');
+        }
+      }
+    });
+  }
+
   document.getElementById('field-form').addEventListener('submit', addField);
 });
 

--- a/templates/edit_fields_modal.html
+++ b/templates/edit_fields_modal.html
@@ -24,17 +24,8 @@
         <label class="block mb-2 text-sm font-medium">Field Name</label>
         <input name="field_name" type="text" class="w-full border px-3 py-2 rounded mb-4" required>
         <label class="block mb-2 text-sm font-medium">Field Type</label>
-        {% set types_seen = [] %}
         <select id="field_type" name="field_type" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200">
           <option disabled selected>Select type</option>
-          {% for table_fields in field_schema.values() %}
-            {% for field, meta in table_fields.items() %}
-              {% if meta.type not in types_seen %}
-                {% do types_seen.append(meta.type) %}
-                <option value="{{ meta.type }}">{{ meta.type }}</option>
-              {% endif %}
-            {% endfor %}
-          {% endfor %}
         </select>
         <div id="field-options-container" class="hidden mb-4">
           <label class="block mb-2 text-sm font-medium">Options (comma-separated)</label>

--- a/templates/wizard_table.html
+++ b/templates/wizard_table.html
@@ -31,17 +31,8 @@
       </div>
       <div>
         <label class="block mb-2 text-sm font-medium">Field Type</label>
-        {% set types_seen = [] %}
         <select id="field_type" name="field_type" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200" required>
           <option disabled selected>Select type</option>
-          {% for table_fields in field_schema.values() %}
-            {% for field, meta in table_fields.items() %}
-              {% if meta.type not in types_seen %}
-                {% do types_seen.append(meta.type) %}
-                <option value="{{ meta.type }}">{{ meta.type }}</option>
-              {% endif %}
-            {% endfor %}
-          {% endfor %}
         </select>
       </div>
       <div id="field-options-container" class="hidden">

--- a/views/admin.py
+++ b/views/admin.py
@@ -28,6 +28,7 @@ from db.schema import get_field_schema
 from db.database import get_connection, check_db_status, init_db_path
 from db.bootstrap import initialize_database
 from imports.tasks import huey, process_import, init_import_table
+from utils.field_registry import FIELD_TYPES
 
 admin_bp = Blueprint('admin', __name__)
 
@@ -258,6 +259,12 @@ def dashboard_filtered_records():
     except ValueError:
         return jsonify([]), 400
     return jsonify(data)
+
+
+@admin_bp.route('/api/field-types')
+def api_field_types():
+    """Return list of available field types."""
+    return jsonify(list(FIELD_TYPES.keys()))
 
 @admin_bp.route('/add-table', methods=['POST'])
 def add_table():


### PR DESCRIPTION
## Summary
- expose `/api/field-types` for available field types
- populate field type selectors dynamically in wizard and editor
- adjust modals and JS accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c377e84e48333900a0116b73a2ccc