### PR TITLE
Remove unused default constants

### DIFF
--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -32,53 +32,6 @@ LAYOUT_DEFAULTS = {
     },
 }
 
-DEFAULT_CONFIGS = [
-    ("log_level", "INFO", "general", "string"),
-    ("handler_type", "rotating", "general", "string"),
-    ("max_file_size", "5242880", "general", "integer"),
-    ("backup_count", "3", "general", "integer"),
-    ("when_interval", "midnight", "general", "string"),
-    ("interval_count", "1", "general", "integer"),
-    (
-        "log_format",
-        "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
-        "general",
-        "string",
-    ),
-    ("filename", "logs/crossbook.log", "general", "string"),
-    ("heading", "Load the glass cannons", "home", "string"),
-]
-
-DEFAULT_BASE_TABLE_ROWS = [
-    ("content", "Content", "Content Index", 1),
-    ("character", "Characters", "View all known characters in Alagaesia", 2),
-    ("thing", "Things", "Artifacts, tools, and curiosities", 3),
-    ("faction", "Factions", "Factions, cultures, and organizations", 4),
-    ("location", "Locations", "Important places throughout the land", 5),
-    (
-        "topic",
-        "Lore Topics",
-        "Themes, magic systems, and unanswered questions",
-        6,
-    ),
-]
-
-DEFAULT_FIELDS = {
-    "content": [
-        ("id", "hidden"),
-        ("content", "text"),
-        ("tags", "multi_select"),
-    ],
-    "character": [
-        ("id", "hidden"),
-        ("character", "text"),
-    ],
-    "thing": [("id", "hidden"), ("thing", "text")],
-    "faction": [("id", "hidden"), ("faction", "text")],
-    "location": [("id", "hidden"), ("location", "text")],
-    "topic": [("id", "hidden"), ("topic", "text")],
-}
-
 
 def _create_core_tables(cur: sqlite3.Cursor) -> None:
     cur.execute(


### PR DESCRIPTION
## Summary
- strip old DEFAULT_* definitions from `db/bootstrap.py`

## Testing
- `pytest -q` *(fails: test_multi_select_any_mode, test_multi_select_all_mode, test_url_field_add_update_and_bulk, test_settings_step_after_db_creation)*

------
https://chatgpt.com/codex/tasks/task_e_684c5d446ae883338c98797a2a639101