### PR TITLE
Add button utility classes and replace inline styles

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -74,3 +74,41 @@ body {
   flex: 1 1 auto;
 }
 
+/* Button styles */
+.btn-primary,
+.btn-secondary,
+.btn-danger {
+  color: #fff;
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.25rem;
+  display: inline-block;
+}
+
+.btn-primary { background-color: var(--color-primary); }
+.btn-secondary { background-color: var(--color-secondary); }
+.btn-danger { background-color: var(--color-danger); }
+
+.btn-primary:hover,
+.btn-secondary:hover,
+.btn-danger:hover {
+  filter: brightness(90%);
+}
+
+/* Card component */
+.card {
+  background-color: #fff;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+/* Modal container */
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0,0,0,0.5);
+  backdrop-filter: blur(4px);
+  z-index: 50;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,10 +24,10 @@
 
     <div class="ml-auto flex space-x-2">
       {% if current_table in field_schema %}
-        <a href="/{{ current_table }}/new" class="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600">+ Add</a>
+        <a href="/{{ current_table }}/new" class="btn-primary px-3 py-1 rounded">+ Add</a>
         {% if current_id %}
           <form method="post" action="/{{ current_table }}/{{ current_id }}/delete" onsubmit="return confirm('Are you sure?')">
-            <button type="submit" class="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">Delete</button>
+            <button type="submit" class="btn-danger px-3 py-1 rounded">Delete</button>
           </form>
         {% endif %}
       {% endif %}

--- a/templates/bulk_edit_modal.html
+++ b/templates/bulk_edit_modal.html
@@ -16,7 +16,7 @@
       <div id="bulk-input-container"></div>
       <div id="bulk-edit-status" class="text-sm hidden"></div>
       <div class="text-right">
-        <button type="submit" class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600">Submit</button>
+        <button type="submit" class="btn-primary px-3 py-1 rounded">Submit</button>
       </div>
     </form>
   </div>

--- a/templates/config_admin.html
+++ b/templates/config_admin.html
@@ -71,7 +71,7 @@
                 {% else %}
                   <input type="text" name="value" value="{{ item.value }}" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-blue-500 focus:border-blue-500">
                 {% endif %}
-                <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Save</button>
+                <button type="submit" class="btn-primary px-3 py-1 rounded">Save</button>
               </form>
             </td>
             <td class="px-2 py-1">{{ item.description }}</td>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -3,15 +3,15 @@
 {% block title %}Dashboard{% endblock %}
 
 {% block nav_buttons %}
-<button id="dashboard_add" onclick="openDashboardModal()" class="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600">+ Add</button>
-<button id="dashboard_edit" class="bg-purple-500 text-white px-3 py-1 rounded hover:bg-purple-600">Edit Layout</button>
-<button id="dashboard_save" class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 hidden">Save Layout</button>
+<button id="dashboard_add" onclick="openDashboardModal()" class="btn-primary px-3 py-1 rounded">+ Add</button>
+<button id="dashboard_edit" class="btn-secondary px-3 py-1 rounded">Edit Layout</button>
+<button id="dashboard_save" class="btn-primary px-3 py-1 rounded hidden">Save Layout</button>
 {% endblock %}
 
 {% block content %}
 <div class="flex items-center mb-4">
   <h1 class="text-3xl font-bold mr-4">Dashboard</h1>
-  <button id="dashboard_update" class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600">Update</button>
+  <button id="dashboard_update" class="btn-primary px-3 py-1 rounded">Update</button>
 </div>
 {% if not widgets %}
 <p class="text-gray-600">No widgets visible with current permissions please create new</p>

--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -85,7 +85,7 @@
           <input id="valueTitleInput" type="text" class="px-3 py-2 border rounded flex-grow" />
           <div id="valueResult" class="font-semibold"></div>
         </div>
-        <button id="dashboardCreateBtn" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 hidden mt-4 block ml-auto">Create</button>
+        <button id="dashboardCreateBtn" type="submit" class="btn-primary px-4 py-2 rounded hidden mt-4 block ml-auto">Create</button>
       </form>
     </div>
     <div id="pane-table" class="hidden">
@@ -167,7 +167,7 @@
           </table>
         </div>
         <input id="tableTitleInput" type="text" placeholder="Widget Title" class="px-3 py-2 border rounded w-full mb-4 hidden" />
-        <button id="tableCreateBtn" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 block ml-auto hidden">Create</button>
+        <button id="tableCreateBtn" type="submit" class="btn-primary px-4 py-2 rounded block ml-auto hidden">Create</button>
       </form>
     </div>
     <div id="pane-chart" class="hidden">
@@ -224,7 +224,7 @@
           </label>
         </div>
         <input id="chartTitleInput" type="text" placeholder="Widget Title" class="px-3 py-2 border rounded w-full mb-4 hidden" />
