### PR TITLE
Enable click-to-edit on detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Large files are not streamed—they are fully loaded into memory during parsing,
 
   * `add_table.js` for creating new tables
   * `autosize_text.js` provides inline text editing
+  * `click_to_edit.js` enables clicking a non-boolean field to enter edit mode
   * `bulk_edit_modal.js` for multi-record editing
   * `column_visibility.js` to toggle table columns
   * `dashboard_modal.js` for dashboard widgets

--- a/static/js/click_to_edit.js
+++ b/static/js/click_to_edit.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const grid = document.getElementById('layout-grid');
+  if (!grid) return;
+  const table = grid.dataset.table;
+  const recordId = grid.dataset.recordId;
+
+  grid.addEventListener('click', (e) => {
+    if (grid.classList.contains('editing')) return;
+    const fieldEl = e.target.closest('.draggable-field');
+    if (!fieldEl) return;
+    if (['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A'].includes(e.target.tagName)) {
+      return;
+    }
+    const field = fieldEl.dataset.field;
+    const fieldType = fieldEl.dataset.type;
+
+    // Skip booleans so users can toggle them directly
+    if (fieldType === 'boolean') return;
+
+    if (fieldType === 'text') {
+      const textEl = fieldEl.querySelector('.autosize-text');
+      if (textEl) textEl.dispatchEvent(new Event('click'));
+      return;
+    }
+
+    if (fieldEl.querySelector('form')) return;
+
+    if (table && recordId && field) {
+      window.location.href = `/${table}/${recordId}?edit=${field}`;
+    }
+  });
+});
+

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -39,6 +39,7 @@
     <div id="layout-grid"
          class="relative w-full grid"
          data-table="{{ table }}"
+         data-record-id="{{ record.id }}"
          style="
            grid-template-columns: repeat(20, 1fr);
            grid-auto-rows: 1em;
@@ -208,6 +209,7 @@
 </script>
 <script type="module" src="{{ url_for('static', filename='js/field_ajax.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/autosize_text.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/click_to_edit.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/editor.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/undo_edit.js') }}"></script>
 


### PR DESCRIPTION
## Summary
- allow click anywhere on a non-boolean field to enter edit mode
- include new `click_to_edit.js` script
- document the new script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d7dc174d88333a8766e6d71106fe0