### PR TITLE
Fix hide name styling and link column visibility to DB

### DIFF
--- a/static/js/column_visibility.js
+++ b/static/js/column_visibility.js
@@ -1,6 +1,17 @@
 document.addEventListener("DOMContentLoaded", () => {
   const checkboxes = () => document.querySelectorAll(".column-toggle");
 
+  const table = document.getElementById("records-table")?.dataset.table;
+
+  const sendStyling = (field, hide) => {
+    if (!table) return;
+    fetch(`/${table}/style`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ field, styling: { hideName: hide } })
+    }).catch(err => console.error("Styling update failed", err));
+  };
+
   const getSelectedFields = () =>
     Array.from(checkboxes())
       .filter(cb => cb.checked)
@@ -39,7 +50,12 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Attach listeners
-  checkboxes().forEach(cb => cb.addEventListener("change", updateVisibility));
+  checkboxes().forEach(cb =>
+    cb.addEventListener("change", () => {
+      updateVisibility();
+      sendStyling(cb.value, !cb.checked);
+    })
+  );
 
   // Initial update
   updateVisibility();

--- a/static/js/field_styling.js
+++ b/static/js/field_styling.js
@@ -7,6 +7,8 @@ function applyStyling(el, styling) {
   el.style.color = styling.color || '';
   const label = el.querySelector('div.text-sm.font-bold.capitalize.mb-1');
   if (label) label.classList.toggle('hidden', !!styling.hideName);
+  const inlineLabel = el.querySelector('.autosize-text b');
+  if (inlineLabel) inlineLabel.classList.toggle('hidden', !!styling.hideName);
 }
 
 function sendStyling(table, field, styling) {

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -51,8 +51,9 @@
     </button>
     <div id="column-dropdown" class="absolute z-10 mt-2 bg-white border rounded shadow hidden p-2 space-y-1 w-48">
       {% for field in fields if not field.startswith('_') %}
+        {% set styling = field_schema[table][field].styling or {} %}
         <label class="flex items-center space-x-2">
-          <input type="checkbox" class="column-toggle" value="{{ field }}" checked>
+          <input type="checkbox" class="column-toggle" value="{{ field }}" {% if not styling.hideName %}checked{% endif %}>
           <span class="text-sm">{{ field }}</span>
         </label>
       {% endfor %}

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -10,13 +10,14 @@
 {# Field-specific rendering macros #}
 
 {% macro render_text(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
+  {% set styling = field_schema[table][field].styling or {} %}
   <div class="autosize-text"
        data-field="{{ field }}"
        data-record-id="{{ record_id }}"
        data-update-url="{{ url_for(update_endpoint, table=table, record_id=record_id) }}"
        data-raw-value="{{ value }}"
        data-label="{{ field|capitalize }}">
-    <b>{{ field|capitalize }}:</b> {{ value }}
+    {% if not styling.hideName %}<b>{{ field|capitalize }}:</b>{% endif %} {{ value }}
   </div>
 {% endmacro %}
 


### PR DESCRIPTION
## Summary
- respect `hideName` styling in text field macro
- toggle inline label in `applyStyling`
- persist column visibility to `field_schema` and initialise checkboxes from DB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d59613d488333bb35a31de1e7d230