### PR TITLE
Make header sticky with offset

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -39,7 +39,7 @@
     <div id="sidebar-handle" class="hidden fixed top-0 left-0 h-screen w-3 bg-gray-800 text-gray-100 flex items-center justify-center cursor-pointer">&raquo;</div>
 
     <div id="content-wrapper" class="flex-1 flex flex-col md:ml-64">
-      <header id="page-header" class="bg-gray-800 text-gray-100 p-4 flex items-center justify-between">
+      <header id="page-header" class="bg-gray-800 text-gray-100 p-4 flex items-center justify-between sticky top-0 z-40 shadow-md">
         <div class="flex items-center space-x-2">
           {% block nav_buttons %}{% endblock %}
         </div>
@@ -55,7 +55,7 @@
         </div>
       </header>
 
-      <main id="main-content" class="p-4 card mt-2">
+      <main id="main-content" class="p-4 card mt-16">
         {% block content %}{% endblock %}
       </main>
     </div>


### PR DESCRIPTION
## Summary
- keep header visible by using Tailwind's `sticky` position
- offset main content so it isn't covered by the header
- add subtle shadow to the header for better separation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f49a2ed7c8333866e3021d7a2c6ee