### PR TITLE
Fix autosize ResizeObserver target

### DIFF
--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -97,8 +97,9 @@ function makeEditable(displayEl) {
 
 export function attach(el) {
   fitText(el);
+  const container = el.parentElement || el;
   const observer = new ResizeObserver(() => fitText(el));
-  observer.observe(el);
+  observer.observe(container);
   el._autosizeObserver = observer;
   el.addEventListener('click', () => makeEditable(el));
 }


### PR DESCRIPTION
## Summary
- ensure ResizeObserver observes parent container for autosize text fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d571b16f48333af300633e36343fb