### PR TITLE
Highlight active field during inline edit

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -15,6 +15,13 @@ input[type=number] {
   padding: 0 !important;
 }
 
+/* Highlight field container when its value is being edited */
+#layout-grid .draggable-field.active-edit {
+  border: 1px blue dashed !important;
+  box-shadow: 0 0 0 2px rgba(0,0,0,0.1) !important;
+  background-color: #fafafa !important;
+}
+
 /* 2) In edit mode, reset padding only */
 #layout-grid.editing .draggable-field {
   padding: 0;

--- a/static/js/click_to_edit.js
+++ b/static/js/click_to_edit.js
@@ -60,6 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const html = await fetchFieldHTML(field, true);
     if (!html) return;
     fieldEl.innerHTML = html;
+    fieldEl.classList.add('active-edit');
     initQuill(fieldEl);
     currentEl = fieldEl;
 
@@ -76,6 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (newHtml) {
           fieldEl.innerHTML = newHtml;
         }
+        fieldEl.classList.remove('active-edit');
         currentEl = null;
       }
     };

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -170,20 +170,26 @@
 <script>const layoutCache = {{ field_schema_layout | tojson }};</script>
 <script>window.FIELD_LAYOUT_DEFAULTS = {{ field_layout_defaults | tojson }};</script>
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('.draggable-field').forEach(el => {
-      let data = el.dataset.styling;
-      try {
-        el._styling = data ? JSON.parse(data) : {};
-      } catch (e) {
-        el._styling = {};
-      }
-      if (window.applyFieldStyling) {
-        window.applyFieldStyling(el, el._styling);
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.draggable-field').forEach(el => {
+        let data = el.dataset.styling;
+        try {
+          el._styling = data ? JSON.parse(data) : {};
+        } catch (e) {
+          el._styling = {};
+        }
+        if (window.applyFieldStyling) {
+          window.applyFieldStyling(el, el._styling);
+        }
+      });
+      const params = new URLSearchParams(window.location.search);
+      const editField = params.get('edit');
+      if (editField) {
+        const activeEl = document.getElementById(`draggable-field-${editField}`);
+        if (activeEl) activeEl.classList.add('active-edit');
       }
     });
-  });
-</script>
+  </script>
 <script src="{{ url_for('static', filename='js/layout_editor.js') }}"></script>
 <script src="{{ url_for('static', filename='js/field_styling.js') }}"></script>
 


### PR DESCRIPTION
## Summary
- improve `click_to_edit.js` to add/remove an `active-edit` class when a field is being edited
- style `.draggable-field.active-edit` with an outline
- mark the correct field as active on page load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb5ed49f08333ae5878bb0c96d3aa