### PR TITLE
Improve AJAX editing without page reload

### DIFF
--- a/static/js/click_to_edit.js
+++ b/static/js/click_to_edit.js
@@ -1,52 +1,84 @@
 import { submitFieldAjax } from './field_ajax.js';
 
+// Helper to fetch the HTML for a specific field either in view or edit mode
+async function fetchFieldHTML(field, edit) {
+  const url = new URL(window.location.href);
+  if (edit) {
+    url.searchParams.set('edit', field);
+  } else {
+    url.searchParams.delete('edit');
+  }
+  const resp = await fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+  const text = await resp.text();
+  const doc = new DOMParser().parseFromString(text, 'text/html');
+  const el = doc.querySelector(`.draggable-field[data-field="${field}"]`);
+  return el ? el.innerHTML : null;
+}
+
+// Minimal inline version of editor.js initialization for Quill
+function initQuill(container) {
+  if (typeof Quill === 'undefined') return;
+  container.querySelectorAll('[data-quill]').forEach(el => {
+    const form = el.closest('form');
+    if (!form) return;
+    let input = form.querySelector('input[name="new_value"]');
+    if (!input) {
+      input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = 'new_value';
+      form.appendChild(input);
+    }
+    const quill = new Quill(el, { theme: 'snow' });
+    input.value = quill.root.innerHTML;
+    quill.on('text-change', () => {
+      input.value = quill.root.innerHTML;
+      if (form.hasAttribute('data-autosave')) {
+        submitFieldAjax(form);
+      }
+    });
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const grid = document.getElementById('layout-grid');
   if (!grid) return;
 
-  const table = grid.dataset.table;
-  const recordId = grid.dataset.recordId;
+  let currentEl = null;
 
-  grid.addEventListener('click', (e) => {
+  grid.addEventListener('click', async (e) => {
     if (grid.classList.contains('editing')) return;
-
     const fieldEl = e.target.closest('.draggable-field');
     if (!fieldEl) return;
-
     if (['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A'].includes(e.target.tagName)) {
       return;
     }
 
     const field = fieldEl.dataset.field;
     const type = fieldEl.dataset.type;
+    if (type === 'boolean' || fieldEl.querySelector('form') || currentEl) return;
 
-    console.log('[click_to_edit] clicked field:', field, 'type:', type);
+    const html = await fetchFieldHTML(field, true);
+    if (!html) return;
+    fieldEl.innerHTML = html;
+    initQuill(fieldEl);
+    currentEl = fieldEl;
 
-    if (type === 'boolean') return;
-    if (fieldEl.querySelector('form')) return;
-
-    if (table && recordId && field) {
-      const url = new URL(window.location.href);
-      url.searchParams.set('edit', field);
-      console.log('[click_to_edit] navigating to:', url.pathname + url.search);
-      window.location.href = url.pathname + url.search;
-    }
-  });
-
-  const url = new URL(window.location.href);
-  const editField = url.searchParams.get('edit');
-  if (editField) {
-    const activeEl = document.querySelector(`.draggable-field[data-field="${editField}"]`);
-    const form = activeEl ? activeEl.querySelector('form') : null;
-    const handleClickAway = (e) => {
-      if (activeEl && activeEl.contains(e.target)) return;
+    const form = fieldEl.querySelector('form');
+    const handleClickAway = async (evt) => {
+      if (fieldEl.contains(evt.target)) return;
       document.removeEventListener('click', handleClickAway);
-      Promise.resolve(form ? submitFieldAjax(form) : null).finally(() => {
-        const newUrl = new URL(window.location.href);
-        newUrl.searchParams.delete('edit');
-        window.location.href = newUrl.pathname + newUrl.search;
-      });
+      try {
+        if (form) await submitFieldAjax(form);
+      } catch (err) {
+        console.error('submitFieldAjax failed', err);
+      } finally {
+        const newHtml = await fetchFieldHTML(field, false);
+        if (newHtml) {
+          fieldEl.innerHTML = newHtml;
+        }
+        currentEl = null;
+      }
     };
     document.addEventListener('click', handleClickAway);
-  }
+  });
 });


### PR DESCRIPTION
## Summary
- update `click_to_edit.js` to load forms and update values via AJAX instead of reloading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb0a5effc833381727133cca10b9e