### PR TITLE
Add back links in wizard templates

### DIFF
--- a/templates/wizard_import.html
+++ b/templates/wizard_import.html
@@ -16,6 +16,7 @@
     <input type="file" name="file" accept=".csv" class="border rounded px-2 py-1">
   </div>
   <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Import</button>
+  <a href="{{ url_for('wizard.table_step') }}" class="ml-4 text-blue-600 underline">Back</a>
   <a href="{{ url_for('wizard.skip_import') }}" class="ml-4 underline">Skip</a>
-</form>
+  </form>
 {% endblock %}

--- a/templates/wizard_settings.html
+++ b/templates/wizard_settings.html
@@ -29,6 +29,7 @@
   </div>
   {% endfor %}
   <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Continue</button>
+  <a href="{{ url_for('wizard.database_step') }}" class="ml-4 text-blue-600 underline">Back</a>
 </form>
 <script src="{{ url_for('static', filename='js/wizard_settings.js') }}"></script>
 {% endblock %}

--- a/templates/wizard_table.html
+++ b/templates/wizard_table.html
@@ -18,7 +18,8 @@
     <button type="button" onclick="showAddFieldModal()" class="bg-gray-200 px-2 py-1 rounded">Add Field</button>
   </div>
   <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Continue</button>
-</form>
+  <a href="{{ url_for('wizard.settings_step') }}" class="ml-4 text-blue-600 underline">Back</a>
+  </form>
 
 <!-- Add Field Modal -->
 <div id="addFieldModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50" onclick="if(event.target.id === 'addFieldModal') hideAddFieldModal()">


### PR DESCRIPTION
## Summary
- add Back links to settings, table, and import steps of the setup wizard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3d240c408333906ac36804edbad6