### PR TITLE
Remove import button from dashboard

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,7 +4,6 @@
 
 {% block nav_buttons %}
 <button id="dashboard_add" onclick="openDashboardModal()" class="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600">+ Add</button>
-<a href="/import" class="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600">Import</a>
 <button id="dashboard_edit" class="bg-purple-500 text-white px-3 py-1 rounded hover:bg-purple-600">Edit Layout</button>
 <button id="dashboard_save" class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 hidden">Save Layout</button>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove `Import` button from the dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eabcb2dd88333af2b0bb454814b2c