### PR TITLE
Copy config metadata during bootstrap

### DIFF
--- a/tests/test_wizard_database.py
+++ b/tests/test_wizard_database.py
@@ -26,8 +26,12 @@ def test_settings_step_after_db_creation():
     config = {row['key']: row['value'] for row in rows}
     assert config.get('db_path')
     assert config.get('heading') == ''
-    # ensure other defaults exist
+    # ensure other defaults exist and metadata copied
     assert 'log_level' in config
+    meta = {row['key']: row for row in rows}
+    assert meta['log_level']['section'] == 'logging'
+    assert meta['log_level']['type'] == 'select'
+    assert meta['log_level']['options']
 
     # restore original test database
     from db.database import init_db_path

--- a/views/admin.py
+++ b/views/admin.py
@@ -31,7 +31,7 @@ from imports.import_csv import parse_csv
 from utils.validation import validation_sorter
 from db.schema import get_field_schema
 from db.database import get_connection, check_db_status, init_db_path
-from db.bootstrap import initialize_database
+from db.bootstrap import initialize_database, ensure_default_configs
 from imports.tasks import process_import, init_import_table
 from utils.field_registry import FIELD_TYPES
 
@@ -124,6 +124,7 @@ def update_database_file():
         save_path = os.path.join('data', filename)
         file.save(save_path)
         initialize_database(save_path)
+        ensure_default_configs(save_path)
         init_db_path(save_path)
         update_config('db_path', save_path)
         reload_app_state()
@@ -139,6 +140,7 @@ def update_database_file():
         save_path = os.path.join('data', filename)
         open(save_path, 'a').close()
         initialize_database(save_path)
+        ensure_default_configs(save_path)
         init_db_path(save_path)
         update_config('db_path', save_path)
         reload_app_state()


### PR DESCRIPTION
## Summary
- load metadata for config rows from the default database
- ensure new databases created via the admin page also insert default configs
- verify metadata copying in the wizard database test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f17cc32b48333a4656c99f513efd9