### PR TITLE
Implement single-field edit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,14 +450,14 @@ Overall, `detail_view.html` works in tandem with `macros/fields.html` and the JS
     - For number fields, the input’s `onchange` handler calls `field_ajax.js` to save the new value via `fetch`, displaying a short “Saved” indicator without refreshing the page.
 - If the field is **not** being edited (normal display mode):
   - For **textarea** fields (which contain HTML content), it wraps the value in a `<div class="prose">` and marks it safe, so the HTML formatting is rendered. This nicely displays paragraphs, links, etc., with Tailwind’s typography styles.
-  - For **select/multi_select** (if they were to be used), and **date** fields: it simply displays the value in a span. (Currently select fields have no special behavior because support is not implemented yet, so they just show whatever value is stored.)
+  - For **select** fields: the chosen option is shown as plain text. **multi_select** and **foreign_key** values appear as blue tag badges. When in edit mode these fields use searchable dropdowns with checkboxes.
+  - For **date** fields: simply display the stored date string.
   - For **foreign_key** fields: displays the value in a span with italic, blue styling as a hint that it’s a reference. (This is a placeholder; ideally it would be a link to that related record’s page, but that requires additional context which is not yet provided to the template.)
   - For **boolean** fields: Instead of a plain text "True/False", it provides a quick toggle UI even in view mode. It renders a small form with a hidden field specifying the field name and another hidden field `new_value_override` flipping the boolean (if current value is true, `new_value_override` is "0", otherwise "1"). It then shows a button that is green and labeled "Yes" if true (or red and "No" if false). Clicking this button submits the form to the `update_field` route, toggling the value immediately. This design means booleans can be toggled without entering an edit state.
   - For all other fields (text, number, etc.): it simply displays the value in a span.
-  - In addition, for any non-boolean field in view mode, an edit icon link (✏️) is shown after the value. Clicking this link reloads the page with the `?edit=<field>` parameter to activate the edit form (as described above).
   - When a field is edited via the `?edit=<field>` query parameter, the macro now logs `[DEBUG: field → field_type]` to the Flask logger. This provides helpful context without cluttering the rendered page.
 
