### PR TITLE
Add title field type and wizard prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from db.schema import (
     update_foreign_field_options,
     load_base_tables,
     load_card_info,
+    get_title_field,
 )
 from db.config import get_config_rows
 from utils.field_registry import FIELD_TYPES
@@ -88,6 +89,7 @@ def inject_field_schema():
     return {
         'field_schema': schema,
         'update_foreign_field_options': update_foreign_field_options,
+        'get_title_field': get_title_field,
         'nav_cards': current_app.config['CARD_INFO'],
         'base_tables': current_app.config['BASE_TABLES'],
         'field_macro_map': macro_map,

--- a/static/js/edit_fields.js
+++ b/static/js/edit_fields.js
@@ -9,6 +9,7 @@ document.addEventListener("DOMContentLoaded", () => {
       .then(res => res.json())
       .then(types => {
         types.forEach(t => {
+          if (t === 'title') return;
           const opt = document.createElement('option');
           opt.value = t;
           opt.textContent = t;

--- a/static/js/wizard_table.js
+++ b/static/js/wizard_table.js
@@ -77,6 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(res => res.json())
       .then(types => {
         types.forEach(t => {
+          if (t === 'title') return;
           const opt = document.createElement('option');
           opt.value = t;
           opt.textContent = t;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -57,14 +57,7 @@
               <tr><th class="px-2 py-1 text-left">ID</th><th class="px-2 py-1 text-left">Value</th></tr>
               {% elif widget.parsed.type == 'filtered-records' %}
               {% set tbl = widget.parsed.table %}
-              {% set fields = field_schema[tbl].keys() | list %}
-              {% if tbl in fields %}
-                {% set label_field = tbl %}
-              {% elif fields|length > 1 %}
-                {% set label_field = fields[1] %}
-              {% else %}
-                {% set label_field = fields[0] %}
-              {% endif %}
+              {% set label_field = get_title_field(tbl) or tbl %}
               <tr><th class="px-2 py-1 text-left">ID</th><th class="px-2 py-1 text-left">{{ label_field }}</th></tr>
               {% else %}
               <tr><th class="px-2 py-1 text-left">Table</th><th class="px-2 py-1 text-left">Count</th></tr>
@@ -82,14 +75,7 @@
               {% endfor %}
             {% elif widget.parsed.type == 'filtered-records' %}
               {% set tbl = widget.parsed.table %}
-              {% set fields = field_schema[tbl].keys() | list %}
-              {% if tbl in fields %}
-                {% set label_field = tbl %}
-              {% elif fields|length > 1 %}
-                {% set label_field = fields[1] %}
-              {% else %}
-                {% set label_field = fields[0] %}
-              {% endif %}
+              {% set label_field = get_title_field(tbl) or tbl %}
               {% for row in widget.parsed.data if widget.parsed %}
                 <tr><td class="px-2 py-1"><a href="/{{ tbl }}/{{ row.id }}" class="text-blue-600 underline">{{ row.id }}</a></td><td class="px-2 py-1">{{ row[label_field] }}</td></tr>
               {% endfor %}

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% import "macros/fields.html" as fields with context %}
-{% set title_display = record.get(table) %}
+{% set title_field = get_title_field(table) %}
+{% set title_display = record.get(title_field) if title_field else record.get(table) %}
 {% block title %}{{ table|capitalize }} {{ title_display }}{% endblock %}
 {% block content %}
 {# Define the percentage snap constant (# of % per grid column) #}
@@ -10,7 +11,11 @@
 
   <!-- Left: Main Details -->
   <div class="flex-1">
+    {% if title_field %}
+    {% set display_value = record.get(title_field) or "Untitled" %}
+    {% else %}
     {% set display_value = record.get(table) or record.get("title") or record.get("name") or "Untitled" %}
+    {% endif %}
     <h1 class="text-2xl font-bold mb-4">
       {{ display_value }}
       <span class="text-gray-500 text-base">(ID {{ record.id }})</span>
@@ -46,7 +51,7 @@
          ">
 
       {% for field, value in record.items() %}
-        {% if field_schema[table][field].type != 'hidden' %}
+        {% if field_schema[table][field].type not in ['hidden', 'title'] %}
           {% set layout     = field_schema_layout[field] %}
           {% set styling    = field_schema[table][field].styling or {} %}
           {# Compute 1-based start lines and spans using PCT_SNAP #}

--- a/templates/wizard_table.html
+++ b/templates/wizard_table.html
@@ -8,6 +8,10 @@
     <input type="text" name="table_name" class="border rounded px-2 py-1 w-full">
   </div>
   <div>
+    <label class="block mb-1">Title Field</label>
+    <input type="text" name="title_field" class="border rounded px-2 py-1 w-full" required>
+  </div>
+  <div>
     <label class="block mb-1">Description</label>
     <input type="text" name="description" class="border rounded px-2 py-1 w-full">
   </div>

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -182,6 +182,7 @@ def validate_multi_select_column(values: list[str], options: list[str]) -> dict:
     }
 
 # Register built-in field types with the registry
+register_type('title', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=12, default_height=4, macro='render_text')
 register_type('text', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=12, default_height=4, macro='render_text')
 register_type('number', sql_type='REAL', validator=lambda t, f, v: validate_number_column(v), default_width=4, default_height=3, macro='render_number')
 register_type('date', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=6, default_height=4, macro='render_date')

--- a/views/admin.py
+++ b/views/admin.py
@@ -299,7 +299,7 @@ def add_table():
     if not table_name.isidentifier():
         return jsonify({'error': 'Invalid table name'}), 400
     try:
-        success = create_base_table(table_name, description)
+        success = create_base_table(table_name, description, table_name)
     except Exception as exc:
         current_app.logger.exception('Failed to create table %s: %s', table_name, exc)
         return jsonify({'error': str(exc)}), 400

--- a/views/records.py
+++ b/views/records.py
@@ -24,6 +24,7 @@ from db.schema import (
     get_field_schema,
     update_layout as db_update_layout,
     update_field_styling as db_update_field_styling,
+    get_title_field,
 )
 from db.dashboard import sum_field as db_sum_field
 from db.config import get_layout_defaults
@@ -159,7 +160,10 @@ def api_list(table):
         cols = [r[1] for r in cur.fetchall()]
         if not cols:
             return jsonify([])
-        if table in cols:
+        title_field = get_title_field(table)
+        if title_field:
+            label_field = title_field
+        elif table in cols:
             label_field = table
         elif len(cols) > 1:
             label_field = cols[1]
@@ -274,6 +278,8 @@ def add_field_route(table, record_id):
         )
         current_app.logger.info('table=%s record_id=%s form=%s', table, record_id, dict(request.form))
         field_type = request.form['field_type']
+        if field_type == 'title':
+            return 'Cannot add additional title field', 400
         field_options_raw = request.form.get('field_options', '')
         foreign_key = request.form.get('foreign_key_target', None)
         styling_raw = request.form.get('styling')

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -138,11 +138,12 @@ def table_step():
     progress = session.setdefault('wizard_progress', {})
     if request.method == 'POST':
         table_name = (request.form.get('table_name') or '').strip()
+        title_field = (request.form.get('title_field') or '').strip()
         description = (request.form.get('description') or '').strip()
         fields_json = request.form.get('fields_json', '')
         fields_text = request.form.get('fields', '')
-        if table_name:
-            if create_base_table(table_name, description):
+        if table_name and title_field:
+            if create_base_table(table_name, description, title_field):
                 field_defs = []
                 if fields_json:
                     try:
@@ -157,6 +158,8 @@ def table_step():
                                 field_defs.append({'name': name, 'type': ftype})
 
                 for f in field_defs:
+                    if f.get('name') == title_field:
+                        continue
                     name = f.get('name')
                     ftype = f.get('type')
                     if not name or not ftype:


### PR DESCRIPTION
## Summary
- introduce `title` field type
- provide helper `get_title_field`
- store title field when creating new tables
- skip title fields in detail view rendering
- exclude `title` option from add-field forms
- prompt for title field in setup wizard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1d2e52ac8333810aec0ae5e03347