### PR TITLE
Add green Import button on dashboard

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,6 +4,7 @@
 
 {% block nav_buttons %}
 <button id="dashboard_add" onclick="openDashboardModal()" class="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600">+ Add</button>
+<a href="/import" class="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600">Import</a>
 <button id="dashboard_edit" class="bg-purple-500 text-white px-3 py-1 rounded hover:bg-purple-600">Edit</button>
 <button id="dashboard_save" class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 hidden">Save Layout</button>
 {% endblock %}


### PR DESCRIPTION
## Summary
- tweak dashboard nav buttons to include an Import link styled in green

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d75655b708333b68d24e5a89d6545