### PR TITLE
Add IDs to key UI elements

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,22 +16,22 @@
     {% set current_table = segments[0] %}
     {% set current_id = segments[1] if segments|length > 1 else None %}
 
-  <div class="flex min-h-screen">
+  <div id="layout-container" class="flex min-h-screen">
     <button id="sidebarCollapse" class="fixed top-2 left-2 z-50 p-2 text-lg bg-gray-800 text-gray-100 rounded" aria-label="Toggle sidebar">&laquo;</button>
     <aside id="sidebar" class="fixed md:static top-0 left-0 z-40 w-64 h-screen pt-4 bg-gray-800 text-gray-100 hidden md:block flex flex-col flex-shrink-0">
-      <nav class="flex-1 overflow-y-auto px-3 space-y-2">
-        <a href="/" class="block px-2 py-1 rounded hover:bg-gray-700 {{ 'bg-gray-700' if not current_table else '' }}">Home</a>
+      <nav id="sidebar-nav" class="flex-1 overflow-y-auto px-3 space-y-2">
+        <a id="nav-link-home" href="/" class="block px-2 py-1 rounded hover:bg-gray-700 {{ 'bg-gray-700' if not current_table else '' }}">Home</a>
         {% for nav in nav_cards if nav.table_name != 'dashboard' %}
-          <a href="/{{ nav.table_name }}" class="block px-2 py-1 rounded hover:bg-gray-700 {{ 'bg-gray-700' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
+          <a id="nav-link-{{ nav.table_name }}" href="/{{ nav.table_name }}" class="block px-2 py-1 rounded hover:bg-gray-700 {{ 'bg-gray-700' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
         {% endfor %}
       </nav>
-      <div class="p-3 grid grid-cols-2 gap-2">
+      <div id="nav-buttons" class="p-3 grid grid-cols-2 gap-2">
         {% block nav_buttons %}{% endblock %}
       </div>
     </aside>
 
-    <div class="flex-1 flex flex-col">
-      <header class="bg-gray-800 text-gray-100 p-4 flex items-center">
+    <div id="content-wrapper" class="flex-1 flex flex-col">
+      <header id="page-header" class="bg-gray-800 text-gray-100 p-4 flex items-center">
         <div class="ml-auto flex space-x-2">
           {% if current_table in field_schema %}
             <a href="/{{ current_table }}/new" class="btn-primary px-3 py-1 rounded">+ Add</a>
@@ -44,7 +44,7 @@
         </div>
       </header>
 
-      <main class="p-4 card mt-2">
+      <main id="page-main" class="p-4 card mt-2">
         {% block content %}{% endblock %}
       </main>
     </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="flex items-center mb-4">
+<div id="dashboard-header" class="flex items-center mb-4">
   <h1 class="text-3xl font-bold mr-4">Dashboard</h1>
   <button id="dashboard_update" class="btn-primary px-3 py-1 rounded">Update</button>
 </div>

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -6,10 +6,10 @@
 {# Define the percentage snap constant (# of % per grid column) #}
 {% set PCT_SNAP = 5 %}
 
-<div class="max-w-6xl mx-auto bg-white p-6 rounded shadow-md flex space-x-6">
+<div id="detail-container" class="max-w-6xl mx-auto bg-white p-6 rounded shadow-md flex space-x-6">
 
   <!-- Left: Main Details -->
-  <div class="flex-1">
+  <div id="detail-main" class="flex-1">
     {% set display_value = record.get(table) or record.get("title") or record.get("name") or "Untitled" %}
     <h1 class="text-2xl font-bold mb-4">
       {{ display_value }}
@@ -109,7 +109,7 @@
   </div>
 
   <!-- Right: Related Content -->
-  <div class="w-full md:w-1/3 lg:w-1/4 xl:w-64 border-l-2 border-blue-200 pl-6 flex-shrink-0">
+  <div id="related-content" class="w-full md:w-1/3 lg:w-1/4 xl:w-64 border-l-2 border-blue-200 pl-6 flex-shrink-0">
     <h2 class="text-xl font-semibold mb-2">Related Pages</h2>
     <ul class="space-y-2 text-blue-700 text-sm">
       {% for section, group in related.items() %}

--- a/templates/import_view.html
+++ b/templates/import_view.html
@@ -2,7 +2,7 @@
 {% block title %}Import Records{% endblock %}
 
 {% block content %}
-<div class="max-w-6xl mx-auto p-6">
+<div id="import-container" class="max-w-6xl mx-auto p-6">
   <h1 class="text-3xl font-bold mb-6">Import CSV</h1>
 
   <div class="mb-6">

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,19 +9,19 @@
 
 {% block content %}
 <h1 class="text-4xl font-bold text-center mb-10">{{ heading }}</h1>
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
-  <a href="/dashboard" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
+<div id="home-card-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
+  <a id="card-dashboard" href="/dashboard" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
     <h2 class="text-2xl font-bold mb-2">Dashboard</h2>
     <p class="text-gray-600">View overall summary and stats</p>
   </a>
   {% for card in cards %}
-  <a href="/{{ card.table_name }}"
+  <a id="card-{{ card.table_name }}" href="/{{ card.table_name }}"
      class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
     <h2 class="text-2xl font-bold mb-2">{{ card.display_name }}</h2>
     <p class="text-gray-600">{{ card.description }}</p>
   </a>
   {% endfor %}
-  <a href="#" onclick="openAddTableModal()" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition flex items-center justify-center">
+  <a id="card-add-table" href="#" onclick="openAddTableModal()" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition flex items-center justify-center">
     <span class="text-blue-500 text-5xl font-bold">+</span>
   </a>
 </div>

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -7,11 +7,11 @@
 <button id="bulk_edit" onclick="openBulkEditModal()" class="btn-primary px-3 py-1 rounded opacity-50" disabled>Bulk Edit</button>
 {% endblock %}
 {% block content %}
-<div class="w-full bg-white p-6 rounded shadow-md">
+<div id="list-view-container" class="w-full bg-white p-6 rounded shadow-md">
   <h1 class="text-2xl font-bold mb-4">{{ table|capitalize }}s</h1>
 
   <!-- Search form -->
-  <form method="get" class="mb-4 flex items-center justify-between">
+  <form id="list-search-form" method="get" class="mb-4 flex items-center justify-between">
     {# Left side: Search input + button #}
     <div class="flex items-center space-x-2">
       <input


### PR DESCRIPTION
## Summary
- give sidebar nav, header, main layout, and other components unique IDs
- mark card grid items on the index page with IDs
- add IDs to list and detail view wrappers
- assign IDs to dashboard and import page containers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684efbeba36c8333bd1110588766f696