### PR TITLE
Remove unused imports

### DIFF
--- a/db/edit_fields.py
+++ b/db/edit_fields.py
@@ -1,4 +1,3 @@
-import sqlite3
 import json
 from db.database import get_connection
 from db.config import get_layout_defaults

--- a/db/schema.py
+++ b/db/schema.py
@@ -1,4 +1,3 @@
-import sqlite3
 import json
 import logging
 

--- a/db/validation.py
+++ b/db/validation.py
@@ -13,6 +13,5 @@ def validate_field(table: str, field: str):
         raise ValueError(f"Invalid column `{field}` for table `{table}`")
 
 def validate_fields(table: str, fields: list[str]):
-    from db.schema import get_field_schema
     for f in fields:
         validate_field(table, f)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, current_app, redirect, url_for, session, request
+from flask import Flask, render_template, current_app, redirect, url_for, request
 import logging
 import sqlite3
 import os
@@ -18,7 +18,7 @@ from db.schema import (
 )
 from db.config import get_config_rows
 from utils.field_registry import FIELD_TYPES
-import utils.validation  # ensure register_type() runs at startup
+import utils.validation  # ensure register_type() runs at startup  # noqa: F401
 
 app = Flask(__name__, static_url_path='/static')
 app.secret_key = os.environ.get('SECRET_KEY', 'crossbook-secret')

--- a/views/admin.py
+++ b/views/admin.py
@@ -31,7 +31,7 @@ from utils.validation import validation_sorter
 from db.schema import get_field_schema
 from db.database import get_connection, check_db_status, init_db_path
 from db.bootstrap import initialize_database
-from imports.tasks import huey, process_import, init_import_table
+from imports.tasks import process_import, init_import_table
 from utils.field_registry import FIELD_TYPES
 
 admin_bp = Blueprint('admin', __name__)


### PR DESCRIPTION
## Summary
- delete unused imports across the codebase
- keep `utils.validation` import but silence flake8 warning

## Testing
- `flake8 --select=F401 $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e788fb1948333ba92c97d227f2ff2