### PR TITLE
Remove default bootstrap data

### DIFF
--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -1,6 +1,5 @@
 import os
 import sqlite3
-import json
 
 BASE_TABLES = [
     "content",
@@ -177,72 +176,16 @@ def _create_base_tables(cur: sqlite3.Cursor) -> None:
 
 
 def _insert_defaults(cur: sqlite3.Cursor, path: str) -> None:
-    cur.execute("SELECT COUNT(*) FROM config")
-    if cur.fetchone()[0] == 0:
-        defaults = list(DEFAULT_CONFIGS)
-        defaults.append(
-            (
-                "layout_defaults",
-                json.dumps(LAYOUT_DEFAULTS),
-                "layout",
-                "json",
-            )
-        )
-        defaults.append(("db_path", path, "database", "string"))
-        cur.executemany(
-            "INSERT INTO config (key, value, section, type, date_updated) "
-            "VALUES (?, ?, ?, ?, datetime('now'))",
-            defaults,
-        )
-
-    cur.execute("SELECT COUNT(*) FROM config_base_tables")
-    if cur.fetchone()[0] == 0:
-        cur.executemany(
-            "INSERT INTO config_base_tables (table_name, display_name, description, sort_order) "
-            "VALUES (?, ?, ?, ?)",
-            DEFAULT_BASE_TABLE_ROWS,
-        )
-
-    cur.execute("SELECT COUNT(*) FROM field_schema")
-    if cur.fetchone()[0] == 0:
-        rows = []
-        for table, fields in DEFAULT_FIELDS.items():
-            row_start = 0
-            for field, ftype in fields:
-                rows.append(
-                    (
-                        table,
-                        field,
-                        ftype,
-                        None,
-                        None,
-                        0,
-                        0,
-                        row_start,
-                        0,
-                        None,
-                    )
-                )
-                row_start += 1
-        cur.executemany(
-            """
-            INSERT INTO field_schema (
-                table_name, field_name, field_type, field_options, foreign_key,
-                col_start, col_span, row_start, row_span, styling
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            rows,
-        )
+    """Insert default rows into the core tables."""
+    # Defaults are intentionally omitted so new databases start empty.
+    return
 
 
 def initialize_database(path: str) -> None:
-    """Create a new database with core tables and default rows."""
+    """Create a new database containing only the core tables."""
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with sqlite3.connect(path) as conn:
         cur = conn.cursor()
         _create_core_tables(cur)
-        _create_base_tables(cur)
-        _insert_defaults(cur, path)
         conn.commit()
 

--- a/tests/test_wizard_database.py
+++ b/tests/test_wizard_database.py
@@ -27,8 +27,7 @@ def test_settings_step_after_db_creation():
     assert os.path.abspath(os.path.join('data', new_name)) == db_database.DB_PATH
 
     config = get_all_config()
-    assert config.get('db_path')
-    assert 'heading' in config
+    assert config == {}
 
     # restore original test database
     from db.database import init_db_path


### PR DESCRIPTION
## Summary
- avoid populating default configuration, base tables and field schema in the bootstrap logic
- only create the core tables when initializing a new database
- update wizard database test to expect empty config after initialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5932f76c83339dab0402112417b5