### PR TITLE
Fix text field label display

### DIFF
--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -166,7 +166,7 @@
     {% if macro_name and (self|attr(macro_name)) %}
       {{ (self|attr(macro_name))(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
     {% else %}
-      <span class="ml-1">{{ value }}</span>
+      <span class="ml-1" data-field="{{ field }}">{{ field|capitalize }}: {{ value }}</span>
     {% endif %}
   </div>
 {% endmacro %}


### PR DESCRIPTION
## Summary
- ensure default field rendering includes the field name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d74f92f2083339f72f34b8cf22d15