### PR TITLE
Fix log_level select in admin config

### DIFF
--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -4,8 +4,20 @@ import json
 
 # Default configuration settings used by the setup wizard
 DEFAULT_CONFIGS = [
-    ("log_level", "INFO", "general", "string"),
-    ("handler_type", "rotating", "general", "string"),
+    (
+        "log_level",
+        "INFO",
+        "general",
+        "select",
+        ["DEBUG", "INFO", "WARNING", "ERROR"],
+    ),
+    (
+        "handler_type",
+        "rotating",
+        "general",
+        "select",
+        ["rotating", "timed", "stream"],
+    ),
     ("max_file_size", 5242880, "general", "integer"),
     ("backup_count", 3, "general", "integer"),
     ("when_interval", "midnight", "general", "string"),
@@ -126,11 +138,19 @@ def ensure_default_configs(path: str) -> None:
         cur.execute("SELECT COUNT(*) FROM config")
         count = cur.fetchone()[0]
         if count == 0:
-            for key, value, section, type_ in DEFAULT_CONFIGS:
-                cur.execute(
-                    "INSERT INTO config (key, value, section, type) VALUES (?, ?, ?, ?)",
-                    (key, str(value), section, type_),
-                )
+            for cfg in DEFAULT_CONFIGS:
+                if len(cfg) == 5:
+                    key, value, section, type_, options = cfg
+                    cur.execute(
+                        "INSERT INTO config (key, value, section, type, options) VALUES (?, ?, ?, ?, ?)",
+                        (key, str(value), section, type_, json.dumps(options)),
+                    )
+                else:
+                    key, value, section, type_ = cfg
+                    cur.execute(
+                        "INSERT INTO config (key, value, section, type) VALUES (?, ?, ?, ?)",
+                        (key, str(value), section, type_),
+                    )
             conn.commit()
 
 def initialize_database(path: str) -> None:

--- a/templates/config_admin.html
+++ b/templates/config_admin.html
@@ -29,7 +29,13 @@
                 <form method="post" action="{{ url_for('admin.update_config_route', key=item.key) }}"
                       class="{% if item.type == 'json' %}flex flex-col items-start space-y-2 w-full{% else %}flex items-center space-x-2{% endif %}"
                       {% if item.type == 'json' %}data-json-key="{{ item.key }}"{% endif %}>
-                {% if item.type in ('integer', 'number') %}
+                {% if item.type == 'select' or item.options %}
+                  <select name="value" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-blue-500 focus:border-blue-500">
+                    {% for opt in item.options %}
+                      <option value="{{ opt }}" {% if item.value == opt %}selected{% endif %}>{{ opt }}</option>
+                    {% endfor %}
+                  </select>
+                {% elif item.type in ('integer', 'number') %}
                   <input type="number" name="value" value="{{ item.value }}" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-blue-500 focus:border-blue-500">
                 {% elif item.type == 'boolean' %}
                   <input type="checkbox" name="value" value="1" {% if item.value in ('1', 1, True, 'true') %}checked{% endif %} class="h-4 w-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500">

--- a/tests/test_admin_config.py
+++ b/tests/test_admin_config.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import re
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from main import app
+from db.database import init_db_path
+
+init_db_path('data/crossbook.db')
+
+app.testing = True
+client = app.test_client()
+
+def test_log_level_field_is_select():
+    resp = client.get('/admin/config')
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    m = re.search(r'log_level</td>\s*<td[^>]*>\s*<form[^>]*>(.*?)</form>', html, re.S)
+    assert m is not None
+    row_html = m.group(1)
+    assert '<select' in row_html
+    options = re.findall(r'<option value="([^"]+)"', row_html)
+    assert {'DEBUG', 'INFO', 'WARNING', 'ERROR'}.issubset(set(options))


### PR DESCRIPTION
## Summary
- render select elements in configuration page
- store log level and handler type defaults as select type
- support options when inserting default config
- test admin configuration page rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc88b18608333a10de1535bf5091c