### PR TITLE
Add text size styling for fields

### DIFF
--- a/static/js/field_styling.js
+++ b/static/js/field_styling.js
@@ -5,6 +5,7 @@ function applyStyling(el, styling) {
   el.classList.toggle('italic', !!styling.italic);
   el.classList.toggle('underline', !!styling.underline);
   el.style.color = styling.color || '';
+  el.style.fontSize = styling.size ? `${styling.size}px` : '';
   const label = el.querySelector('div.text-sm.font-bold.capitalize.mb-1');
   if (label) label.classList.remove('hidden');
 }
@@ -29,6 +30,10 @@ document.addEventListener('DOMContentLoaded', () => {
     <label class="flex items-center space-x-2"><input type="checkbox" data-opt="bold"> <span>Bold</span></label>
     <label class="flex items-center space-x-2"><input type="checkbox" data-opt="italic"> <span>Italic</span></label>
     <label class="flex items-center space-x-2"><input type="checkbox" data-opt="underline"> <span>Underline</span></label>
+    <label class="flex items-center space-x-2">
+      <span class="whitespace-nowrap">Size</span>
+      <input type="number" data-opt="size" min="10" max="48" step="1" class="w-16 border rounded px-1 text-xs">
+    </label>
     <div id="color-presets" class="flex space-x-1 mt-1"></div>
   `;
   document.body.appendChild(menu);
@@ -59,6 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
     menu.querySelector('[data-opt="bold"]').checked = !!styling.bold;
     menu.querySelector('[data-opt="italic"]').checked = !!styling.italic;
     menu.querySelector('[data-opt="underline"]').checked = !!styling.underline;
+    menu.querySelector('[data-opt="size"]').value = styling.size || '';
     selectedColor = styling.color || '#000000';
     menu.style.left = `${e.pageX}px`;
     menu.style.top = `${e.pageY}px`;
@@ -92,7 +98,8 @@ document.addEventListener('DOMContentLoaded', () => {
       bold: menu.querySelector('[data-opt="bold"]').checked,
       italic: menu.querySelector('[data-opt="italic"]').checked,
       underline: menu.querySelector('[data-opt="underline"]').checked,
-      color: selectedColor
+      color: selectedColor,
+      size: parseInt(menu.querySelector('[data-opt="size"]').value, 10) || null
     });
     currentEl._styling = styling;
     applyStyling(currentEl, styling);

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -54,17 +54,19 @@
           {% set col_span  = layout.colSpan  or 1 %}
           {% set row_start = layout.rowStart or 1 %}
           {% set row_span  = layout.rowSpan  or 1 %}
+          {% set style_parts = [
+            'position: relative',
+            'grid-column: ' ~ col_start ~ ' / span ' ~ col_span,
+            'grid-row: ' ~ row_start ~ ' / span ' ~ row_span
+          ] %}
+          {% if styling.color %}{% set _ = style_parts.append('color: ' ~ styling.color) %}{% endif %}
+          {% if styling.size %}{% set _ = style_parts.append('font-size: ' ~ styling.size ~ 'px') %}{% endif %}
           <div id="draggable-field-{{ field }}"
                class="draggable-field border p-2 rounded shadow bg-gray-50{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }}"
                data-field="{{ field }}"
                data-type="{{ field_schema[table][field].type }}"
                data-styling='{{ styling | tojson }}'
-               style="
-                position: relative;
-                 grid-column: {{ col_start }} / span {{ col_span }};
-                 grid-row:    {{ row_start }} / span {{ row_span }};
-                 {% if styling.color %}color: {{ styling.color }};{% endif %}
-               ">
+               style="{{ style_parts | join('; ') }}">
             {{ fields.render_editable_field(
                  field, value, record.id, request,
                 'detail_view', 'records.update_field',

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -198,8 +198,11 @@
 {% macro render_editable_field(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema, field_macro_map=None) %}
   {% set edit_param = request.args.get('edit') %}
   {% set styling = field_schema[table][field].styling or {} %}
+  {% set style_parts = [] %}
+  {% if styling.color %}{% set _ = style_parts.append('color: ' ~ styling.color) %}{% endif %}
+  {% if styling.size %}{% set _ = style_parts.append('font-size: ' ~ styling.size ~ 'px') %}{% endif %}
   <div class="mt-2 h-full{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }}"
-       {% if styling.color %}style="color: {{ styling.color }}"{% endif %}
+       {% if style_parts %}style="{{ style_parts|join('; ') }}"{% endif %}
        data-styling='{{ styling | tojson }}'>
     {% do current_app.logger.debug('[render] field=%s type=%s edit_param=%s', field, field_type, edit_param) %}
     <label class="block text-sm font-medium capitalize">{{ field }}</label>


### PR DESCRIPTION
## Summary
- allow modifying font size via field styling context menu
- support font size in Jinja templates when rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eadfaba6c8333a65973d598cef5e6