### PR TITLE
Implement dashboard right-click styling

### DIFF
--- a/static/js/field_styling.js
+++ b/static/js/field_styling.js
@@ -1,4 +1,4 @@
-// Context menu for styling fields on the detail view
+// Context menu for styling fields on the detail view and dashboard widgets
 
 function applyStyling(el, styling) {
   el.classList.toggle('font-bold', !!styling.bold);
@@ -19,8 +19,10 @@ function sendStyling(table, field, styling) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  const layoutGrid = document.getElementById('layout-grid');
+  const layoutGrid = document.getElementById('layout-grid') ||
+                     document.getElementById('dashboard-grid');
   if (!layoutGrid) return;
+  const isDashboard = layoutGrid.id === 'dashboard-grid';
 
   const menu = document.createElement('div');
   menu.id = 'field-style-menu';
@@ -91,8 +93,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   menu.addEventListener('change', () => {
     if (!currentEl) return;
-    const table = layoutGrid.dataset.table;
-    const field = currentEl.dataset.field;
 
     const styling = Object.assign({}, currentEl._styling, {
       bold: menu.querySelector('[data-opt="bold"]').checked,
@@ -103,7 +103,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     currentEl._styling = styling;
     applyStyling(currentEl, styling);
-    sendStyling(table, field, styling);
+
+    if (!isDashboard) {
+      const table = layoutGrid.dataset.table;
+      const field = currentEl.dataset.field;
+      sendStyling(table, field, styling);
+    }
   });
 });
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -119,8 +119,24 @@
 
 <script>const FIELD_SCHEMA = {{ field_schema | tojson }};</script>
 <script>window.WIDGET_LAYOUT = {{ widget_layout | tojson }};</script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('#dashboard-grid .draggable-field').forEach(el => {
+      let data = el.dataset.styling;
+      try {
+        el._styling = data ? JSON.parse(data) : {};
+      } catch (e) {
+        el._styling = {};
+      }
+      if (window.applyFieldStyling) {
+        window.applyFieldStyling(el, el._styling);
+      }
+    });
+  });
+</script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="{{ url_for('static', filename='js/flowbite-charts.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/field_styling.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_modal.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_grid.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_charts.js') }}"></script>


### PR DESCRIPTION
## Summary
- extend `field_styling.js` so the context menu also works on `dashboard-grid`
- initialise widget styling in `dashboard.html`
- load the shared styling script on the dashboard page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb19f478883339e816235151fc3e3