### PR TITLE
Fix detail view field labels

### DIFF
--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -201,7 +201,8 @@
   <div class="mt-2 h-full{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }}"
        {% if styling.color %}style="color: {{ styling.color }}"{% endif %}
        data-styling='{{ styling | tojson }}'>
-    {{ current_app.logger.debug('[render] field=%s type=%s edit_param=%s', field, field_type, edit_param) }}
+    {% do current_app.logger.debug('[render] field=%s type=%s edit_param=%s', field, field_type, edit_param) %}
+    <label class="block text-sm font-medium capitalize">{{ field }}</label>
     {% if field_type == 'text' %}
       {{ render_text(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
     {% elif field_type == 'number' %}


### PR DESCRIPTION
## Summary
- prevent debug logging from rendering to the page
- show field name labels in detail view

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ea72165d88333bf7626953d280a69