### PR TITLE
Load Flowbite charts only on dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Layout Editor Persistence:** detail page layouts save to the database via the `/<table>/layout` endpoint.
 * **Automatic Dashboard Widget Placement:** New widgets are inserted at the next
   available row in the grid without specifying `row_start`.
-* **Dashboard Charts:** Pie, bar and line chart widgets rely on Flowbite Charts. The repo ships a placeholder `flowbite-charts.min.js`; download the real library for production use.
+* **Dashboard Charts:** Pie, bar and line chart widgets rely on Flowbite Charts. The library is loaded only on the dashboard view. The repo ships a placeholder `flowbite-charts.min.js`; download the real library for production use.
 * **Table Widget:** Displays simple tabular data such as base table record counts.
 * **Select Value Counts:** Table widget option that shows counts of each choice for a select or multi-select field.
 * **Top/Bottom Numeric:** Table widget listing records with the highest or lowest values for a numeric field.

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,9 +6,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
   <link rel="stylesheet" href="https://cdn.quilljs.com/1.3.7/quill.snow.css">
   <script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  {# <script src="https://cdn.jsdelivr.net/npm/flowbite-charts/dist/flowbite-charts.min.js"></script> #}
-  <script src="{{ url_for('static', filename='js/flowbite-charts.min.js') }}"></script>
+  {# Dashboard views load chart libraries explicitly #}
   <title>{% block title %}Crossbook{% endblock %}</title>
 </head>
 <body class="bg-white text-gray-900 {% block body_class %}{% endblock %}">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -120,6 +120,8 @@
 
 <script>const FIELD_SCHEMA = {{ field_schema | tojson }};</script>
 <script>window.WIDGET_LAYOUT = {{ widget_layout | tojson }};</script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="{{ url_for('static', filename='js/flowbite-charts.min.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_modal.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_grid.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_charts.js') }}"></script>


### PR DESCRIPTION
## Summary
- remove Flowbite chart script from global template
- load Chart.js and Flowbite Charts only on dashboard
- document restricted loading of Flowbite Charts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7839be388333a52881ac3f0c1707