### PR TITLE
Add scroll limit for list view table

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -155,6 +155,12 @@ input[type=number] {
   background-repeat: repeat, repeat;
 }
 
+/* Keep record tables within the viewport width */
+.list-view-page .records-table-wrapper {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
 /* Outline the title when it is being edited */
 #record-title[contenteditable="true"] {
   outline: 1px dashed #2563eb;

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -70,7 +70,7 @@
   {% if records %}
   <div id="loading-indicator" class="hidden text-sm text-gray-600 mb-2">Loading...</div>
   {% include '_record_count.html' %}
-  <div class="overflow-x-auto rounded-lg border border-gray-200 w-full">
+  <div class="records-table-wrapper overflow-x-auto rounded-lg border border-gray-200 w-full">
     <table id="records-table" data-table="{{ table }}" class="min-w-max divide-y divide-gray-200 text-sm">
       <thead class="bg-gray-50">
         <tr>


### PR DESCRIPTION
## Summary
- keep records table width within viewport

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f2baa34648333952e167ac9459730