### PR TITLE
Fix editable field rendering

### DIFF
--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -201,13 +201,25 @@
   <div class="mt-2 h-full{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }}"
        {% if styling.color %}style="color: {{ styling.color }}"{% endif %}
        data-styling='{{ styling | tojson }}'>
-    {% set macro_name = field_macro_map.get(field_type) if field_macro_map else None %}
     {{ current_app.logger.debug('[render] field=%s type=%s edit_param=%s', field, field_type, edit_param) }}
-    {% if macro_name and (self|attr(macro_name)) %}
-      {% if edit_param == field %}
-        {{ current_app.logger.debug('[DEBUG: ' ~ field ~ ' \u2192 ' ~ field_type ~ ']') }}
-      {% endif %}
-      {{ (self|attr(macro_name))(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
+    {% if field_type == 'text' %}
+      {{ render_text(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
+    {% elif field_type == 'number' %}
+      {{ render_number(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
+    {% elif field_type == 'date' %}
+      {{ render_date(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
+    {% elif field_type == 'select' %}
+      {{ render_select(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
+    {% elif field_type == 'multi_select' %}
+      {{ render_multi_select(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
+    {% elif field_type == 'foreign_key' %}
+      {{ render_foreign_key(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
+    {% elif field_type == 'boolean' %}
+      {{ render_boolean(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
+    {% elif field_type == 'textarea' %}
+      {{ render_textarea(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
+    {% elif field_type == 'url' %}
+      {{ render_url(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
     {% else %}
       <span class="ml-1" data-field="{{ field }}"><b>{{ field|capitalize }}:</b> {{ value }}</span>
     {% endif %}


### PR DESCRIPTION
## Summary
- fix dynamic macro lookup in `render_editable_field`
- call rendering macros directly based on field type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea3efeac8833381c3fa5a7d58077e