### PR TITLE
Integrate Flowbite UI components

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Automatic Dashboard Widget Placement:** New widgets are inserted at the next
   available row in the grid without specifying `row_start`.
 * **Dashboard Charts:** Pie, bar and line chart widgets rely on Flowbite Charts. The library is loaded only on the dashboard view. The repo ships a placeholder `flowbite-charts.min.js`; download the real library for production use.
+* **Flowbite UI Components:** Dropdowns and tabs use [Flowbite](https://github.com/themesberg/flowbite), an MIT-licensed library that permits commercial use.
 * **Table Widget:** Displays simple tabular data such as base table record counts.
 * **Select Value Counts:** Table widget option that shows counts of each choice for a select or multi-select field.
 * **Top/Bottom Numeric:** Table widget listing records with the highest or lowest values for a numeric field.
@@ -479,4 +480,4 @@ Modification, redistribution, or commercial deployment is prohibited without wri
 
 ## Acknowledgements
 
-This project uses [Flowbite](https://github.com/themesberg/flowbite) and Flowbite Charts under the MIT License.
+This project uses [Flowbite](https://github.com/themesberg/flowbite) and Flowbite Charts under the MIT License. Both libraries are open source and may be used commercially.

--- a/static/js/column_visibility.js
+++ b/static/js/column_visibility.js
@@ -24,20 +24,6 @@ document.addEventListener("DOMContentLoaded", () => {
       });
     });
   };
