### PR TITLE
Move nav buttons to sidebar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,13 +18,16 @@
 
   <div id="sidebarBackdrop" class="modal hidden md:hidden"></div>
   <div class="flex min-h-screen">
-    <aside id="sidebar" class="fixed md:static top-0 left-0 z-40 w-64 h-screen pt-4 bg-gray-800 text-gray-100 transform -translate-x-full md:translate-x-0 transition-transform">
-      <nav class="h-full overflow-y-auto px-3 space-y-2">
+    <aside id="sidebar" class="fixed md:static top-0 left-0 z-40 w-64 h-screen pt-4 bg-gray-800 text-gray-100 transform -translate-x-full md:translate-x-0 transition-transform flex flex-col">
+      <nav class="flex-1 overflow-y-auto px-3 space-y-2">
         <a href="/" class="block px-2 py-1 rounded hover:bg-gray-700 {{ 'bg-gray-700' if not current_table else '' }}">Home</a>
         {% for nav in nav_cards if nav.table_name != 'dashboard' %}
           <a href="/{{ nav.table_name }}" class="block px-2 py-1 rounded hover:bg-gray-700 {{ 'bg-gray-700' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
         {% endfor %}
       </nav>
+      <div class="p-3 grid grid-cols-2 gap-2">
+        {% block nav_buttons %}{% endblock %}
+      </div>
     </aside>
 
     <div class="flex-1 flex flex-col md:ml-64">
@@ -41,7 +44,6 @@
               </form>
             {% endif %}
           {% endif %}
-          {% block nav_buttons %}{% endblock %}
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- relocate `nav_buttons` block from header to bottom of sidebar
- display buttons in a two-column grid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb86c0b1c8333a945606d7433ff2d