### PR TITLE
Enable Escape key to dismiss modals

### DIFF
--- a/static/js/add_table.js
+++ b/static/js/add_table.js
@@ -1,9 +1,23 @@
+let addTableTrigger = null;
+let escHandler = (e) => {
+  if (e.key === 'Escape') {
+    closeAddTableModal();
+  }
+};
+
 export function openAddTableModal() {
+  addTableTrigger = document.activeElement;
   document.getElementById('addTableModal').classList.remove('hidden');
+  document.addEventListener('keydown', escHandler);
 }
 
 export function closeAddTableModal() {
   document.getElementById('addTableModal').classList.add('hidden');
+  document.removeEventListener('keydown', escHandler);
+  if (addTableTrigger) {
+    addTableTrigger.focus();
+    addTableTrigger = null;
+  }
   const err = document.getElementById('tableError');
   if (err) {
     err.textContent = '';

--- a/static/js/bulk_edit_modal.js
+++ b/static/js/bulk_edit_modal.js
@@ -1,10 +1,24 @@
+let bulkTrigger = null;
+let escHandler = (e) => {
+  if (e.key === 'Escape') {
+    closeBulkEditModal();
+  }
+};
+
 export function openBulkEditModal() {
   updateSelectedCount();
+  bulkTrigger = document.activeElement;
   document.getElementById('bulkEditModal').classList.remove('hidden');
+  document.addEventListener('keydown', escHandler);
 }
 
 export function closeBulkEditModal() {
   document.getElementById('bulkEditModal').classList.add('hidden');
+  document.removeEventListener('keydown', escHandler);
+  if (bulkTrigger) {
+    bulkTrigger.focus();
+    bulkTrigger = null;
+  }
 }
 
 let tableName;

--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -1,9 +1,23 @@
+let dashboardTrigger = null;
+let escHandler = (e) => {
+  if (e.key === 'Escape') {
+    closeDashboardModal();
+  }
+};
+
 export function openDashboardModal() {
+  dashboardTrigger = document.activeElement;
   document.getElementById('dashboardModal').classList.remove('hidden');
+  document.addEventListener('keydown', escHandler);
 }
 
 export function closeDashboardModal() {
   document.getElementById('dashboardModal').classList.add('hidden');
+  document.removeEventListener('keydown', escHandler);
+  if (dashboardTrigger) {
+    dashboardTrigger.focus();
+    dashboardTrigger = null;
+  }
 }
 
 let selectedOperation = null;

--- a/static/js/relations.js
+++ b/static/js/relations.js
@@ -1,10 +1,18 @@
 let modalData = {}; // Holds context for the modal interaction (source table, source id, and target table)
+let relationTrigger = null;
+let escHandler = (e) => {
+  if (e.key === 'Escape') {
+    closeModal();
+  }
+};
 
 // Opens the relation modal and populates it with entries from the target table
 export function openAddRelationModal(tableA, idA, tableB) {
   modalData = { tableA, idA, tableB }; // Save context for use during submit
+  relationTrigger = document.activeElement;
   const modal = document.getElementById('relationModal');
   modal.classList.remove('hidden'); // Show modal
+  document.addEventListener('keydown', escHandler);
 
   const select = document.getElementById('relationOptions');
   select.innerHTML = '<option>Loading...</option>'; // Temporary placeholder
@@ -31,6 +39,11 @@ export function openAddRelationModal(tableA, idA, tableB) {
 // Closes the modal (used by the Cancel button)
 export function closeModal() {
   document.getElementById('relationModal').classList.add('hidden');
+  document.removeEventListener('keydown', escHandler);
+  if (relationTrigger) {
+    relationTrigger.focus();
+    relationTrigger = null;
+  }
 }
 
 // Called when user clicks Add inside the modal to submit the selected relation

--- a/static/js/wizard_table.js
+++ b/static/js/wizard_table.js
@@ -1,11 +1,24 @@
 let fields = [];
+let addFieldTrigger = null;
+let escHandler = (e) => {
+  if (e.key === 'Escape') {
+    hideAddFieldModal();
+  }
+};
 
 function showAddFieldModal() {
+  addFieldTrigger = document.activeElement;
   document.getElementById('addFieldModal').classList.remove('hidden');
+  document.addEventListener('keydown', escHandler);
 }
 
 function hideAddFieldModal() {
   document.getElementById('addFieldModal').classList.add('hidden');
+  document.removeEventListener('keydown', escHandler);
+  if (addFieldTrigger) {
+    addFieldTrigger.focus();
+    addFieldTrigger = null;
+  }
 }
 
 function resetAddFieldForm() {


### PR DESCRIPTION
## Summary
- return focus to the trigger element after closing modals
- handle Escape key for bulk edit modal
- handle Escape key for add field modal
- handle Escape key for add table modal
- handle Escape key for relation modal
- handle Escape key for dashboard modal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef267a4808333b87030169a29cedd