### PR TITLE
Fix wizard DB change reloading

### DIFF
--- a/tests/test_api_records.py
+++ b/tests/test_api_records.py
@@ -6,6 +6,13 @@ from urllib.parse import parse_qs
 # Ensure the app module can be imported
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from main import app
+from db.database import init_db_path
+
+init_db_path('data/crossbook.db')
+try:
+    os.remove('local_settings.py')
+except FileNotFoundError:
+    pass
 
 app.testing = True
 client = app.test_client()

--- a/tests/test_wizard_database.py
+++ b/tests/test_wizard_database.py
@@ -32,7 +32,17 @@ def test_settings_step_after_db_creation():
 
     # restore original test database
     from db.database import init_db_path
+    from db.config import update_config
     init_db_path('data/crossbook.db')
+    update_config('db_path', 'data/crossbook.db')
+    from views.admin import reload_app_state
+    with app.app_context():
+        reload_app_state()
     if orig_settings:
         with open('local_settings.py', 'w') as fh:
             fh.write(orig_settings)
+    else:
+        try:
+            os.remove('local_settings.py')
+        except FileNotFoundError:
+            pass

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -67,6 +67,7 @@ def database_step():
                 init_db_path(save_path)
                 update_config('db_path', save_path)
                 write_local_settings(save_path)
+                reload_app_state()
         name = request.form.get('create_name')
         if name:
             filename = secure_filename(name)
@@ -78,6 +79,7 @@ def database_step():
             init_db_path(save_path)
             update_config('db_path', save_path)
             write_local_settings(save_path)
+            reload_app_state()
         progress['database'] = True
         session['wizard_progress'] = progress
         return redirect(url_for('wizard.settings_step'))


### PR DESCRIPTION
## Summary
- refresh global context variables when the wizard changes the database
- ensure tests reset DB path and remove local settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c489b81cc83338eb18a390c64653b