### PR TITLE
Require wizard progress flag before starting setup

### DIFF
--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -11,6 +11,24 @@ BASE_TABLES = [
     "topic",
 ]
 
+# Default configuration settings used by the setup wizard
+DEFAULT_CONFIGS = [
+    ("log_level", "INFO", "general", "string"),
+    ("handler_type", "rotating", "general", "string"),
+    ("max_file_size", 5242880, "general", "integer"),
+    ("backup_count", 3, "general", "integer"),
+    ("when_interval", "midnight", "general", "string"),
+    ("interval_count", 1, "general", "integer"),
+    (
+        "log_format",
+        "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+        "general",
+        "string",
+    ),
+    ("filename", "logs/crossbook.log", "general", "string"),
+    ("heading", "", "home", "string"),
+]
+
 LAYOUT_DEFAULTS = {
     "width": {
         "textarea": 12,

--- a/tests/test_wizard_start.py
+++ b/tests/test_wizard_start.py
@@ -1,0 +1,13 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from main import app
+
+app.testing = True
+client = app.test_client()
+
+
+def test_wizard_start_without_progress_redirects_home():
+    resp = client.get('/wizard/')
+    assert resp.status_code == 302
+    assert resp.headers['Location'].endswith('/')

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -37,6 +37,9 @@ def _next_step():
 
 @wizard_bp.route('/wizard/')
 def wizard_start():
+    progress = session.get('wizard_progress')
+    if not progress:
+        return redirect(url_for('home'))
     next_ep = _next_step()
     if next_ep:
         return redirect(url_for(next_ep))


### PR DESCRIPTION
## Summary
- ensure setup wizard only runs if `wizard_progress` is set in the session
- provide default configuration options for the wizard
- test that `/wizard/` redirects home when no progress exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8e45bd4c8333be2a1640cf29fcb2