-        <button id="chartCreateBtn" type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 block ml-auto hidden">Create</button>
+        <button id="chartCreateBtn" type="submit" class="btn-primary px-4 py-2 rounded block ml-auto hidden">Create</button>
       </form>
     </div>
   </div>

--- a/templates/database_admin.html
+++ b/templates/database_admin.html
@@ -9,9 +9,9 @@
     <div id="db-path-display" class="px-2 py-1 text-sm font-mono rounded {{ 'text-green-600' if db_status == 'valid' else 'text-red-600' }}">{{ db_path }}</div>
     <form id="db-upload-form" class="flex items-center space-x-2" enctype="multipart/form-data">
       <input type="file" name="file" accept=".db" class="text-sm border border-gray-300 rounded" />
-      <button type="submit" class="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded border border-white hover:border-transparent">Change Database</button>
+      <button type="submit" class="btn-danger px-3 py-1 rounded">Change Database</button>
     </form>
-    <button id="create-db-btn" type="button" class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded">Create New DB</button>
+    <button id="create-db-btn" type="button" class="btn-primary px-3 py-1 rounded">Create New DB</button>
   </div>
 </div>
 <script type="module" src="{{ url_for('static', filename='js/database_admin.js') }}"></script>

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -17,10 +17,10 @@
     </h1>
 
     <div id="detail-button-container" class="flex space-x-2 mb-4">
-      <button id="toggle-edit-layout" class="px-4 py-2 bg-blue-500 text-white rounded">
+      <button id="toggle-edit-layout" class="btn-primary px-4 py-2 rounded">
         Edit Layout
       </button>
-      <button id="save-layout" class="px-4 py-2 bg-green-500 text-white hidden rounded">
+      <button id="save-layout" class="btn-primary px-4 py-2 hidden rounded">
         Save Layout
       </button>
       <button id="reset-layout" class="px-4 py-2 bg-gray-300 text-black rounded hidden">
@@ -29,7 +29,7 @@
       <button
         id="add-field"
         onclick="openLayoutModal()"
-        class="ml-2 px-4 py-2 bg-green-500 text-white rounded"
+        class="btn-primary ml-2 px-4 py-2 rounded"
       >
         Edit Fields
       </button>
@@ -159,7 +159,7 @@
     <div class="flex justify-end">
       <button
         onclick="submitRelation()"
-        class="px-4 py-2 rounded bg-green-500 text-white hover:bg-green-600"
+        class="btn-primary px-4 py-2 rounded"
       >
         Add
       </button>

--- a/templates/edit_fields_modal.html
+++ b/templates/edit_fields_modal.html
@@ -46,7 +46,7 @@
         </div>
         <div class="flex justify-end mt-4">
           <button type="submit"
-                  class="px-4 py-2 rounded bg-green-500 text-white hover:bg-green-600">Submit</button>
+                  class="btn-primary px-4 py-2 rounded">Submit</button>
         </div>
       </form>
       <script src="{{ url_for('static', filename='js/edit_fields.js') }}"></script>
@@ -88,7 +88,7 @@
           <button
             id="remove-submit-btn"
             type="submit"
-            class="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+            class="btn-danger px-4 py-2 rounded disabled:opacity-50"
             disabled>
             Remove
           </button>

--- a/templates/import_view.html
+++ b/templates/import_view.html
@@ -20,7 +20,7 @@
       <form method="POST" action="/import" enctype="multipart/form-data" class="flex items-center space-x-2">
         <input type="hidden" name="table" value="{{ selected_table }}">
         <input type="file" name="file" accept=".csv" class="border rounded px-3 py-2">
-        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Upload</button>
+        <button type="submit" class="btn-primary px-4 py-2 rounded">Upload</button>
       </form>
       {% endif %}
       {% if num_records is defined %}
@@ -29,7 +29,7 @@
       </div>
       {% endif %}
       <!-- Import Records button, initially disabled -->
-    <button id="import-btn" type="button" disabled class="ml-auto bg-green-500 text-white px-4 py-2 rounded opacity-50 cursor-not-allowed">
+    <button id="import-btn" type="button" disabled class="ml-auto btn-primary px-4 py-2 rounded opacity-50 cursor-not-allowed">
       Import Records
     </button>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,8 +3,8 @@
 {% block title %}Home{% endblock %}
 
 {% block nav_buttons %}
-<a href="/import" class="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600">Import</a>
-<a href="/admin" class="bg-indigo-500 text-white px-3 py-1 rounded hover:bg-indigo-600">Admin</a>
+<a href="/import" class="btn-primary px-3 py-1 rounded">Import</a>
+<a href="/admin" class="btn-secondary px-3 py-1 rounded">Admin</a>
 {% endblock %}
 
 {% block content %}
