### PR TITLE
Restore click-to-edit script

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 │   │   ├── edit_fields.js           # Client-side field schema editing
 │   │   ├── editor.js                # Initialize Quill editors
 │   │   ├── field_ajax.js            # Inline updates via fetch
+│   │   ├── click_to_edit.js        # Click a field to toggle edit mode
 │   │   ├── filter_visibility.js     # Show/hide filter controls
 │   │   ├── layout_editor.js         # Drag/drop & layout persistence
 │   │   ├── dashboard_grid.js       # Drag and resize dashboard widgets
@@ -201,6 +202,7 @@ Large files are not streamed—they are fully loaded into memory during parsing,
   * `edit_fields.js` for client-side schema and field editing
   * `editor.js` initializes Quill editors for textarea fields (see the [Quill documentation](https://quilljs.com/docs/quickstart/) for editor usage)
   * `field_ajax.js` for inline field updates without page reloads (imported by `detail_view.html`)
+  * `click_to_edit.js` toggles a field into edit mode when clicked
   * `filter_visibility.js` for showing/hiding filter controls
   * `layout_editor.js` for drag-and-drop and grid persistence
   * `relations.js` for AJAX-based add/remove relationships

--- a/static/js/click_to_edit.js
+++ b/static/js/click_to_edit.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const grid = document.getElementById('layout-grid');
+  if (!grid) return;
+
+  const table = grid.dataset.table;
+  const recordId = grid.dataset.recordId;
+
+  grid.addEventListener('click', (e) => {
+    if (grid.classList.contains('editing')) return;
+
+    const fieldEl = e.target.closest('.draggable-field');
+    if (!fieldEl) return;
+
+    if (['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A'].includes(e.target.tagName)) {
+      return;
+    }
+
+    const field = fieldEl.dataset.field;
+    const type = fieldEl.dataset.type;
+
+    if (type === 'boolean') return;
+    if (fieldEl.querySelector('form')) return;
+
+    if (table && recordId && field) {
+      const url = new URL(window.location.href);
+      url.searchParams.set('edit', field);
+      window.location.href = url.pathname + url.search;
+    }
+  });
+});

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -205,6 +205,7 @@
   };
 </script>
 <script type="module" src="{{ url_for('static', filename='js/field_ajax.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/click_to_edit.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/editor.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/undo_edit.js') }}"></script>
 


### PR DESCRIPTION
## Summary
- add `click_to_edit.js` to bring back click-to-edit behavior
- include the new script in `detail_view.html`
- document the script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9ca190f883339c2343d07b7f1f82