-
-  document.getElementById("toggle-columns").addEventListener("click", (e) => {
-    e.stopPropagation();
-    document.getElementById("column-dropdown").classList.toggle("hidden");
-  });
-
-  document.addEventListener("click", () => {
-    document.getElementById("column-dropdown").classList.add("hidden");
-  });
-
-  document.getElementById("column-dropdown").addEventListener("click", (e) => {
-    e.stopPropagation();
-  });
-
   // Attach listeners
   checkboxes().forEach(cb =>
     cb.addEventListener("change", () => {

--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -353,26 +353,6 @@ function updateTablePreview() {
 
 function setActiveTab(name) {
   activeTab = name;
-  const tabs = ['value', 'table', 'chart'];
-  const colorMap = {
-    value: ['border-blue-600', 'text-blue-600'],
-    table: ['border-purple-600', 'text-purple-600'],
-    chart: ['border-pink-600', 'text-pink-600']
-  };
-
-  tabs.forEach(tabName => {
-    const tabEl = document.getElementById(`tab-${tabName}`);
-    const paneEl = document.getElementById(`pane-${tabName}`);
-    tabEl.classList.remove('border-blue-600', 'text-blue-600', 'border-purple-600', 'text-purple-600', 'border-pink-600', 'text-pink-600', 'border-transparent', 'text-gray-600');
-
-    if (tabName === name) {
-      tabEl.classList.add(...colorMap[tabName]);
-      paneEl.classList.remove('hidden');
-    } else {
-      tabEl.classList.add('border-transparent', 'text-gray-600');
-      paneEl.classList.add('hidden');
-    }
-  });
   updateColumnOptions();
   if (activeTab === 'table') updateTablePreview();
 }

--- a/static/js/edit_fields.js
+++ b/static/js/edit_fields.js
@@ -39,27 +39,6 @@ document.addEventListener("DOMContentLoaded", () => {
   });
   
 
-// Initialize Add/Remove tabs
-function initEditFieldsTabs() {
-  const tabAdd = document.getElementById("tab-add");
-  const tabRemove = document.getElementById("tab-remove");
-  const paneAdd = document.getElementById("pane-add");
-  const paneRemove = document.getElementById("pane-remove");
-
-  tabAdd.addEventListener("click", () => {
-    tabAdd.classList.add("border-blue-600", "text-blue-600");
-    tabRemove.classList.remove("border-blue-600", "text-blue-600");
-    paneAdd.classList.remove("hidden");
-    paneRemove.classList.add("hidden");
-  });
-
-  tabRemove.addEventListener("click", () => {
-    tabRemove.classList.add("border-blue-600", "text-blue-600");
-    tabAdd.classList.remove("border-blue-600", "text-blue-600");
-    paneRemove.classList.remove("hidden");
-    paneAdd.classList.add("hidden");
-  });
-}
 
 // Store fetched counts here
 let removeCounts = {};
@@ -114,6 +93,3 @@ function updateRemoveInfo(count) {
   }
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  initEditFieldsTabs();
-});

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,10 +2,10 @@
 <html>
 <head>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flowbite@1.6.5/dist/flowbite.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=IBM+Plex+Sans:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/overrides.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flowbite@1.6.5/dist/flowbite.min.css" />
   <link rel="stylesheet" href="{{ url_for('static', filename='lib/quill.snow.css') }}">
   <script src="{{ url_for('static', filename='lib/quill.js') }}"></script>
   {# Dashboard views load chart libraries explicitly #}

--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -3,20 +3,21 @@
      onclick="if(event.target.id === 'dashboardModal') closeDashboardModal()">
   <div class="bg-white p-6 rounded-lg shadow-lg w-fit min-w-[24rem] max-w-full relative">
     <button onclick="closeDashboardModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
-    <div class="mb-4">
-      <ul class="flex border-b border-gray-200">
-        <li class="-mb-px mr-1">
-          <button id="tab-value" class="bg-white inline-block py-2 px-4 font-semibold border-b-2 border-blue-600">Value</button>
+    <div class="mb-4 border-b border-gray-200">
+      <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="dashboardTab" data-tabs-toggle="#dashboardTabContent" role="tablist">
+        <li class="mr-2" role="presentation">
+          <button id="tab-value" data-tabs-target="#pane-value" type="button" role="tab" aria-controls="pane-value" aria-selected="true" class="inline-block p-2 rounded-t-lg border-b-2 text-blue-600 border-blue-600">Value</button>
         </li>
-        <li class="-mb-px mr-1">
-          <button id="tab-table" class="bg-white inline-block py-2 px-4 font-semibold text-gray-600 hover:text-gray-800 border-b-2 border-transparent">Table</button>
+        <li class="mr-2" role="presentation">
+          <button id="tab-table" data-tabs-target="#pane-table" type="button" role="tab" aria-controls="pane-table" aria-selected="false" class="inline-block p-2 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300">Table</button>
         </li>
-        <li class="-mb-px">
-          <button id="tab-chart" class="bg-white inline-block py-2 px-4 font-semibold text-gray-600 hover:text-gray-800 border-b-2 border-transparent">Chart</button>
+        <li role="presentation">
+          <button id="tab-chart" data-tabs-target="#pane-chart" type="button" role="tab" aria-controls="pane-chart" aria-selected="false" class="inline-block p-2 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300">Chart</button>
         </li>
       </ul>
     </div>
-    <div id="pane-value">
+    <div id="dashboardTabContent">
+    <div id="pane-value" role="tabpanel" aria-labelledby="tab-value">
       <form id="dashboardTableForm" class="relative w-full" onsubmit="event.preventDefault();">
 
         <div id="dashboardOperation" class="flex gap-2 mb-4">
@@ -227,6 +228,7 @@
         <button id="chartCreateBtn" type="submit" class="btn-primary px-4 py-2 rounded block ml-auto hidden">Create</button>
       </form>
     </div>
+  </div>
   </div>
 </div>
 

--- a/templates/edit_fields_modal.html
+++ b/templates/edit_fields_modal.html
@@ -2,22 +2,23 @@
      onclick="if(event.target.id === 'layoutModal') closeLayoutModal()">
   <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button type="button" onclick="closeLayoutModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
-    <div class="mb-4">
-      <ul class="flex border-b border-gray-200">
-        <li class="-mb-px mr-1">
-          <button id="tab-add" class="bg-white inline-block py-2 px-4 font-semibold border-b-2 border-blue-600">
+    <div class="mb-4 border-b border-gray-200">
+      <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="editFieldsTabs" data-tabs-toggle="#editFieldsContent" role="tablist">
+        <li class="mr-2" role="presentation">
+          <button id="tab-add" data-tabs-target="#pane-add" type="button" role="tab" aria-controls="pane-add" aria-selected="true" class="inline-block p-2 rounded-t-lg border-b-2 text-blue-600 border-blue-600">
             Add Field
           </button>
         </li>
-        <li class="-mb-px">
-          <button id="tab-remove" class="bg-white inline-block py-2 px-4 font-semibold text-gray-600 hover:text-gray-800 border-b-2 border-transparent">
+        <li role="presentation">
+          <button id="tab-remove" data-tabs-target="#pane-remove" type="button" role="tab" aria-controls="pane-remove" aria-selected="false" class="inline-block p-2 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300">
             Remove Field
           </button>
         </li>
       </ul>
     </div>
+    <div id="editFieldsContent">
     <!-- Add Field Pane -->
-    <div id="pane-add">
+    <div id="pane-add" role="tabpanel" aria-labelledby="tab-add">
       <h3 class="text-lg font-bold mb-4">Add Field to {{table}}</h3>
       <form method="POST" id="add-field-form" action="/{{ table }}/{{ record.id }}/add-field">
         <input type="hidden" name="record_id" value="{{ record.id }}">
@@ -96,4 +97,5 @@
       </form>
     </div>
  </div>
+</div>
 </div>

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -46,10 +46,10 @@
   </form>
   <!-- Visibility control -->
   <div class="relative inline-block text-left mb-4" id="column-visibility-wrapper">
-    <button id="toggle-columns" type="button" class="px-2 py-1 bg-gray-200 rounded">
+    <button id="toggle-columns" type="button" data-dropdown-toggle="column-dropdown" class="px-2 py-1 bg-gray-200 rounded">
       Columns
     </button>
-    <div id="column-dropdown" class="absolute z-10 mt-2 bg-white border rounded shadow hidden p-2 space-y-1 w-48">
+    <div id="column-dropdown" class="z-10 hidden mt-2 bg-white border rounded shadow p-2 space-y-1 w-48">
       {% for field in fields if not field.startswith('_') %}
         <label class="flex items-center space-x-2">
           <input type="checkbox" class="column-toggle" value="{{ field }}" checked>
@@ -60,10 +60,10 @@
   </div>
   <!-- Filters control -->
   <div id="filters-visibility-wrapper" class="relative inline-block text-left mb-4">
-    <button type="button" id="toggle-filters" class="px-2 py-1 bg-gray-200 rounded">
+    <button type="button" id="toggle-filters" data-dropdown-toggle="filter-dropdown" class="px-2 py-1 bg-gray-200 rounded">
       Filters
     </button>
-    <div id="filter-dropdown" class="absolute z-10 mt-2 bg-white border rounded shadow hidden p-2 space-y-1 w-48">
+    <div id="filter-dropdown" class="z-10 hidden mt-2 bg-white border rounded shadow p-2 space-y-1 w-48">
     </div>
   </div>
   


### PR DESCRIPTION
## Summary
- load Flowbite after Tailwind in `base.html`
- switch list view dropdowns to Flowbite
- simplify modal tabs using Flowbite tabs
- drop custom JS for tab toggling
- document Flowbite dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee3e908a88333b9e0283c4e57c9ea