### PR TITLE
Populate default configs for new databases

### DIFF
--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -155,6 +155,21 @@ def _insert_defaults(cur: sqlite3.Cursor, path: str, include_base_tables: bool =
     return
 
 
+def ensure_default_configs(path: str) -> None:
+    """Insert DEFAULT_CONFIGS into the config table if it is empty."""
+    with sqlite3.connect(path) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM config")
+        count = cur.fetchone()[0]
+        if count == 0:
+            for key, value, section, type_ in DEFAULT_CONFIGS:
+                cur.execute(
+                    "INSERT INTO config (key, value, section, type) VALUES (?, ?, ?, ?)",
+                    (key, str(value), section, type_),
+                )
+            conn.commit()
+
+
 def initialize_database(path: str, include_base_tables: bool = False) -> None:
     """Create a new database with core tables."""
     os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/tests/test_wizard_database.py
+++ b/tests/test_wizard_database.py
@@ -24,7 +24,9 @@ def test_settings_step_after_db_creation():
 
     config = get_all_config()
     assert config.get('db_path')
-    assert 'heading' not in config
+    assert config.get('heading') == ''
+    # ensure other defaults exist
+    assert 'log_level' in config
 
     # restore original test database
     from db.database import init_db_path

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -11,7 +11,7 @@ from werkzeug.utils import secure_filename
 import os
 import json
 import db.database as db_database
-from db.bootstrap import initialize_database, DEFAULT_CONFIGS
+from db.bootstrap import initialize_database, ensure_default_configs
 from db.config import update_config, get_all_config, get_config_rows
 from db.schema import create_base_table
 from db.edit_fields import add_column_to_table, add_field_to_schema
@@ -67,6 +67,7 @@ def database_step():
                 save_path = os.path.join('data', filename)
                 file.save(save_path)
                 initialize_database(save_path, include_base_tables=False)
+                ensure_default_configs(save_path)
                 db_database.init_db_path(save_path)
                 update_config('db_path', save_path)
                 reload_app_state()
@@ -78,6 +79,7 @@ def database_step():
             save_path = os.path.join('data', filename)
             open(save_path, 'a').close()
             initialize_database(save_path, include_base_tables=False)
+            ensure_default_configs(save_path)
             db_database.init_db_path(save_path)
             update_config('db_path', save_path)
             reload_app_state()


### PR DESCRIPTION
## Summary
- add `ensure_default_configs` helper
- call helper from setup wizard after initializing a database
- adjust tests to expect defaults inserted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d54bb7d6083339caca69091a6c88f