### PR TITLE
Ensure UI reloads table list after changing database

### DIFF
--- a/static/js/database_admin.js
+++ b/static/js/database_admin.js
@@ -38,6 +38,7 @@ function initDatabaseControls() {
               const color = data.status === 'valid' ? 'text-green-600' : 'text-red-600';
               disp.classList.add(color);
             }
+            window.location.reload();
           } else if (data.error) {
             console.error('Failed to change database:', data.error);
           } else {
@@ -72,6 +73,7 @@ function initDatabaseControls() {
               const color = data.status === 'valid' ? 'text-green-600' : 'text-red-600';
               disp.classList.add(color);
             }
+            window.location.reload();
           }
         });
     });

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -7,6 +7,12 @@ from utils.field_registry import register_type, get_field_type
 logger = logging.getLogger(__name__)
 SCHEMA = get_field_schema()
 
+
+def reload_schema() -> None:
+    """Reload validation schema from the active database."""
+    global SCHEMA
+    SCHEMA = get_field_schema()
+
 def validation_sorter(table, field, header, fieldType, values):
     logger.debug("✅ Validation function was triggered.")
 

--- a/views/admin.py
+++ b/views/admin.py
@@ -21,7 +21,7 @@ from db.dashboard import (
     get_top_numeric_values,
     get_filtered_records,
 )
-from db.schema import create_base_table, refresh_card_cache
+from db.schema import create_base_table, refresh_card_cache, update_foreign_field_options
 from imports.import_csv import parse_csv
 from utils.validation import validation_sorter
 from db.schema import get_field_schema
@@ -120,6 +120,12 @@ def update_database_file():
         init_db_path(save_path)
         update_config('db_path', save_path)
         write_local_settings(save_path)
+        card_info, base_tables = refresh_card_cache()
+        current_app.config['CARD_INFO'] = card_info
+        current_app.config['BASE_TABLES'] = base_tables
+        update_foreign_field_options()
+        from utils import validation
+        validation.reload_schema()
         if wants_json:
             return jsonify({'db_path': save_path, 'status': check_db_status(save_path)})
         return redirect(url_for('admin.database_page'))
@@ -135,6 +141,12 @@ def update_database_file():
         init_db_path(save_path)
         update_config('db_path', save_path)
         write_local_settings(save_path)
+        card_info, base_tables = refresh_card_cache()
+        current_app.config['CARD_INFO'] = card_info
+        current_app.config['BASE_TABLES'] = base_tables
+        update_foreign_field_options()
+        from utils import validation
+        validation.reload_schema()
         session['wizard_progress'] = {'database': True, 'skip_import': True}
         session.pop('wizard_complete', None)
         if wants_json:

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -13,7 +13,7 @@ import json
 from db.database import DB_PATH, check_db_status, init_db_path
 from db.bootstrap import initialize_database
 from db.config import update_config, get_all_config
-from db.schema import create_base_table, refresh_card_cache
+from db.schema import create_base_table, refresh_card_cache, update_foreign_field_options
 from db.edit_fields import add_column_to_table, add_field_to_schema
 from imports.import_csv import parse_csv
 from db.records import create_record
@@ -67,6 +67,12 @@ def database_step():
                 init_db_path(save_path)
                 update_config('db_path', save_path)
                 write_local_settings(save_path)
+                card_info, base_tables = refresh_card_cache()
+                current_app.config['CARD_INFO'] = card_info
+                current_app.config['BASE_TABLES'] = base_tables
+                update_foreign_field_options()
+                from utils import validation
+                validation.reload_schema()
         name = request.form.get('create_name')
         if name:
             filename = secure_filename(name)
@@ -78,6 +84,12 @@ def database_step():
             init_db_path(save_path)
             update_config('db_path', save_path)
             write_local_settings(save_path)
+            card_info, base_tables = refresh_card_cache()
+            current_app.config['CARD_INFO'] = card_info
+            current_app.config['BASE_TABLES'] = base_tables
+            update_foreign_field_options()
+            from utils import validation
+            validation.reload_schema()
         progress['database'] = True
         session['wizard_progress'] = progress
         return redirect(url_for('wizard.settings_step'))


### PR DESCRIPTION
## Summary
- refresh cached table metadata when the database file changes
- reload application schema and foreign key options for the new database

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c3808d9fc833396d4a7381970c064