### PR TITLE
Move Home text next to sidebar icon

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -19,15 +19,16 @@
   <div id="app-container" class="flex min-h-screen">
     <aside id="sidebar" class="fixed md:static top-0 left-0 z-40 w-64 h-screen pt-4 bg-gray-800 text-gray-100 hidden md:block flex flex-col flex-shrink-0">
       <div class="flex items-center justify-between px-2">
-        <a href="/" class="p-2 text-gray-100" aria-label="Home">
+        <a href="/" class="p-2 text-gray-100 flex items-center space-x-1" aria-label="Home">
           <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M9.293 2.293a1 1 0 0 1 1.414 0l7 7A1 1 0 0 1 17 11h-1v6a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-6H3a1 1 0 0 1-.707-1.707l7-7Z" clip-rule="evenodd" />
           </svg>
+          <span>Home</span>
         </a>
         <button id="sidebarCollapse" class="p-2 text-lg bg-gray-800 text-gray-100 rounded" aria-label="Toggle sidebar">&laquo;</button>
       </div>
       <nav class="flex-1 overflow-y-auto px-3 space-y-2">
-        <a href="/" class="nav-link {{ 'bg-gray-700' if not current_table else '' }}">Home</a>
+        {# Home link moved next to icon above #}
         {% for nav in nav_cards if nav.table_name != 'dashboard' %}
           <a href="/{{ nav.table_name }}" class="nav-link {{ 'bg-gray-700' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
         {% endfor %}


### PR DESCRIPTION
## Summary
- adjust sidebar so the "Home" label appears next to the home icon

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2a3c43488333b73bdb060d553f7d