### PR TITLE
Add dynamic value widget rendering

### DIFF
--- a/static/js/dashboard_values.js
+++ b/static/js/dashboard_values.js
@@ -1,0 +1,70 @@
+// Dashboard value widget rendering
+
+document.addEventListener('DOMContentLoaded', () => {
+  const valueWidgets = document.querySelectorAll('[data-type="value"]');
+  valueWidgets.forEach(async widget => {
+    const cfgText = widget.dataset.config;
+    if (!cfgText) return;
+    let cfg;
+    try {
+      cfg = JSON.parse(cfgText);
+    } catch (err) {
+      console.error('[dashboard_values] Invalid config', err);
+      return;
+    }
+
+    const resultEl = widget.querySelector('.value-result');
+    if (!resultEl) return;
+
+    async function fetchValue(table, field, op) {
+      const endpoint = op === 'sum' ? 'sum-field' : 'count-nonnull';
+      const key = op === 'sum' ? 'sum' : 'count';
+      try {
+        const res = await fetch(`/${table}/${endpoint}?field=${encodeURIComponent(field)}`);
+        const data = await res.json();
+        return data[key] || 0;
+      } catch (e) {
+        console.error('[dashboard_values] fetch error', e);
+        return 0;
+      }
+    }
+
+    if (cfg.operation === 'sum' || cfg.operation === 'count') {
+      const { table, field } = cfg;
+      resultEl.textContent = '...';
+      const val = await fetchValue(table, field, cfg.operation);
+      resultEl.textContent = val;
+      return;
+    }
+
+    if (cfg.operation === 'math') {
+      const { math_operation, field1, field2, agg1 = 'sum', agg2 = 'sum' } = cfg;
+      if (!field1 || !math_operation) return;
+      resultEl.textContent = '...';
+      if (math_operation === 'average') {
+        const [t, f] = field1.split(':');
+        const total = await fetchValue(t, f, 'sum');
+        const count = await fetchValue(t, f, 'count');
+        resultEl.textContent = count ? total / count : 0;
+        return;
+      }
+      if (!field2) return;
+      const [t1, f1] = field1.split(':');
+      const [t2, f2] = field2.split(':');
+      const v1 = await fetchValue(t1, f1, agg1);
+      const v2 = await fetchValue(t2, f2, agg2);
+      let result = 0;
+      switch (math_operation) {
+        case 'add':
+          result = v1 + v2; break;
+        case 'subtract':
+          result = v1 - v2; break;
+        case 'multiply':
+          result = v1 * v2; break;
+        case 'divide':
+          result = v1 / (v2 || 1); break;
+      }
+      resultEl.textContent = result;
+    }
+  });
+});

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -35,11 +35,11 @@
     <div class="dashboard-widget draggable-field min-h-0 border p-2 rounded shadow bg-gray-50"
          data-widget="{{ widget.id }}"
          data-type="{{ widget.widget_type }}"
-         {% if widget.widget_type == 'chart' %}data-config='{{ widget.content }}'{% endif %}
+         {% if widget.widget_type in ['chart', 'value'] %}data-config='{{ widget.content }}'{% endif %}
          style="grid-column: {{ col_start }} / span {{ col_span }}; grid-row: {{ row_start }} / span {{ row_span }};">
       {% if widget.widget_type == 'value' %}
         <div class="font-semibold">{{ widget.title }}</div>
-        <div>{{ widget.content }}</div>
+        <div class="value-result">Loading...</div>
       {% elif widget.widget_type == 'chart' %}
         <div class="font-semibold mb-2">{{ widget.title }}</div>
         <canvas></canvas>
@@ -120,4 +120,5 @@
 <script type="module" src="{{ url_for('static', filename='js/dashboard_modal.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_grid.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_charts.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/dashboard_values.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- support value widgets by saving config on dashboard widget container
- load new `dashboard_values.js` to render numeric values
- display computed value from DB instead of raw JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da856c5ec8333859600fad398c96c