### PR TITLE
Add hover sidebar handle

### DIFF
--- a/static/js/sidebar_toggle.js
+++ b/static/js/sidebar_toggle.js
@@ -1,14 +1,26 @@
 const sidebar = document.getElementById('sidebar');
 const collapseBtn = document.getElementById('sidebarCollapse');
+const sidebarHandle = document.getElementById('sidebar-handle');
 
 function setToggleIcon() {
   collapseBtn.innerHTML = sidebar.classList.contains('md:block') ? '&laquo;' : '&raquo;';
 }
 
+function updateHandleVisibility() {
+  if (sidebar.classList.contains('md:block')) {
+    sidebarHandle.classList.add('hidden');
+  } else {
+    sidebarHandle.classList.remove('hidden');
+  }
+}
+
 function toggleSidebar() {
   sidebar.classList.toggle('md:block');
   setToggleIcon();
+  updateHandleVisibility();
 }
 
 setToggleIcon();
+updateHandleVisibility();
 collapseBtn.addEventListener('click', toggleSidebar);
+sidebarHandle.addEventListener('click', toggleSidebar);

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,6 +31,7 @@
         {% block nav_buttons %}{% endblock %}
       </div>
     </aside>
+    <div id="sidebar-handle" class="hidden fixed top-0 left-0 h-screen w-3 bg-gray-800 text-gray-100 flex items-center justify-center cursor-pointer">&raquo;</div>
 
     <div id="content-wrapper" class="flex-1 flex flex-col">
       <header id="page-header" class="bg-gray-800 text-gray-100 p-4 flex items-center">


### PR DESCRIPTION
## Summary
- add sidebar handle container in `base.html`
- show or hide handle based on sidebar visibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0356db8883338144de6063bf557d