### PR TITLE
Persist dashboard styling

### DIFF
--- a/static/js/field_styling.js
+++ b/static/js/field_styling.js
@@ -18,6 +18,14 @@ function sendStyling(table, field, styling) {
   }).catch(err => console.error('Styling update failed', err));
 }
 
+function sendDashboardStyling(widgetId, styling) {
+  fetch('/dashboard/style', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ widget_id: widgetId, styling })
+  }).catch(err => console.error('Dashboard styling update failed', err));
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const layoutGrid = document.getElementById('layout-grid') ||
                      document.getElementById('dashboard-grid');
@@ -139,6 +147,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const table = layoutGrid.dataset.table;
       const field = currentEl.dataset.field;
       sendStyling(table, field, styling);
+    } else {
+      const widgetId = currentEl.dataset.widget;
+      if (widgetId) {
+        sendDashboardStyling(widgetId, styling);
+      }
     }
   });
 });

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -38,6 +38,7 @@
          data-widget="{{ widget.id }}"
          data-type="{{ widget.widget_type }}"
          {% if widget.widget_type in ['chart', 'value'] %}data-config='{{ widget.content }}'{% endif %}
+         data-styling="{{ widget.styling or '{}' }}"
          style="grid-column: {{ col_start }} / span {{ col_span }}; grid-row: {{ row_start }} / span {{ row_span }};">
       {% if widget.widget_type == 'value' %}
         <div class="font-semibold">{{ widget.title }}</div>

--- a/views/admin.py
+++ b/views/admin.py
@@ -17,6 +17,7 @@ from db.dashboard import (
     get_dashboard_widgets,
     create_widget,
     update_widget_layout,
+    update_widget_styling,
     get_base_table_counts,
     get_top_numeric_values,
     get_filtered_records,
@@ -218,6 +219,17 @@ def dashboard_update_layout():
     layout_items = data['layout']
     updated = update_widget_layout(layout_items)
     return jsonify({'success': True, 'updated': updated})
+
+
+@admin_bp.route('/dashboard/style', methods=['POST'])
+def dashboard_update_style():
+    data = request.get_json(silent=True) or {}
+    widget_id = data.get('widget_id')
+    styling = data.get('styling')
+    if widget_id is None or not isinstance(styling, dict):
+        return jsonify({'error': 'Invalid data'}), 400
+    success = update_widget_styling(widget_id, styling)
+    return jsonify({'success': bool(success)})
 
 
 @admin_bp.route('/dashboard/base-count')


### PR DESCRIPTION
## Summary
- include styling column when loading widgets
- save dashboard widget styling on right-click
- expose API to save widget styling
- add data-styling attribute for widgets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684eb5735804833396fd8d59cb80239a