### PR TITLE
Ensure validation macros load on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from db.schema import (
 from db.config import get_config_rows
 from utils.flask_helpers import start_timer, log_request, log_exception
 from utils.field_registry import FIELD_TYPES
+import utils.validation  # ensure register_type() runs at startup
 
 app = Flask(__name__, static_url_path='/static')
 app.secret_key = os.environ.get('SECRET_KEY', 'crossbook-secret')
@@ -86,12 +87,16 @@ def inject_field_schema():
     schema = get_field_schema()
     print("Injected field schema keys 1:", list(schema.keys()))
     current_app.logger.debug("Injected field schema keys 2: %s", list(schema.keys()))
+
+    macro_map = {name: ft.macro for name, ft in FIELD_TYPES.items() if ft.macro}
+    current_app.logger.debug("Field macro map keys: %s", list(macro_map.keys()))
+
     return {
         'field_schema': schema,
         'update_foreign_field_options': update_foreign_field_options,
         'nav_cards': current_app.config['CARD_INFO'],
         'base_tables': current_app.config['BASE_TABLES'],
-        'field_macro_map': {name: ft.macro for name, ft in FIELD_TYPES.items() if ft.macro},
+        'field_macro_map': macro_map,
     }
 
 @app.route("/")


### PR DESCRIPTION
## Summary
- import `utils.validation` to trigger field type registration
- log `field_macro_map` keys when injecting schema context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dedba855483338a8d87d68b69c16b