### PR TITLE
Ensure UI reloads table list after changing database

### DIFF
--- a/static/js/database_admin.js
+++ b/static/js/database_admin.js
@@ -38,6 +38,7 @@ function initDatabaseControls() {
               const color = data.status === 'valid' ? 'text-green-600' : 'text-red-600';
               disp.classList.add(color);
             }
+            window.location.reload();
           } else if (data.error) {
             console.error('Failed to change database:', data.error);
           } else {
@@ -72,6 +73,7 @@ function initDatabaseControls() {
               const color = data.status === 'valid' ? 'text-green-600' : 'text-red-600';
               disp.classList.add(color);
             }
+            window.location.reload();
           }
         });
     });

--- a/views/admin.py
+++ b/views/admin.py
@@ -120,6 +120,9 @@ def update_database_file():
         init_db_path(save_path)
         update_config('db_path', save_path)
         write_local_settings(save_path)
+        card_info, base_tables = refresh_card_cache()
+        current_app.config['CARD_INFO'] = card_info
+        current_app.config['BASE_TABLES'] = base_tables
         if wants_json:
             return jsonify({'db_path': save_path, 'status': check_db_status(save_path)})
         return redirect(url_for('admin.database_page'))
@@ -135,6 +138,9 @@ def update_database_file():
         init_db_path(save_path)
         update_config('db_path', save_path)
         write_local_settings(save_path)
+        card_info, base_tables = refresh_card_cache()
+        current_app.config['CARD_INFO'] = card_info
+        current_app.config['BASE_TABLES'] = base_tables
         session['wizard_progress'] = {'database': True, 'skip_import': True}
         session.pop('wizard_complete', None)
         if wants_json:


### PR DESCRIPTION
## Summary
- refresh cached table metadata when the database file changes
- reload the page after a database change to update navigation

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3808d9fc833396d4a7381970c064