### PR TITLE
Adjust database init to skip base tables

### DIFF
--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -176,7 +176,7 @@ def _create_base_tables(cur: sqlite3.Cursor) -> None:
             )
 
 
-def _insert_defaults(cur: sqlite3.Cursor, path: str) -> None:
+def _insert_defaults(cur: sqlite3.Cursor, path: str, include_base_tables: bool = True) -> None:
     cur.execute("SELECT COUNT(*) FROM config")
     if cur.fetchone()[0] == 0:
         defaults = list(DEFAULT_CONFIGS)
@@ -195,54 +195,57 @@ def _insert_defaults(cur: sqlite3.Cursor, path: str) -> None:
             defaults,
         )
 
-    cur.execute("SELECT COUNT(*) FROM config_base_tables")
-    if cur.fetchone()[0] == 0:
-        cur.executemany(
-            "INSERT INTO config_base_tables (table_name, display_name, description, sort_order) "
-            "VALUES (?, ?, ?, ?)",
-            DEFAULT_BASE_TABLE_ROWS,
-        )
-
-    cur.execute("SELECT COUNT(*) FROM field_schema")
-    if cur.fetchone()[0] == 0:
-        rows = []
-        for table, fields in DEFAULT_FIELDS.items():
-            row_start = 0
-            for field, ftype in fields:
-                rows.append(
-                    (
-                        table,
-                        field,
-                        ftype,
-                        None,
-                        None,
-                        0,
-                        0,
-                        row_start,
-                        0,
-                        None,
-                    )
-                )
-                row_start += 1
-        cur.executemany(
-            """
-            INSERT INTO field_schema (
-                table_name, field_name, field_type, field_options, foreign_key,
-                col_start, col_span, row_start, row_span, styling
+    if include_base_tables:
+        cur.execute("SELECT COUNT(*) FROM config_base_tables")
+        if cur.fetchone()[0] == 0:
+            cur.executemany(
+                "INSERT INTO config_base_tables (table_name, display_name, description, sort_order) "
+                "VALUES (?, ?, ?, ?)",
+                DEFAULT_BASE_TABLE_ROWS,
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            rows,
-        )
+
+    if include_base_tables:
+        cur.execute("SELECT COUNT(*) FROM field_schema")
+        if cur.fetchone()[0] == 0:
+            rows = []
+            for table, fields in DEFAULT_FIELDS.items():
+                row_start = 0
+                for field, ftype in fields:
+                    rows.append(
+                        (
+                            table,
+                            field,
+                            ftype,
+                            None,
+                            None,
+                            0,
+                            0,
+                            row_start,
+                            0,
+                            None,
+                        )
+                    )
+                    row_start += 1
+            cur.executemany(
+                """
+                INSERT INTO field_schema (
+                    table_name, field_name, field_type, field_options, foreign_key,
+                    col_start, col_span, row_start, row_span, styling
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                rows,
+            )
 
 
-def initialize_database(path: str) -> None:
-    """Create a new database with core tables and default rows."""
+def initialize_database(path: str, include_base_tables: bool = True) -> None:
+    """Create a new database with core tables and optional base tables."""
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with sqlite3.connect(path) as conn:
         cur = conn.cursor()
         _create_core_tables(cur)
-        _create_base_tables(cur)
-        _insert_defaults(cur, path)
+        if include_base_tables:
+            _create_base_tables(cur)
+        _insert_defaults(cur, path, include_base_tables=include_base_tables)
         conn.commit()
 

--- a/views/admin.py
+++ b/views/admin.py
@@ -131,7 +131,7 @@ def update_database_file():
             return redirect(url_for('admin.database_page'))
         save_path = os.path.join('data', filename)
         file.save(save_path)
-        initialize_database(save_path)
+        initialize_database(save_path, include_base_tables=False)
         init_db_path(save_path)
         update_config('db_path', save_path)
         write_local_settings(save_path)
@@ -147,7 +147,7 @@ def update_database_file():
             filename += '.db'
         save_path = os.path.join('data', filename)
         open(save_path, 'a').close()
-        initialize_database(save_path)
+        initialize_database(save_path, include_base_tables=False)
         init_db_path(save_path)
         update_config('db_path', save_path)
         write_local_settings(save_path)

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -63,7 +63,7 @@ def database_step():
             if filename.endswith('.db'):
                 save_path = os.path.join('data', filename)
                 file.save(save_path)
-                initialize_database(save_path)
+                initialize_database(save_path, include_base_tables=False)
                 db_database.init_db_path(save_path)
                 update_config('db_path', save_path)
                 write_local_settings(save_path)
@@ -75,7 +75,7 @@ def database_step():
                 filename += '.db'
             save_path = os.path.join('data', filename)
             open(save_path, 'a').close()
-            initialize_database(save_path)
+            initialize_database(save_path, include_base_tables=False)
             db_database.init_db_path(save_path)
             update_config('db_path', save_path)
             write_local_settings(save_path)


### PR DESCRIPTION
## Summary
- allow database bootstrap to optionally exclude base tables
- create new DBs without prepopulated entity tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c55a04fd88333a462128161043994