### PR TITLE
Add config forms to wizard

### DIFF
--- a/logging_setup.py
+++ b/logging_setup.py
@@ -10,15 +10,15 @@ def configure_logging(app):
     # Clear existing handlers that Flask may have added
     app.logger.handlers.clear()
 
-    level_name = cfg.get("log_level", "INFO").upper()
-    level = getattr(logging, level_name, logging.INFO)
+    level_name = cfg.get("log_level")
+    level = getattr(logging, level_name.upper(), logging.INFO) if level_name else logging.INFO
 
     handler_type = cfg.get("handler_type", "stream")
-    filename = cfg.get("filename", "logs/crossbook.log")
-    max_bytes = int(cfg.get("max_file_size", 5 * 1024 * 1024))
-    backup = int(cfg.get("backup_count", 3))
-    when_interval = cfg.get("when_interval", "midnight")
-    interval = int(cfg.get("interval_count", 1))
+    filename = cfg.get("filename", "crossbook.log")
+    max_bytes = int(cfg.get("max_file_size") or 0)
+    backup = int(cfg.get("backup_count") or 0)
+    when_interval = cfg.get("when_interval")
+    interval = int(cfg.get("interval_count") or 0)
     log_fmt = cfg.get(
         "log_format",
         "[%(asctime)s] %(levelname)s in %(module)s:%(funcName)s: %(message)s",

--- a/main.py
+++ b/main.py
@@ -77,7 +77,7 @@ def inject_field_schema():
 
 @app.route("/")
 def home():
-    heading = get_all_config().get('heading', 'Load the Glass Cannon')
+    heading = get_all_config().get('heading')
     return render_template(
         "index.html",
         cards=current_app.config['CARD_INFO'],

--- a/templates/wizard_settings.html
+++ b/templates/wizard_settings.html
@@ -3,18 +3,22 @@
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">Step 2: Configure Settings</h1>
 <form method="post" class="space-y-4">
+  {% for key, default, section, typ in defaults %}
   <div>
-    <label class="block mb-1">Site Heading</label>
-    <input type="text" name="heading" value="{{ config.get('heading','') }}" class="border rounded px-2 py-1 w-full">
+    <label class="block mb-1">{{ key.replace('_', ' ') | capitalize }}</label>
+    {% if key == 'log_level' %}
+      <select name="{{ key }}" class="border rounded px-2 py-1">
+        {% for lvl in ['DEBUG','INFO','WARNING','ERROR'] %}
+        <option value="{{ lvl }}" {% if (config.get(key) or default) == lvl %}selected{% endif %}>{{ lvl }}</option>
+        {% endfor %}
+      </select>
+    {% elif typ in ('integer', 'number') %}
+      <input type="number" name="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full">
+    {% else %}
+      <input type="text" name="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full">
+    {% endif %}
   </div>
-  <div>
-    <label class="block mb-1">Logging Level</label>
-    <select name="log_level" class="border rounded px-2 py-1">
-      {% for lvl in ['DEBUG','INFO','WARNING','ERROR'] %}
-      <option value="{{ lvl }}" {% if config.get('log_level') == lvl %}selected{% endif %}>{{ lvl }}</option>
-      {% endfor %}
-    </select>
-  </div>
+  {% endfor %}
   <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Continue</button>
 </form>
 {% endblock %}

--- a/tests/test_wizard_database.py
+++ b/tests/test_wizard_database.py
@@ -28,7 +28,7 @@ def test_settings_step_after_db_creation():
 
     config = get_all_config()
     assert config.get('db_path')
-    assert 'heading' in config
+    assert 'heading' not in config
 
     # restore original test database
     from db.database import init_db_path

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -11,7 +11,7 @@ from werkzeug.utils import secure_filename
 import os
 import json
 import db.database as db_database
-from db.bootstrap import initialize_database
+from db.bootstrap import initialize_database, DEFAULT_CONFIGS
 from db.config import update_config, get_all_config
 from db.schema import create_base_table
 from db.edit_fields import add_column_to_table, add_field_to_schema
@@ -66,7 +66,6 @@ def database_step():
                 initialize_database(save_path, include_base_tables=False)
                 db_database.init_db_path(save_path)
                 update_config('db_path', save_path)
-                update_config('heading', 'Load the glass cannons')
                 write_local_settings(save_path)
                 reload_app_state()
         name = request.form.get('create_name')
@@ -79,7 +78,6 @@ def database_step():
             initialize_database(save_path, include_base_tables=False)
             db_database.init_db_path(save_path)
             update_config('db_path', save_path)
-            update_config('heading', 'Load the glass cannons')
             write_local_settings(save_path)
             reload_app_state()
         progress['database'] = True
@@ -94,16 +92,14 @@ def settings_step():
     progress = session.setdefault('wizard_progress', {})
     config = get_all_config()
     if request.method == 'POST':
-        heading = request.form.get('heading')
-        level = request.form.get('log_level')
-        if heading is not None:
-            update_config('heading', heading)
-        if level is not None:
-            update_config('log_level', level)
+        for key, _default, _section, _type in DEFAULT_CONFIGS:
+            val = request.form.get(key)
+            if val is not None:
+                update_config(key, val)
         progress['settings'] = True
         session['wizard_progress'] = progress
         return redirect(url_for('wizard.table_step'))
-    return render_template('wizard_settings.html', config=config)
+    return render_template('wizard_settings.html', config=config, defaults=DEFAULT_CONFIGS)
 
 
 @wizard_bp.route('/wizard/table', methods=['GET', 'POST'])


### PR DESCRIPTION
## Summary
- collect all default config entries in the setup wizard
- store each answer with `update_config`
- drop `heading` preset from DB creation
- remove fallback defaults in `main` and logging setup
- adapt wizard test to new flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c60f1c4948333b9c169ef6bcaab93