### PR TITLE
Add configurable wizard settings

### DIFF
--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -181,6 +181,16 @@ def _insert_defaults(cur: sqlite3.Cursor, path: str, include_base_tables: bool =
     return
 
 
+def _insert_default_configs(cur: sqlite3.Cursor) -> None:
+    from datetime import datetime
+
+    ts = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    cur.executemany(
+        "INSERT INTO config (key, value, section, type, date_updated) VALUES (?, ?, ?, ?, ?)",
+        [(k, v, s, t, ts) for k, v, s, t in DEFAULT_CONFIGS],
+    )
+
+
 def initialize_database(path: str, include_base_tables: bool = False) -> None:
     """Create a new database with core tables."""
     os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -189,6 +199,6 @@ def initialize_database(path: str, include_base_tables: bool = False) -> None:
         _create_core_tables(cur)
         if include_base_tables:
             _create_base_tables(cur)
-        # Default records are no longer inserted
+        _insert_default_configs(cur)
         conn.commit()
 

--- a/db/config.py
+++ b/db/config.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from db.database import get_connection
+from db.bootstrap import DEFAULT_CONFIGS
 import json
 
 
@@ -79,6 +80,14 @@ def update_config(key: str, value: str) -> int:
             "UPDATE config SET value = ?, date_updated = ? WHERE key = ?",
             (value, timestamp, key),
         )
+        if cur.rowcount == 0:
+            meta = next((c for c in DEFAULT_CONFIGS if c[0] == key), None)
+            section = meta[2] if meta else "general"
+            ctype = meta[3] if meta else "string"
+            cur.execute(
+                "INSERT INTO config (key, value, section, type, date_updated) VALUES (?, ?, ?, ?, ?)",
+                (key, value, section, ctype, timestamp),
+            )
         conn.commit()
         affected = cur.rowcount
 

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -10,15 +10,15 @@ def configure_logging(app):
     # Clear existing handlers that Flask may have added
     app.logger.handlers.clear()
 
-    level_name = cfg.get("log_level", "INFO").upper()
+    level_name = (cfg.get("log_level") or "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
 
     handler_type = cfg.get("handler_type", "stream")
-    filename = cfg.get("filename", "logs/crossbook.log")
-    max_bytes = int(cfg.get("max_file_size", 5 * 1024 * 1024))
-    backup = int(cfg.get("backup_count", 3))
-    when_interval = cfg.get("when_interval", "midnight")
-    interval = int(cfg.get("interval_count", 1))
+    filename = cfg.get("filename") or "logs/crossbook.log"
+    max_bytes = int(cfg.get("max_file_size") or 5 * 1024 * 1024)
+    backup = int(cfg.get("backup_count") or 3)
+    when_interval = cfg.get("when_interval") or "midnight"
+    interval = int(cfg.get("interval_count") or 1)
     log_fmt = cfg.get(
         "log_format",
         "[%(asctime)s] %(levelname)s in %(module)s:%(funcName)s: %(message)s",

--- a/main.py
+++ b/main.py
@@ -77,7 +77,7 @@ def inject_field_schema():
 
 @app.route("/")
 def home():
-    heading = get_all_config().get('heading', 'Load the Glass Cannon')
+    heading = get_all_config().get('heading')
     return render_template(
         "index.html",
         cards=current_app.config['CARD_INFO'],

--- a/templates/wizard_settings.html
+++ b/templates/wizard_settings.html
@@ -15,6 +15,38 @@
       {% endfor %}
     </select>
   </div>
+  <div>
+    <label class="block mb-1">Handler Type</label>
+    <select name="handler_type" class="border rounded px-2 py-1">
+      {% for opt in ['rotating', 'timed', 'stream'] %}
+      <option value="{{ opt }}" {% if config.get('handler_type') == opt %}selected{% endif %}>{{ opt }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div>
+    <label class="block mb-1">Max File Size</label>
+    <input type="number" name="max_file_size" value="{{ config.get('max_file_size','') }}" class="border rounded px-2 py-1">
+  </div>
+  <div>
+    <label class="block mb-1">Backup Count</label>
+    <input type="number" name="backup_count" value="{{ config.get('backup_count','') }}" class="border rounded px-2 py-1">
+  </div>
+  <div>
+    <label class="block mb-1">When Interval</label>
+    <input type="text" name="when_interval" value="{{ config.get('when_interval','') }}" class="border rounded px-2 py-1">
+  </div>
+  <div>
+    <label class="block mb-1">Interval Count</label>
+    <input type="number" name="interval_count" value="{{ config.get('interval_count','') }}" class="border rounded px-2 py-1">
+  </div>
+  <div>
+    <label class="block mb-1">Log Format</label>
+    <input type="text" name="log_format" value="{{ config.get('log_format','') }}" class="border rounded px-2 py-1 w-full">
+  </div>
+  <div>
+    <label class="block mb-1">Log Filename</label>
+    <input type="text" name="filename" value="{{ config.get('filename','') }}" class="border rounded px-2 py-1 w-full">
+  </div>
   <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Continue</button>
 </form>
 {% endblock %}

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -13,6 +13,7 @@ import json
 import db.database as db_database
 from db.bootstrap import initialize_database
 from db.config import update_config, get_all_config
+from db.bootstrap import DEFAULT_CONFIGS
 from db.schema import create_base_table
 from db.edit_fields import add_column_to_table, add_field_to_schema
 from imports.import_csv import parse_csv
@@ -92,12 +93,9 @@ def settings_step():
     progress = session.setdefault('wizard_progress', {})
     config = get_all_config()
     if request.method == 'POST':
-        heading = request.form.get('heading')
-        level = request.form.get('log_level')
-        if heading is not None:
-            update_config('heading', heading)
-        if level is not None:
-            update_config('log_level', level)
+        for key, _default, _section, _type in DEFAULT_CONFIGS:
+            if key in request.form:
+                update_config(key, request.form.get(key))
         progress['settings'] = True
         session['wizard_progress'] = progress
         return redirect(url_for('wizard.table_step'))


### PR DESCRIPTION
## Summary
- populate new databases with default config values
- persist new config items when setting up the wizard
- extend wizard settings form for all configuration options
- rely on stored configuration instead of in-code defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5c1c8fcc83338f02f7baa29c30c8