### PR TITLE
Show selected record count in bulk edit modal

### DIFF
--- a/db/config.py
+++ b/db/config.py
@@ -79,6 +79,11 @@ def update_config(key: str, value: str) -> int:
             "UPDATE config SET value = ?, date_updated = ? WHERE key = ?",
             (value, timestamp, key),
         )
+        if cur.rowcount == 0:
+            cur.execute(
+                "INSERT INTO config (key, value, date_updated) VALUES (?, ?, ?)",
+                (key, value, timestamp),
+            )
         conn.commit()
         affected = cur.rowcount
 

--- a/static/js/bulk_edit_modal.js
+++ b/static/js/bulk_edit_modal.js
@@ -1,4 +1,5 @@
 export function openBulkEditModal() {
+  updateSelectedCount();
   document.getElementById('bulkEditModal').classList.remove('hidden');
 }
 
@@ -9,12 +10,21 @@ export function closeBulkEditModal() {
 let tableName;
 let bulkBtn;
 
+function updateSelectedCount() {
+  const count = document.querySelectorAll('.row-select:checked').length;
+  const el = document.getElementById('bulk-edit-count');
+  if (el) {
+    el.textContent = `${count} record${count === 1 ? '' : 's'} selected`;
+  }
+}
+
 function updateBulkButtonState() {
   const any = document.querySelectorAll('.row-select:checked').length > 0;
   if (bulkBtn) {
     bulkBtn.disabled = !any;
     bulkBtn.classList.toggle('opacity-50', !any);
   }
+  updateSelectedCount();
 }
 
 function buildInput() {

--- a/templates/bulk_edit_modal.html
+++ b/templates/bulk_edit_modal.html
@@ -2,7 +2,8 @@
      onclick="if(event.target.id === 'bulkEditModal') closeBulkEditModal()">
   <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button type="button" onclick="closeBulkEditModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
-    <h3 class="text-lg font-bold mb-4">Bulk Edit {{ table }}</h3>
+    <h3 class="text-lg font-bold">Bulk Edit {{ table }}</h3>
+    <p id="bulk-edit-count" class="text-sm text-gray-600 mb-4"></p>
     <form id="bulk-edit-form" class="space-y-4">
       <div>
         <label for="bulk-field" class="block text-sm font-medium text-gray-700 mb-1">Field</label>

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -66,6 +66,7 @@ def database_step():
                 initialize_database(save_path, include_base_tables=False)
                 db_database.init_db_path(save_path)
                 update_config('db_path', save_path)
+                update_config('heading', 'Load the glass cannons')
                 write_local_settings(save_path)
                 reload_app_state()
         name = request.form.get('create_name')
@@ -78,6 +79,7 @@ def database_step():
             initialize_database(save_path, include_base_tables=False)
             db_database.init_db_path(save_path)
             update_config('db_path', save_path)
+            update_config('heading', 'Load the glass cannons')
             write_local_settings(save_path)
             reload_app_state()
         progress['database'] = True


### PR DESCRIPTION
## Summary
- show count of selected rows in the bulk edit modal
- allow `update_config` to insert missing keys
- persist default heading when creating a new DB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5cb0b5c08333a9e5caeb95a506d7