### PR TITLE
Reduce logging verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ This is the core of the Flask application. It defines the web routes, handles da
  - Instead, templates call the `get_field_options(table, field)` helper to fetch options at render time.
 
 #### Request Logging
-The application logs each request's start, completion time, and status code. `start_timer` stores the start time, `log_request` records the duration, and `log_exception` captures uncaught errors. Werkzeug's default logging is disabled so only these messages appear.
+The application logs each request's start, completion time, and status code at the DEBUG level. `start_timer` stores the start time, `log_request` records the duration, and `log_exception` captures uncaught errors. Werkzeug's default logging is disabled so only these messages appear when the application is running in debug mode.
 
 #### Field Schema Injection
 The context processor `inject_field_schema` loads the field schema and navigation card data before rendering templates, exposing them and `update_foreign_field_options` globally.

--- a/utils/flask_helpers.py
+++ b/utils/flask_helpers.py
@@ -5,13 +5,13 @@ from flask import g, request, current_app
 def start_timer():
     """Record the start time of the request and log the request start."""
     g.start_time = time.time()
-    current_app.logger.info(f"[REQ] {request.method} {request.path} started")
+    current_app.logger.debug(f"[REQ] {request.method} {request.path} started")
 
 
 def log_request(response):
     """Log the duration and status code of the completed request."""
     duration = time.time() - g.get("start_time", time.time())
-    current_app.logger.info(
+    current_app.logger.debug(
         f"[REQ] {request.method} {request.path} completed in {duration:.3f}s with {response.status_code}"
     )
     return response


### PR DESCRIPTION
## Summary
- lower request log messages from INFO to DEBUG
- update README request logging explanation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd0834af08333907c9344c5d32c54