### PR TITLE
Remove local_settings DB override

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -5,10 +5,6 @@ import os
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 DEFAULT_DB_PATH = os.path.join(PROJECT_ROOT, "data", "crossbook.db")
 
-try:
-    from local_settings import CROSSBOOK_DB_PATH as LOCAL_DB_PATH
-except Exception:
-    LOCAL_DB_PATH = None
 from contextlib import contextmanager
 
 try:
@@ -20,25 +16,17 @@ try:
 except Exception:
     SUPPORTS_REGEX = False
 
-DB_PATH = os.path.abspath(LOCAL_DB_PATH or DEFAULT_DB_PATH)
+DB_PATH = os.path.abspath(DEFAULT_DB_PATH)
 
 
 def init_db_path(path: str | None = None) -> None:
-    """Set DB_PATH from an argument, local settings, or the DB config table."""
-    global DB_PATH, LOCAL_DB_PATH
+    """Set DB_PATH from an argument or the DB config table."""
+    global DB_PATH
     if path:
         DB_PATH = os.path.abspath(path)
         return
 
-    try:
-        import importlib
-        ls = importlib.import_module("local_settings")
-        importlib.reload(ls)
-        LOCAL_DB_PATH = getattr(ls, "CROSSBOOK_DB_PATH", None)
-    except Exception:
-        LOCAL_DB_PATH = None
-
-    DB_PATH = os.path.abspath(LOCAL_DB_PATH or DEFAULT_DB_PATH)
+    DB_PATH = os.path.abspath(DEFAULT_DB_PATH)
 
     try:
         from db.config import get_database_config

--- a/tests/test_api_records.py
+++ b/tests/test_api_records.py
@@ -9,10 +9,6 @@ from main import app
 from db.database import init_db_path
 
 init_db_path('data/crossbook.db')
-try:
-    os.remove('local_settings.py')
-except FileNotFoundError:
-    pass
 
 app.testing = True
 client = app.test_client()

--- a/tests/test_wizard_database.py
+++ b/tests/test_wizard_database.py
@@ -11,10 +11,6 @@ client = app.test_client()
 
 def test_settings_step_after_db_creation():
     new_name = 'test_created.db'
-    orig_settings = ''
-    if os.path.exists('local_settings.py'):
-        with open('local_settings.py') as fh:
-            orig_settings = fh.read()
     # ensure file removed if exists from prior runs
     try:
         os.remove(os.path.join('data', new_name))
@@ -38,11 +34,3 @@ def test_settings_step_after_db_creation():
     from views.admin import reload_app_state
     with app.app_context():
         reload_app_state()
-    if orig_settings:
-        with open('local_settings.py', 'w') as fh:
-            fh.write(orig_settings)
-    else:
-        try:
-            os.remove('local_settings.py')
-        except FileNotFoundError:
-            pass

--- a/views/admin.py
+++ b/views/admin.py
@@ -37,15 +37,6 @@ from utils.field_registry import FIELD_TYPES
 admin_bp = Blueprint('admin', __name__)
 
 
-def write_local_settings(db_path: str, filename: str = 'local_settings.py') -> None:
-    """Persist the database path so init_db_path can load it on startup."""
-    try:
-        with open(filename, 'w') as fh:
-            fh.write(f"CROSSBOOK_DB_PATH = '{db_path}'\n")
-    except Exception as exc:
-        current_app.logger.exception('Failed to write %s: %s', filename, exc)
-
-
 def reload_app_state() -> None:
     """Refresh cached navigation and schema data after a DB change."""
     card_info, base_tables = refresh_card_cache()
@@ -113,7 +104,6 @@ def update_config_route(key):
     value = request.form.get('value', '')
     update_config(key, value)
     if key == 'db_path':
-        write_local_settings(value)
         reload_app_state()
     if key in get_logging_config():
         configure_logging(current_app)
@@ -134,7 +124,6 @@ def update_database_file():
         initialize_database(save_path, include_base_tables=False)
         init_db_path(save_path)
         update_config('db_path', save_path)
-        write_local_settings(save_path)
         reload_app_state()
         if wants_json:
             return jsonify({'db_path': save_path, 'status': check_db_status(save_path)})
@@ -150,7 +139,6 @@ def update_database_file():
         initialize_database(save_path, include_base_tables=False)
         init_db_path(save_path)
         update_config('db_path', save_path)
-        write_local_settings(save_path)
         reload_app_state()
         session['wizard_progress'] = {'database': True, 'skip_import': True}
         session.pop('wizard_complete', None)

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -17,7 +17,7 @@ from db.schema import create_base_table
 from db.edit_fields import add_column_to_table, add_field_to_schema
 from imports.import_csv import parse_csv
 from db.records import create_record
-from views.admin import write_local_settings, reload_app_state
+from views.admin import reload_app_state
 
 wizard_bp = Blueprint('wizard', __name__)
 
@@ -69,7 +69,6 @@ def database_step():
                 initialize_database(save_path, include_base_tables=False)
                 db_database.init_db_path(save_path)
                 update_config('db_path', save_path)
-                write_local_settings(save_path)
                 reload_app_state()
         name = request.form.get('create_name')
         if name:
@@ -81,7 +80,6 @@ def database_step():
             initialize_database(save_path, include_base_tables=False)
             db_database.init_db_path(save_path)
             update_config('db_path', save_path)
-            write_local_settings(save_path)
             reload_app_state()
         progress['database'] = True
         session['wizard_progress'] = progress


### PR DESCRIPTION
## Summary
- drop use of `local_settings.py` for database path
- update admin and wizard modules to stop writing local settings
- adjust tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d2e0f12548333b459db8cc19f430b