### PR TITLE
Remove handler_type options hardcoding

### DIFF
--- a/templates/wizard_settings.html
+++ b/templates/wizard_settings.html
@@ -12,10 +12,10 @@
       {{ item.labels or key.replace('_', ' ')|capitalize }}
       {% if item.required %}<span class="text-red-600">*</span>{% endif %}
     </label>
-    {% if key == 'log_level' %}
+    {% if item.options %}
       <select name="{{ key }}" id="{{ key }}" class="border rounded px-2 py-1">
-        {% for lvl in ['DEBUG','INFO','WARNING','ERROR'] %}
-        <option value="{{ lvl }}" {% if (config.get(key) or default) == lvl %}selected{% endif %}>{{ lvl }}</option>
+        {% for opt in item.options %}
+        <option value="{{ opt }}" {% if (config.get(key) or default) == opt %}selected{% endif %}>{{ opt }}</option>
         {% endfor %}
       </select>
     {% elif typ in ('integer', 'number') %}

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -92,6 +92,11 @@ def database_step():
 def settings_step():
     progress = session.setdefault('wizard_progress', {})
     rows = get_config_rows()
+    for row in rows:
+        try:
+            row['options'] = json.loads(row.get('options') or '[]')
+        except Exception:
+            row['options'] = []
     config = {row['key']: row['value'] for row in rows}
     if request.method == 'POST':
         handler_type = request.form.get('handler_type', config.get('handler_type'))


### PR DESCRIPTION
## Summary
- parse config row options JSON in the wizard setup step
- render any config row with options as a select input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d2ee235cc833392fe91c3c9e0b9a7