### PR TITLE
Add IDs to major UI elements

### DIFF
--- a/templates/_record_rows.html
+++ b/templates/_record_rows.html
@@ -1,5 +1,5 @@
 {% for record in records %}
-<tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location.href='/{{ table }}/{{ record.id }}'">
+<tr id="record-{{ record.id }}" class="hover:bg-gray-50 cursor-pointer" onclick="window.location.href='/{{ table }}/{{ record.id }}'">
   <td class="px-2 py-2" data-static onclick="event.stopPropagation()">
     <input type="checkbox" class="row-select" value="{{ record.id }}">
   </td>

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,7 @@
     {% set current_table = segments[0] %}
     {% set current_id = segments[1] if segments|length > 1 else None %}
 
-  <div class="flex min-h-screen">
+  <div id="app-container" class="flex min-h-screen">
     <aside id="sidebar" class="fixed md:static top-0 left-0 z-40 w-64 h-screen pt-4 bg-gray-800 text-gray-100 hidden md:block flex flex-col flex-shrink-0">
       <nav class="flex-1 overflow-y-auto px-3 space-y-2">
         <a href="/" class="block px-2 py-1 rounded hover:bg-gray-700 {{ 'bg-gray-700' if not current_table else '' }}">Home</a>
@@ -29,8 +29,8 @@
       </div>
     </aside>
 
-    <div class="flex-1 flex flex-col">
-      <header class="bg-gray-800 text-gray-100 p-4 flex items-center">
+    <div id="content-wrapper" class="flex-1 flex flex-col">
+      <header id="page-header" class="bg-gray-800 text-gray-100 p-4 flex items-center">
         <div class="ml-auto flex items-center space-x-2">
           {% if current_table in field_schema %}
             <a href="/{{ current_table }}/new" class="btn-primary px-3 py-1 rounded">+ Add</a>
@@ -44,7 +44,7 @@
         </div>
       </header>
 
-      <main class="p-4 card mt-2">
+      <main id="main-content" class="p-4 card mt-2">
         {% block content %}{% endblock %}
       </main>
     </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -34,7 +34,7 @@
       'rowStart': row_start,
       'rowSpan': row_span
     } }) %}
-    <div class="dashboard-widget draggable-field min-h-0 border p-2 rounded shadow bg-gray-50"
+    <div id="widget-{{ widget.id }}" class="dashboard-widget draggable-field min-h-0 border p-2 rounded shadow bg-gray-50"
          data-widget="{{ widget.id }}"
          data-type="{{ widget.widget_type }}"
          {% if widget.widget_type in ['chart', 'value'] %}data-config='{{ widget.content }}'{% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 <h1 class="text-4xl font-bold text-center mb-10">{{ heading }}</h1>
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
+<div id="card-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
   <a href="/dashboard" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
     <h2 class="text-2xl font-bold mb-2">Dashboard</h2>
     <p class="text-gray-600">View overall summary and stats</p>

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -7,11 +7,11 @@
 <button id="bulk_edit" onclick="openBulkEditModal()" class="btn-primary px-3 py-1 rounded opacity-50" disabled>Bulk Edit</button>
 {% endblock %}
 {% block content %}
-<div class="w-full bg-white p-6 rounded shadow-md">
+<div id="list-view-container" class="w-full bg-white p-6 rounded shadow-md">
   <h1 class="text-2xl font-bold mb-4">{{ table|capitalize }}s</h1>
 
   <!-- Search form -->
-  <form method="get" class="mb-4 flex items-center justify-between">
+  <form id="search-form" method="get" class="mb-4 flex items-center justify-between">
     {# Left side: Search input + button #}
     <div class="flex items-center space-x-2">
       <input

--- a/templates/new_record.html
+++ b/templates/new_record.html
@@ -4,7 +4,7 @@
 {% block content %}
 <h1 class="text-2xl font-bold mb-6">Create New {{ table|capitalize }}</h1>
 
-<form method="post" class="space-y-4">
+<form id="new-record-form" method="post" class="space-y-4">
   {% for field, ftype in fields.items() %}
     {% if field != "id" and ftype != "hidden" %}
       <div>


### PR DESCRIPTION
## Summary
- assign IDs to app container, header and main content
- add unique IDs for dashboard widgets and records table rows
- tag forms and list view containers with IDs for better test automation
- set unique ID on index card grid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684efd80e3208333a39e29a85e65dbb1