### PR TITLE
Expose menu globally and hide after saving layout

### DIFF
--- a/static/js/field_styling.js
+++ b/static/js/field_styling.js
@@ -22,6 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!layoutGrid) return;
 
   const menu = document.createElement('div');
+  menu.id = 'field-style-menu';
+  window.fieldStyleMenu = menu;
   menu.className = 'absolute bg-white border rounded shadow p-2 space-y-1 hidden z-50 text-sm';
   menu.innerHTML = `
     <label class="flex items-center space-x-2"><input type="checkbox" data-opt="hideName"> <span>Hide Name</span></label>

--- a/static/js/layout_editor.js
+++ b/static/js/layout_editor.js
@@ -94,6 +94,7 @@ function handleSaveLayout() {
   const resetLayoutBtn      = document.getElementById('reset-layout');
   toggleEditLayoutBtn.classList.remove('hidden');
   layoutGrid.classList.remove('editing');
+  document.getElementById('field-style-menu')?.classList.add('hidden');
   addFieldBtn.classList.remove('hidden');
     document.querySelectorAll('.resize-handle')
 .forEach(h => h.classList.add('hidden'));


### PR DESCRIPTION
## Summary
- assign `field-style-menu` id and expose the menu globally for field styling
- ensure layout save hides the styling menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d567fa79c8333b6197ac439ce1bd5