### PR TITLE
Fix dashboard widget overflow

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -110,6 +110,7 @@ input[type=number] {
 #dashboard-grid .dashboard-widget {
   padding: 0.5rem !important;   /* Tailwind p-2 */
   box-sizing: border-box;       /* so h-full includes padding */
+  height: 100%;                 /* keep content within grid cell */
 }
 #dashboard-grid .resize-handle {
   position: absolute;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -47,5 +47,6 @@
 /* Add a subtle outline around dashboard widgets */
 .dashboard-widget {
   outline: 1px solid #e5e7eb; /* tailwind gray-200 */
+  height: 100%;
 }
 


### PR DESCRIPTION
## Summary
- ensure dashboard widgets fill their grid cell

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ed1fe8a3083338db532f507d7339e