### PR TITLE
Implement click-away save in detail view

### DIFF
--- a/static/js/click_to_edit.js
+++ b/static/js/click_to_edit.js
@@ -1,3 +1,5 @@
+import { submitFieldAjax } from './field_ajax.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const grid = document.getElementById('layout-grid');
   if (!grid) return;
@@ -30,4 +32,21 @@ document.addEventListener('DOMContentLoaded', () => {
       window.location.href = url.pathname + url.search;
     }
   });
+
+  const url = new URL(window.location.href);
+  const editField = url.searchParams.get('edit');
+  if (editField) {
+    const activeEl = document.querySelector(`.draggable-field[data-field="${editField}"]`);
+    const form = activeEl ? activeEl.querySelector('form') : null;
+    const handleClickAway = (e) => {
+      if (activeEl && activeEl.contains(e.target)) return;
+      document.removeEventListener('click', handleClickAway);
+      Promise.resolve(form ? submitFieldAjax(form) : null).finally(() => {
+        const newUrl = new URL(window.location.href);
+        newUrl.searchParams.delete('edit');
+        window.location.href = newUrl.pathname + newUrl.search;
+      });
+    };
+    document.addEventListener('click', handleClickAway);
+  }
 });

--- a/static/js/field_ajax.js
+++ b/static/js/field_ajax.js
@@ -4,7 +4,7 @@ export function submitFieldAjax(formEl) {
     statusEl.textContent = 'Saving…';
     statusEl.classList.remove('hidden');
   }
-  fetch(formEl.action, {
+  return fetch(formEl.action, {
     method: formEl.method || 'POST',
     headers: { 'X-Requested-With': 'XMLHttpRequest' },
     body: new FormData(formEl)
@@ -15,12 +15,14 @@ export function submitFieldAjax(formEl) {
         statusEl.textContent = 'Saved';
         setTimeout(() => statusEl.classList.add('hidden'), 2000);
       }
+      return resp;
     })
-    .catch(() => {
+    .catch(err => {
       if (statusEl) {
         statusEl.textContent = 'Error';
         setTimeout(() => statusEl.classList.add('hidden'), 2000);
       }
+      throw err;
     });
 }
 window.submitFieldAjax = submitFieldAjax;


### PR DESCRIPTION
## Summary
- return a promise from `submitFieldAjax` so callers can chain actions
- allow exiting edit mode by clicking outside the field in detail view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eab0ebf9083338c28348a6e0634c1