### PR TITLE
Import macros with context

### DIFF
--- a/main.py
+++ b/main.py
@@ -92,6 +92,7 @@ def inject_field_schema():
         'nav_cards': current_app.config['CARD_INFO'],
         'base_tables': current_app.config['BASE_TABLES'],
         'field_macro_map': macro_map,
+        'current_app': current_app,
     }
 
 @app.route("/")

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% import "macros/fields.html" as fields %}
+{% import "macros/fields.html" as fields with context %}
 {% set title_display = record.get(table) %}
 {% block title %}{{ table|capitalize }} {{ title_display }}{% endblock %}
 {% block content %}

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -196,13 +196,15 @@
 {% endmacro %}
 
 {% macro render_editable_field(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema, field_macro_map=None) %}
+  {% set edit_param = request.args.get('edit') %}
   {% set styling = field_schema[table][field].styling or {} %}
   <div class="mt-2 h-full{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }}"
        {% if styling.color %}style="color: {{ styling.color }}"{% endif %}
        data-styling='{{ styling | tojson }}'>
     {% set macro_name = field_macro_map.get(field_type) if field_macro_map else None %}
+    {{ current_app.logger.debug('[render] field=%s type=%s edit_param=%s', field, field_type, edit_param) }}
     {% if macro_name and (self|attr(macro_name)) %}
-      {% if request.args.get('edit') == field %}
+      {% if edit_param == field %}
         {{ current_app.logger.debug('[DEBUG: ' ~ field ~ ' \u2192 ' ~ field_type ~ ']') }}
       {% endif %}
       {{ (self|attr(macro_name))(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}


### PR DESCRIPTION
## Summary
- pass template context to `fields.html`
- inject `current_app` into Jinja context so macros can access it

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684e7d1f19988333af203838c2b7eaeb