### PR TITLE
Observe draggable container for autosize

### DIFF
--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -97,7 +97,19 @@ function makeEditable(displayEl) {
 
 export function attach(el) {
   fitText(el);
-  const container = el.parentElement || el;
+  let container;
+  if (el.dataset.field) {
+    container = document.getElementById(`draggable-field-${el.dataset.field}`);
+  }
+  if (!container) {
+    if (el.parentElement && el.parentElement.parentElement) {
+      container = el.parentElement.parentElement;
+    } else if (el.parentElement) {
+      container = el.parentElement;
+    } else {
+      container = el;
+    }
+  }
   const observer = new ResizeObserver(() => fitText(el));
   observer.observe(container);
   el._autosizeObserver = observer;


### PR DESCRIPTION
## Summary
- detect corresponding draggable container when attaching text auto-sizing
- fallback to observe the parent's parent for resize when no draggable container exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d587695a0833392d8874bc18a6fc2