### PR TITLE
Add debug console logs for click-to-edit

### DIFF
--- a/static/js/click_to_edit.js
+++ b/static/js/click_to_edit.js
@@ -18,12 +18,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const field = fieldEl.dataset.field;
     const type = fieldEl.dataset.type;
 
+    console.log('[click_to_edit] clicked field:', field, 'type:', type);
+
     if (type === 'boolean') return;
     if (fieldEl.querySelector('form')) return;
 
     if (table && recordId && field) {
       const url = new URL(window.location.href);
       url.searchParams.set('edit', field);
+      console.log('[click_to_edit] navigating to:', url.pathname + url.search);
       window.location.href = url.pathname + url.search;
     }
   });


### PR DESCRIPTION
## Summary
- add console logs in `click_to_edit.js` to show clicked field/type and navigation URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9dc7916883338416efda0e911bb7