### PR TITLE
Add debug logging for form rendering

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,7 +84,7 @@ app.register_blueprint(wizard_bp)
 @app.context_processor
 def inject_field_schema():
     schema = get_field_schema()
-    print("Injected field schema keys:", list(schema.keys()))
+    current_app.logger.debug("Injected field schema keys: %s", list(schema.keys()))
     return {
         'field_schema': schema,
         'update_foreign_field_options': update_foreign_field_options,

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -158,6 +158,7 @@
        data-styling='{{ styling | tojson }}'>
     {% set macro_name = field_macro_map.get(field_type) if field_macro_map else None %}
     {% if macro_name and (self|attr(macro_name)) %}
+      {{ current_app.logger.debug('--- form rendered for ' ~ field) }}
       {{ (self|attr(macro_name))(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
     {% else %}
       <span class="ml-1" data-field="{{ field }}"><b>{{ field|capitalize }}:</b> {{ value }}</span>


### PR DESCRIPTION
## Summary
- log field schema injection using `current_app.logger.debug`
- emit a debug message whenever a field's form macro renders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684daf6838508333b86aaf797bd6e69b