### PR TITLE
Enable inline editing of record titles

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -155,6 +155,11 @@ input[type=number] {
   background-repeat: repeat, repeat;
 }
 
+/* Outline the title when it is being edited */
+#record-title[contenteditable="true"] {
+  outline: 1px dashed #2563eb;
+}
+
 /* handles hidden by default */
  #layout-grid .resize-handle {
    position: absolute;

--- a/static/js/title_edit.js
+++ b/static/js/title_edit.js
@@ -1,0 +1,40 @@
+export function initTitleInlineEdit() {
+  const titleEl = document.getElementById('record-title');
+  if (!titleEl || !titleEl.dataset.field) return;
+
+  let original = '';
+
+  titleEl.addEventListener('dblclick', () => {
+    if (titleEl.getAttribute('contenteditable') === 'true') return;
+    original = titleEl.innerText.trim();
+    titleEl.setAttribute('contenteditable', 'true');
+    titleEl.focus();
+    const range = document.createRange();
+    range.selectNodeContents(titleEl);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+  });
+
+  titleEl.addEventListener('blur', async () => {
+    if (titleEl.getAttribute('contenteditable') !== 'true') return;
+    titleEl.setAttribute('contenteditable', 'false');
+    const newValue = titleEl.innerText.trim();
+    if (newValue === original) return;
+    const data = new FormData();
+    data.append('field', titleEl.dataset.field);
+    data.append('new_value', newValue);
+    try {
+      await fetch(`/${titleEl.dataset.table}/${titleEl.dataset.recordId}/update`, {
+        method: 'POST',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        body: data
+      });
+    } catch (err) {
+      console.error('Title update failed', err);
+      titleEl.innerText = original;
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initTitleInlineEdit);

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -17,7 +17,12 @@
     {% set display_value = record.get(table) or record.get("title") or record.get("name") or "Untitled" %}
     {% endif %}
     <h1 class="text-2xl font-bold mb-4">
-      {{ display_value }}
+      <span id="record-title"
+            {% if title_field %}
+            data-table="{{ table }}"
+            data-record-id="{{ record.id }}"
+            data-field="{{ title_field }}"
+            {% endif %}>{{ display_value }}</span>
       <span class="text-gray-500 text-base">(ID {{ record.id }})</span>
     </h1>
 
@@ -219,6 +224,7 @@
 </script>
 <script type="module" src="{{ url_for('static', filename='js/field_ajax.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/click_to_edit.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/title_edit.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/editor.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/undo_edit.js') }}"></script>
 


### PR DESCRIPTION
## Summary
- allow detail page titles to be edited by double‑clicking
- outline the title while editing so styling is preserved

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f270c711c8333a762747947551c2a