### PR TITLE
Remove env var fallback for database path

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Large files are not streamed—they are fully loaded into memory during parsing,
 
 * **Routing & Views:** Defined in `main.py` using Flask decorators; routes handle list, detail, new record, and error pages. A context processor (`@app.context_processor`) injects the `field_schema`—the in-memory representation of all table fields, types, options, and layout—into all templates and front-end scripts for dynamic form generation and validation. Error handlers (e.g., `@app.errorhandler(404)`) and `abort()` calls manage invalid requests.
 
-* **Configuration & Environment:** Dependencies listed in `requirements.txt`. The SQLite database path defaults to `data/crossbook.db` but can be overridden via the `CROSSBOOK_DB_PATH` environment variable or the `db_path` row of the `config` table.
+* **Configuration & Environment:** Dependencies listed in `requirements.txt`. The SQLite database path defaults to `data/crossbook.db` and is stored in the `db_path` row of the `config` table.
 
 * **Database Layer:** Uses Python’s built-in `sqlite3` in `db/database.py` for connection management. Schema introspection and migrations occur in `db/schema.py`. CRUD operations reside in `db/records.py`; many-to-many join logic in `db/relationships.py`. Validation rules live in `db/validation.py`, and field schema editing utilities in `db/edit_fields.py`.
 
@@ -235,7 +235,7 @@ This is the core of the Flask application. It defines the web routes, handles da
 **Global configuration and variables in `main.py`:**
 
 - **Flask App Initialization:** The Flask app is created with `static_url_path='/static'` so that files in the `static/` directory are served at the `/static` URL path.
-- **`DB_PATH`:** Path to the SQLite database file. Defaults to `data/crossbook.db` but may be overridden via the `CROSSBOOK_DB_PATH` environment variable or the `db_path` value stored in the `config` table. All modules obtain a connection using `with get_connection()` from `db/database.py`.
+- **`DB_PATH`:** Path to the SQLite database file. Defaults to `data/crossbook.db` but is updated from the `db_path` value stored in the `config` table. All modules obtain a connection using `with get_connection()` from `db/database.py`.
 - **`BASE_TABLES`:** Derived from the `config_base_tables` table via `load_base_tables()`. It contains all entity table names and is used to validate route parameters.
 - **`FIELD_SCHEMA`:** Retrieved via `get_field_schema()` whenever needed. It returns a dictionary in the form `{table: {field: {"type": ..., "options": [...], "foreign_key": ..., "layout": {...}, "styling": {...}}}}` describing how each field should be treated in the UI. The `styling` key contains any JSON-parsed styling instructions.
 - **`field_options`:** A `field_options` column in the `field_schema` table contains a JSON-encoded list of options for select fields (e.g., `["Elf", "Human"]`). These options are resolved on demand using the helper `get_field_options()`.
@@ -259,7 +259,7 @@ The following functions encapsulate the application logic:
 
 | Function & Signature                          | Purpose                                                             |
 |-----------------------------------------------|----------------------------------------------------------------------|
-| `get_connection()`                            | Context manager that yields a connection to the SQLite database using `DB_PATH`. The path may come from the `CROSSBOOK_DB_PATH` environment variable or the `db_path` setting in the `config` table. Use `with get_connection()` to ensure it closes automatically. |
+| `get_connection()`                            | Context manager that yields a connection to the SQLite database using `DB_PATH`. The path is loaded from the `db_path` setting in the `config` table. Use `with get_connection()` to ensure it closes automatically. |
 | `load_field_schema()`                         | Queries the database for all defined fields in the `field_schema` table and returns a nested dict of `{table: {field: {"type": ..., "options": [...], "foreign_key": ..., "layout": {...}}}}`. |
 | `get_field_options(table, field)`             | Retrieves a list of options for a given `select` field from the `field_schema` table. Returns a list parsed from the `field_options` column (assumed to be valid JSON), or an empty list if none is present or if parsing fails. Used at render time only inside templates that need it. |
 | `get_all_records(table, search=None)`         | Retrieves up to 1000 records from the specified table. If a `search` string is provided, it filters the results to those where any text-like field contains the search substring (case-insensitive). Only fields of type *text, textarea, select,* or *multi select* are searched. Returns a list of records as dictionaries (each dict maps field names to values). Logs the SQL query and catches any errors (returning an empty list on error). |

--- a/db/database.py
+++ b/db/database.py
@@ -20,21 +20,15 @@ try:
 except Exception:
     SUPPORTS_REGEX = False
 
-DB_PATH = os.path.abspath(
-    os.environ.get("CROSSBOOK_DB_PATH", LOCAL_DB_PATH or DEFAULT_DB_PATH)
-)
+DB_PATH = os.path.abspath(LOCAL_DB_PATH or DEFAULT_DB_PATH)
 
 
 def init_db_path(path: str | None = None) -> None:
-    """Set DB_PATH from arguments, environment, local settings or database config."""
+    """Set DB_PATH from arguments, local settings or database config."""
     global DB_PATH, LOCAL_DB_PATH
     if path:
         DB_PATH = os.path.abspath(path)
         return
-
-    env_path = os.environ.get("CROSSBOOK_DB_PATH")
-    if env_path:
-        env_path = os.path.abspath(env_path)
 
     try:
         import importlib
@@ -66,9 +60,7 @@ def init_db_path(path: str | None = None) -> None:
     except Exception:
         cfg_path = None
 
-    if env_path:
-        DB_PATH = env_path
-    elif local_path:
+    if local_path:
         DB_PATH = local_path
     elif cfg_path:
         DB_PATH = cfg_path


### PR DESCRIPTION
## Summary
- remove ability to override DB path with `CROSSBOOK_DB_PATH`
- document that the `db_path` config table is the source of truth

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c59d6f7b08333ba22a43414f6656d