### PR TITLE
Fix autosize initialization timing

### DIFF
--- a/static/js/autosize_text.js
+++ b/static/js/autosize_text.js
@@ -113,6 +113,7 @@ export function attach(el) {
   const observer = new ResizeObserver(() => fitText(el));
   observer.observe(container);
   el._autosizeObserver = observer;
+  fitText(el);
   el.addEventListener('click', () => makeEditable(el));
 }
 
@@ -120,10 +121,14 @@ export function initAutosizeText() {
   document.querySelectorAll('.autosize-text').forEach(el => attach(el));
 }
 
+function startAutosize() {
+  requestAnimationFrame(initAutosizeText);
+}
+
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initAutosizeText);
+  window.addEventListener('DOMContentLoaded', startAutosize);
 } else {
-  initAutosizeText();
+  startAutosize();
 }
 
 window.initAutosizeText = initAutosizeText;


### PR DESCRIPTION
## Summary
- ensure ResizeObserver is attached before first sizing
- delay initial autosize until the DOM is visible

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d62d7b36c83339a82261719cd282e