### PR TITLE
Add CSS utilities and refactor templates

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -112,3 +112,36 @@ body {
   backdrop-filter: blur(4px);
   z-index: 50;
 }
+
+/* Utility classes */
+.nav-link {
+  display: block;
+  padding: 0.25rem 0.5rem; /* py-1 px-2 */
+  border-radius: 0.25rem;
+}
+.nav-link:hover {
+  background-color: #374151; /* gray-700 */
+}
+
+.card-link {
+  display: block;
+  background-color: #fff;
+  border-radius: 0.75rem; /* rounded-xl */
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1);
+  padding: 1.5rem; /* p-6 */
+  transition: background-color 0.2s;
+}
+.card-link:hover {
+  background-color: #f9fafb; /* gray-50 */
+}
+
+.modal-container {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0,0,0,0.5);
+  backdrop-filter: blur(4px); /* blur-sm */
+  z-index: 50;
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -5,19 +5,19 @@
 {% block content %}
 <h1 class="text-3xl font-bold mb-6">Admin</h1>
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-  <a href="/admin/config" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
+  <a href="/admin/config" class="card-link">
     <h2 class="text-2xl font-bold mb-2">Configuration</h2>
     <p class="text-gray-600">Manage application settings</p>
   </a>
-  <a href="/admin/database" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
+  <a href="/admin/database" class="card-link">
     <h2 class="text-2xl font-bold mb-2">Database</h2>
     <p class="text-gray-600">Manage database file</p>
   </a>
-  <a href="/admin/users" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
+  <a href="/admin/users" class="card-link">
     <h2 class="text-2xl font-bold mb-2">User Management</h2>
     <p class="text-gray-600">Coming soon</p>
   </a>
-  <a href="/admin/automation" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
+  <a href="/admin/automation" class="card-link">
     <h2 class="text-2xl font-bold mb-2">Automation</h2>
     <p class="text-gray-600">Coming soon</p>
   </a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,9 +22,9 @@
         <button id="sidebarCollapse" class="p-2 text-lg bg-gray-800 text-gray-100 rounded" aria-label="Toggle sidebar">&laquo;</button>
       </div>
       <nav class="flex-1 overflow-y-auto px-3 space-y-2">
-        <a href="/" class="block px-2 py-1 rounded hover:bg-gray-700 {{ 'bg-gray-700' if not current_table else '' }}">Home</a>
+        <a href="/" class="nav-link {{ 'bg-gray-700' if not current_table else '' }}">Home</a>
         {% for nav in nav_cards if nav.table_name != 'dashboard' %}
-          <a href="/{{ nav.table_name }}" class="block px-2 py-1 rounded hover:bg-gray-700 {{ 'bg-gray-700' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
+          <a href="/{{ nav.table_name }}" class="nav-link {{ 'bg-gray-700' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
         {% endfor %}
       </nav>
       <div class="p-3 grid grid-cols-2 gap-2">

--- a/templates/bulk_edit_modal.html
+++ b/templates/bulk_edit_modal.html
@@ -1,4 +1,4 @@
-<div id="bulkEditModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
+<div id="bulkEditModal" class="modal-container hidden"
      onclick="if(event.target.id === 'bulkEditModal') closeBulkEditModal()">
   <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button type="button" onclick="closeBulkEditModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>

--- a/templates/dashboard_modal.html
+++ b/templates/dashboard_modal.html
@@ -1,5 +1,5 @@
 <!-- Dashboard Add Modal -->
-<div id="dashboardModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
+<div id="dashboardModal" class="modal-container hidden"
      onclick="if(event.target.id === 'dashboardModal') closeDashboardModal()">
   <div class="bg-white p-6 rounded-lg shadow-lg w-fit min-w-[24rem] max-w-full relative">
     <button onclick="closeDashboardModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -148,7 +148,7 @@
 
 <!-- Relation Modal -->
 <div id="relationModal"
-     class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
+     class="modal-container hidden"
      onclick="if(event.target.id === 'relationModal') closeModal()">
   <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button type="button" onclick="closeModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>

--- a/templates/edit_fields_modal.html
+++ b/templates/edit_fields_modal.html
@@ -1,4 +1,4 @@
-<div id="layoutModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
+<div id="layoutModal" class="modal-container hidden"
      onclick="if(event.target.id === 'layoutModal') closeLayoutModal()">
   <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button type="button" onclick="closeLayoutModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>

--- a/templates/import_view.html
+++ b/templates/import_view.html
@@ -70,7 +70,7 @@
         {% endfor %}
       </div>
     </div>
-    <div id="validationOverlay" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
+    <div id="validationOverlay" class="modal-container hidden"
          onclick="if(event.target.id === 'validationOverlay') this.classList.add('hidden')">
         <div id="validation-popup" class="bg-white p-6 rounded-lg shadow-lg w-auto max-w-[70vw] max-h-[66vh] overflow-auto relative">
             <button type="button" onclick="document.getElementById('validationOverlay').classList.add('hidden')" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,24 +10,24 @@
 {% block content %}
 <h1 class="text-4xl font-bold text-center mb-10">{{ heading }}</h1>
 <div id="card-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
-  <a href="/dashboard" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
+  <a href="/dashboard" class="card-link">
     <h2 class="text-2xl font-bold mb-2">Dashboard</h2>
     <p class="text-gray-600">View overall summary and stats</p>
   </a>
   {% for card in cards %}
   <a href="/{{ card.table_name }}"
-     class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition">
+     class="card-link">
     <h2 class="text-2xl font-bold mb-2">{{ card.display_name }}</h2>
     <p class="text-gray-600">{{ card.description }}</p>
   </a>
   {% endfor %}
-  <a href="#" onclick="openAddTableModal()" class="bg-white rounded-xl shadow-md p-6 hover:bg-gray-50 transition flex items-center justify-center">
+  <a href="#" onclick="openAddTableModal()" class="card-link flex items-center justify-center">
     <span class="text-blue-500 text-5xl font-bold">+</span>
   </a>
 </div>
 
 <!-- Add Table Modal -->
-<div id="addTableModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50"
+<div id="addTableModal" class="modal-container hidden"
      onclick="if(event.target.id === 'addTableModal') closeAddTableModal()">
   <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button type="button" onclick="closeAddTableModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>

--- a/templates/wizard_table.html
+++ b/templates/wizard_table.html
@@ -22,7 +22,7 @@
   </form>
 
 <!-- Add Field Modal -->
-<div id="addFieldModal" class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm hidden flex justify-center items-center z-50" onclick="if(event.target.id === 'addFieldModal') hideAddFieldModal()">
+<div id="addFieldModal" class="modal-container hidden" onclick="if(event.target.id === 'addFieldModal') hideAddFieldModal()">
   <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button type="button" onclick="hideAddFieldModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <form id="field-form" class="space-y-4">


### PR DESCRIPTION
## Summary
- introduce `.nav-link`, `.card-link` and `.modal-container` utilities
- apply the new classes across navigation, cards and modals

## Testing
- `pytest -q`
- `curl -I http://localhost:5000/ | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684f0672b28c83338d65b3afd521a376