### PR TITLE
Move nav buttons to header and widen list table

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -27,15 +27,16 @@
           <a href="/{{ nav.table_name }}" class="nav-link {{ 'bg-gray-700' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
         {% endfor %}
       </nav>
-      <div class="p-3 grid grid-cols-2 gap-2">
-        {% block nav_buttons %}{% endblock %}
-      </div>
-    </aside>
+      <!-- Sidebar action buttons removed -->
+      </aside>
     <div id="sidebar-handle" class="hidden fixed top-0 left-0 h-screen w-3 bg-gray-800 text-gray-100 flex items-center justify-center cursor-pointer">&raquo;</div>
 
     <div id="content-wrapper" class="flex-1 flex flex-col">
-      <header id="page-header" class="bg-gray-800 text-gray-100 p-4 flex items-center">
-        <div class="ml-auto flex items-center space-x-2">
+      <header id="page-header" class="bg-gray-800 text-gray-100 p-4 flex items-center justify-between">
+        <div class="flex items-center space-x-2">
+          {% block nav_buttons %}{% endblock %}
+        </div>
+        <div class="flex items-center space-x-2">
           {% if current_table in field_schema %}
             <a href="/{{ current_table }}/new" class="btn-primary px-3 py-1 rounded">+ Add</a>
             {% if current_id %}

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -70,8 +70,8 @@
   {% if records %}
   <div id="loading-indicator" class="hidden text-sm text-gray-600 mb-2">Loading...</div>
   {% include '_record_count.html' %}
-  <div class="overflow-x-auto rounded-lg border border-gray-200">
-    <table id="records-table" data-table="{{ table }}" class="min-w-full divide-y divide-gray-200 text-sm">
+  <div class="overflow-x-auto rounded-lg border border-gray-200 w-full">
+    <table id="records-table" data-table="{{ table }}" class="min-w-max divide-y divide-gray-200 text-sm">
       <thead class="bg-gray-50">
         <tr>
           <th scope="col" class="px-2 py-2" data-static>


### PR DESCRIPTION
## Summary
- show any nav buttons directly in the page header
- keep sidebar simpler
- allow list view tables to grow wider without breaking layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0a1d7ad48333a74a3f6c47e223a7