-By using this macro in `detail_view.html`, the template stays cleaner and any changes to how fields are rendered (view or edit) can be made in one place. For example, when select fields are implemented, the macro can be updated to handle `field_type == "select"` differently (perhaps render a dropdown with options) without having to touch the main template logic.
+By using this macro in `detail_view.html`, the template stays cleaner and any changes to how fields are rendered (view or edit) can be made in one place. If new field types are introduced later, this macro can be extended to render them appropriately without touching the main template logic.
 
 ## Styling
 

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -10,123 +10,167 @@
 {# Field-specific rendering macros #}
 
 {% macro render_text(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
-  {{ inline_input(field, update_endpoint, table, record_id,
+  {% if request.args.get('edit') == field %}
+    {{ inline_input(field, update_endpoint, table, record_id,
         '<input type="text" name="new_value" value="' ~ value ~
         '" class="border px-1 py-0.5 text-sm rounded" onchange="submitFieldAjax(this.form)">\n<span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
+  {% else %}
+    <span class="ml-1" data-field="{{ field }}">{{ value }}</span>
+  {% endif %}
 {% endmacro %}
 
 {% macro render_textarea(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
-  <form method="POST"
-        action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}"
-        class="w-full mb-2"
-        data-autosave>
-    <input type="hidden" name="field" value="{{ field }}">
-    <input type="hidden" name="new_value" value="{{ value|e }}">
-    <div class="quill-editor" data-quill>{{ value|safe }}</div>
-    <span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>
-  </form>
+  {% if request.args.get('edit') == field %}
+    <form method="POST"
+          action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}"
+          class="w-full mb-2"
+          data-autosave>
+        <input type="hidden" name="field" value="{{ field }}">
+        <input type="hidden" name="new_value" value="{{ value|e }}">
+        <div class="quill-editor" data-quill>{{ value|safe }}</div>
+        <span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>
+    </form>
+  {% else %}
+    <div class="prose" data-field="{{ field }}">{{ value|safe }}</div>
+  {% endif %}
 {% endmacro %}
 
 {% macro render_select(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
-  <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="inline">
-    <input type="hidden" name="field" value="{{ field }}">
-    <select name="new_value"
-            class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200"
-            onchange="submitFieldAjax(this.form)">
-      {% for option in field_schema[table][field].options %}
-        <option value="{{ option }}" {% if option == value %}selected{% endif %}>{{ option }}</option>
-      {% endfor %}
-    </select>
-    <span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>
-  </form>
+  {% if request.args.get('edit') == field %}
+    <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="inline">
+      <input type="hidden" name="field" value="{{ field }}">
+      <select name="new_value"
+              class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200"
+              onchange="submitFieldAjax(this.form)">
+        {% for option in field_schema[table][field].options %}
+          <option value="{{ option }}" {% if option == value %}selected{% endif %}>{{ option }}</option>
+        {% endfor %}
+      </select>
+      <span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>
+    </form>
+  {% else %}
+    <span class="ml-1" data-field="{{ field }}">{{ value }}</span>
+  {% endif %}
 {% endmacro %}
 
 {% macro render_multi_select(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
-  <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="relative w-full multiselect" data-multiselect-dropdown onsubmit="event.preventDefault();">
-    <input type="hidden" name="field" value="{{ field }}">
+  {% if request.args.get('edit') == field %}
+    <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="relative w-full multiselect" data-multiselect-dropdown onsubmit="event.preventDefault();">
+      <input type="hidden" name="field" value="{{ field }}">
+      {% set selected_options = (value or '').split(', ') %}
+
+      <div class="flex flex-wrap gap-1 mb-2">
+        {% for tag in selected_options if tag %}
+          <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">
+            {{ tag }}
+            <button type="button" class="ml-1 text-blue-500 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=\'{{ tag }}\']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
+          </span>
+        {% endfor %}
+      </div>
+
+      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500" onclick="this.nextElementSibling.classList.toggle('hidden')">
+        Choose Tags
+      </button>
+
+      <div class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1" data-options>
+        <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)))">
+
+        {% for option in field_schema[table][field].options %}
+          <label class="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              name="new_value[]"
+              value="{{ option }}"
+              {% if option in selected_options %}checked{% endif %}
+              onchange="submitMultiSelectAuto(this.form)"
+              class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500"
+            >
+            <span class="text-sm">{{ option }}</span>
+          </label>
+        {% endfor %}
+      </div>
+    </form>
+  {% else %}
     {% set selected_options = (value or '').split(', ') %}
-
-    <div class="flex flex-wrap gap-1 mb-2">
+    <div class="flex flex-wrap gap-1" data-field="{{ field }}">
       {% for tag in selected_options if tag %}
-        <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">
-          {{ tag }}
-          <button type="button" class="ml-1 text-blue-500 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=\'{{ tag }}\']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
-        </span>
+        <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">{{ tag }}</span>
       {% endfor %}
+      {% if selected_options|reject('equalto', '')|list|length == 0 %}
+        <span class="text-gray-500">None</span>
+      {% endif %}
     </div>
-
-    <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500" onclick="this.nextElementSibling.classList.toggle('hidden')">
-      Choose Tags
-    </button>
-
-    <div class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1" data-options>
-      <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)))">
-
-      {% for option in field_schema[table][field].options %}
-        <label class="flex items-center space-x-2">
-          <input
-            type="checkbox"
-            name="new_value[]"
-            value="{{ option }}"
-            {% if option in selected_options %}checked{% endif %}
-            onchange="submitMultiSelectAuto(this.form)"
-            class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500"
-          >
-          <span class="text-sm">{{ option }}</span>
-        </label>
-      {% endfor %}
-    </div>
-  </form>
+  {% endif %}
 {% endmacro %}
 
 {% macro render_number(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
-  {{ inline_input(field, update_endpoint, table, record_id,
+  {% if request.args.get('edit') == field %}
+    {{ inline_input(field, update_endpoint, table, record_id,
         '<input type="number" name="new_value" value="' ~ value ~
         '" class="appearance-none border px-1 py-0.5 text-sm rounded"  onchange="submitFieldAjax(this.form)"><span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
+  {% else %}
+    <span class="ml-1" data-field="{{ field }}">{{ value }}</span>
+  {% endif %}
 {% endmacro %}
 
 {% macro render_date(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
-  {{ inline_input(field, update_endpoint, table, record_id,
+  {% if request.args.get('edit') == field %}
+    {{ inline_input(field, update_endpoint, table, record_id,
         '<input type="date" name="new_value" value="' ~ value ~
         '" class="border px-1 py-0.5 text-sm rounded" onchange="submitFieldAjax(this.form)"><span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
+  {% else %}
+    <span class="ml-1" data-field="{{ field }}">{{ value }}</span>
+  {% endif %}
 {% endmacro %}
 
 {% macro render_foreign_key(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
-  <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="relative w-full" data-multiselect-dropdown onsubmit="event.preventDefault();">
-    <input type="hidden" name="field" value="{{ field }}">
+  {% if request.args.get('edit') == field %}
+    <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="relative w-full" data-multiselect-dropdown onsubmit="event.preventDefault();">
+      <input type="hidden" name="field" value="{{ field }}">
+      {% set selected_options = (value or '').split(', ') %}
+
+      <div class="flex flex-wrap gap-1 mb-2">
+        {% for tag in selected_options if tag %}
+          <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">
+            {{ tag }}
+            <button type="button" class="ml-1 text-blue-500 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=\'{{ tag }}\']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
+          </span>
+        {% endfor %}
+      </div>
+
+      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500" onclick="this.nextElementSibling.classList.toggle('hidden')">
+        Choose Tags
+      </button>
+
+      <div class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1" data-options>
+        <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)))">
+
+        {% for option in field_schema[table][field].options %}
+          <label class="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              name="new_value[]"
+              value="{{ option }}"
+              {% if option in selected_options %}checked{% endif %}
+              onchange="submitMultiSelectAuto(this.form)"
+              class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500"
+            >
+            <span class="text-sm">{{ option }}</span>
+          </label>
+        {% endfor %}
+      </div>
+    </form>
+  {% else %}
     {% set selected_options = (value or '').split(', ') %}
-
-    <div class="flex flex-wrap gap-1 mb-2">
+    <div class="flex flex-wrap gap-1" data-field="{{ field }}">
       {% for tag in selected_options if tag %}
-        <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">
-          {{ tag }}
-          <button type="button" class="ml-1 text-blue-500 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=\'{{ tag }}\']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
-        </span>
+        <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">{{ tag }}</span>
       {% endfor %}
+      {% if selected_options|reject('equalto', '')|list|length == 0 %}
+        <span class="text-gray-500">None</span>
+      {% endif %}
     </div>
-
-    <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500" onclick="this.nextElementSibling.classList.toggle('hidden')">
-      Choose Tags
-    </button>
-
-    <div class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1" data-options>
-      <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)))">
-
-      {% for option in field_schema[table][field].options %}
-        <label class="flex items-center space-x-2">
-          <input
-            type="checkbox"
-            name="new_value[]"
-            value="{{ option }}"
-            {% if option in selected_options %}checked{% endif %}
-            onchange="submitMultiSelectAuto(this.form)"
-            class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500"
-          >
-          <span class="text-sm">{{ option }}</span>
-        </label>
-      {% endfor %}
-    </div>
-  </form>
+  {% endif %}
 {% endmacro %}
 
 {% macro render_boolean(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
@@ -142,7 +186,7 @@
 {% endmacro %}
 
 {% macro render_url(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) %}
-  {% if request.args.get('edit') %}
+  {% if request.args.get('edit') == field %}
     {{ inline_input(field, update_endpoint, table, record_id,
           '<input type="url" name="new_value" value="' ~ value ~
           '" class="border px-1 py-0.5 text-sm rounded" onchange="submitFieldAjax(this.form)">\n<span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}


### PR DESCRIPTION
## Summary
- add query-param check to field macros
- render plain text/tags when not editing
- document new behavior for `macros/fields.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e71525d748333856b7a9fd124315a