@@ -43,7 +43,7 @@
         <textarea id="tableDescription" class="w-full border rounded p-2"></textarea>
       </div>
       <div class="flex justify-end">
-        <button type="submit" class="px-4 py-2 rounded bg-blue-500 text-white hover:bg-blue-600">Add</button>
+        <button type="submit" class="btn-primary px-4 py-2 rounded">Add</button>
       </div>
     </form>
   </div>

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -4,7 +4,7 @@
 {% import 'macros/filter_controls.html' as filters %}
 {% block body_class %}list-view-page{% endblock %}
 {% block nav_buttons %}
-<button id="bulk_edit" onclick="openBulkEditModal()" class="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 opacity-50" disabled>Bulk Edit</button>
+<button id="bulk_edit" onclick="openBulkEditModal()" class="btn-primary px-3 py-1 rounded opacity-50" disabled>Bulk Edit</button>
 {% endblock %}
 {% block content %}
 <div class="w-full bg-white p-6 rounded shadow-md">
@@ -21,7 +21,7 @@
         value="{{ request.args.get('search','') }}"
         class="border rounded px-2 py-1 w-64"
       />
-      <button type="submit" class="bg-blue-500 text-white px-3 py-1 rounded ">
+      <button type="submit" class="btn-primary px-3 py-1 rounded ">
         Search
       </button>
     </div>
@@ -38,7 +38,7 @@
       </button>
       <a
         href="{{ url_for('records.export_csv', table=table) }}{{ '?' if base_qs else '' }}{{ base_qs }}"
-        class="text-sm bg-green-500 text-white px-2 py-1 rounded"
+        class="btn-primary text-sm px-2 py-1 rounded"
       >
         Export CSV
       </a>

--- a/templates/new_record.html
+++ b/templates/new_record.html
@@ -25,7 +25,7 @@
     {% endif %}
   {% endfor %}
 
-  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Create</button>
+  <button type="submit" class="btn-primary px-4 py-2 rounded">Create</button>
 </form>
 <script type="module" src="{{ url_for('static', filename='js/editor.js') }}"></script>
 {% endblock %}

--- a/templates/wizard_database.html
+++ b/templates/wizard_database.html
@@ -11,7 +11,7 @@
     <label class="block mb-1">Or create new database</label>
     <input type="text" name="create_name" class="border rounded px-2 py-1" placeholder="name.db">
   </div>
-  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Continue</button>
+  <button type="submit" class="btn-primary px-4 py-2 rounded">Continue</button>
 </form>
 <p class="text-sm mt-4">Current path: {{ db_path }} ({{ db_status }})</p>
 {% endblock %}

--- a/templates/wizard_import.html
+++ b/templates/wizard_import.html
@@ -15,7 +15,7 @@
     <label class="block mb-1">CSV File</label>
     <input type="file" name="file" accept=".csv" class="border rounded px-2 py-1">
   </div>
-  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Import</button>
+  <button type="submit" class="btn-primary px-4 py-2 rounded">Import</button>
   <a href="{{ url_for('wizard.table_step') }}" class="ml-4 text-blue-600 underline">Back</a>
   <a href="{{ url_for('wizard.skip_import') }}" class="ml-4 underline">Skip</a>
   </form>

--- a/templates/wizard_settings.html
+++ b/templates/wizard_settings.html
@@ -28,7 +28,7 @@
     {% endif %}
   </div>
   {% endfor %}
-  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Continue</button>
+  <button type="submit" class="btn-primary px-4 py-2 rounded">Continue</button>
   <a href="{{ url_for('wizard.database_step') }}" class="ml-4 text-blue-600 underline">Back</a>
 </form>
 <script src="{{ url_for('static', filename='js/wizard_settings.js') }}"></script>

--- a/templates/wizard_table.html
+++ b/templates/wizard_table.html
@@ -17,7 +17,7 @@
     <ul id="fields-list" class="mb-2 list-disc pl-5"></ul>
     <button type="button" onclick="showAddFieldModal()" class="bg-gray-200 px-2 py-1 rounded">Add Field</button>
   </div>
-  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Continue</button>
+  <button type="submit" class="btn-primary px-4 py-2 rounded">Continue</button>
   <a href="{{ url_for('wizard.settings_step') }}" class="ml-4 text-blue-600 underline">Back</a>
   </form>
 
@@ -54,7 +54,7 @@
         </select>
       </div>
       <div class="flex justify-end">
-        <button type="submit" class="px-4 py-2 rounded bg-green-500 text-white hover:bg-green-600">Add</button>
+        <button type="submit" class="btn-primary px-4 py-2 rounded">Add</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- extend CSS with reusable button, card, and modal classes
- replace inline button colors with `btn-primary`, `btn-secondary`, and `btn-danger`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684edc2720908333b8b9c1d0eacc50ec