### PR TITLE
Remove unused BASE_TABLES

### DIFF
--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -2,15 +2,6 @@ import os
 import sqlite3
 import json
 
-BASE_TABLES = [
-    "content",
-    "character",
-    "thing",
-    "faction",
-    "location",
-    "topic",
-]
-
 # Default configuration settings used by the setup wizard
 DEFAULT_CONFIGS = [
     ("log_level", "INFO", "general", "string"),
@@ -128,26 +119,6 @@ def _create_core_tables(cur: sqlite3.Cursor) -> None:
     )
 
 
-def _create_base_tables(cur: sqlite3.Cursor) -> None:
-    for table in BASE_TABLES:
-        cur.execute(
-            f"CREATE TABLE IF NOT EXISTS {table} ("
-            "id INTEGER PRIMARY KEY AUTOINCREMENT,"
-            f" {table} TEXT"
-            ")"
-        )
-
-    # join tables for many-to-many relationships
-    for i in range(len(BASE_TABLES)):
-        for j in range(i + 1, len(BASE_TABLES)):
-            a, b = sorted([BASE_TABLES[i], BASE_TABLES[j]])
-            cur.execute(
-                f"CREATE TABLE IF NOT EXISTS {a}_{b} ("
-                f"{a}_id INTEGER,"
-                f"{b}_id INTEGER,"
-                f"UNIQUE({a}_id, {b}_id)"
-                ")"
-            )
 
 
 def _insert_defaults(cur: sqlite3.Cursor, path: str, include_base_tables: bool = True) -> None:
@@ -170,14 +141,12 @@ def ensure_default_configs(path: str) -> None:
             conn.commit()
 
 
-def initialize_database(path: str, include_base_tables: bool = False) -> None:
+def initialize_database(path: str) -> None:
     """Create a new database with core tables."""
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with sqlite3.connect(path) as conn:
         cur = conn.cursor()
         _create_core_tables(cur)
-        if include_base_tables:
-            _create_base_tables(cur)
         # Default records are no longer inserted
         conn.commit()
 

--- a/views/admin.py
+++ b/views/admin.py
@@ -121,7 +121,7 @@ def update_database_file():
             return redirect(url_for('admin.database_page'))
         save_path = os.path.join('data', filename)
         file.save(save_path)
-        initialize_database(save_path, include_base_tables=False)
+        initialize_database(save_path)
         init_db_path(save_path)
         update_config('db_path', save_path)
         reload_app_state()
@@ -136,7 +136,7 @@ def update_database_file():
             filename += '.db'
         save_path = os.path.join('data', filename)
         open(save_path, 'a').close()
-        initialize_database(save_path, include_base_tables=False)
+        initialize_database(save_path)
         init_db_path(save_path)
         update_config('db_path', save_path)
         reload_app_state()

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -66,7 +66,7 @@ def database_step():
             if filename.endswith('.db'):
                 save_path = os.path.join('data', filename)
                 file.save(save_path)
-                initialize_database(save_path, include_base_tables=False)
+                initialize_database(save_path)
                 ensure_default_configs(save_path)
                 db_database.init_db_path(save_path)
                 update_config('db_path', save_path)
@@ -78,7 +78,7 @@ def database_step():
                 filename += '.db'
             save_path = os.path.join('data', filename)
             open(save_path, 'a').close()
-            initialize_database(save_path, include_base_tables=False)
+            initialize_database(save_path)
             ensure_default_configs(save_path)
             db_database.init_db_path(save_path)
             update_config('db_path', save_path)


### PR DESCRIPTION
## Summary
- remove obsolete `BASE_TABLES` constant and related code
- simplify `initialize_database` usage
- update admin and wizard views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d91cc15d88333b1fafd8d1e90026e