### PR TITLE
Use select options from DB

### DIFF
--- a/db/config.py
+++ b/db/config.py
@@ -24,7 +24,20 @@ def get_config_rows():
         "labels",
         "options",
     ]
-    return [dict(zip(columns, row)) for row in rows]
+    result = []
+    for row in rows:
+        item = dict(zip(columns, row))
+        opts = item.get("options")
+        if opts:
+            try:
+                item["options"] = json.loads(opts)
+            except Exception:
+                item["options"] = []
+        else:
+            item["options"] = []
+        result.append(item)
+
+    return result
 
 
 def get_logging_config():

--- a/templates/wizard_settings.html
+++ b/templates/wizard_settings.html
@@ -12,10 +12,10 @@
       {{ item.labels or key.replace('_', ' ')|capitalize }}
       {% if item.required %}<span class="text-red-600">*</span>{% endif %}
     </label>
-    {% if key == 'log_level' %}
+    {% if typ == 'select' %}
       <select name="{{ key }}" id="{{ key }}" class="border rounded px-2 py-1">
-        {% for lvl in ['DEBUG','INFO','WARNING','ERROR'] %}
-        <option value="{{ lvl }}" {% if (config.get(key) or default) == lvl %}selected{% endif %}>{{ lvl }}</option>
+        {% for opt in item.options %}
+        <option value="{{ opt }}" {% if (config.get(key) or default) == opt %}selected{% endif %}>{{ opt }}</option>
         {% endfor %}
       </select>
     {% elif typ in ('integer', 'number') %}


### PR DESCRIPTION
## Summary
- parse config "options" column into lists
- show `<select>` fields when config item type is `select` in the setup wizard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3701b8408333a40e9ddab86356c0