### PR TITLE
Add timestamp support

### DIFF
--- a/db/relationships.py
+++ b/db/relationships.py
@@ -3,6 +3,7 @@ import logging
 logger = logging.getLogger(__name__)
 from db.database import get_connection
 from db.validation import validate_table
+from db.records import touch_last_edited
 
 
 def get_related_records(source_table, record_id):
@@ -95,10 +96,14 @@ def add_relationship(table_a, id_a, table_b, id_b):
                 vals,
             )
             conn.commit()
-            return True
+            success = True
         except Exception as e:
             logger.warning(f"[RELATIONSHIP ADD ERROR] {e}")
-            return False
+            success = False
+        if success:
+            touch_last_edited(table_a, id_a)
+            touch_last_edited(table_b, id_b)
+        return success
 
 
 def remove_relationship(table_a, id_a, table_b, id_b):
@@ -134,7 +139,11 @@ def remove_relationship(table_a, id_a, table_b, id_b):
                 vals,
             )
             conn.commit()
-            return True
+            success = True
         except Exception as e:
             logger.warning(f"[RELATIONSHIP REMOVE ERROR] {e}")
-            return False
+            success = False
+        if success:
+            touch_last_edited(table_a, id_a)
+            touch_last_edited(table_b, id_b)
+        return success

--- a/db/schema.py
+++ b/db/schema.py
@@ -290,12 +290,14 @@ def create_base_table(table_name: str, description: str, title_field: str) -> bo
                 logger.error("Table %s already exists", table_name)
                 return False
 
-            # Create the base table
+            # Create the base table with timestamp columns
             cur.execute(
                 f"""
                 CREATE TABLE {table_name} (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    {title_field} TEXT
+                    {title_field} TEXT,
+                    date_created TEXT,
+                    last_edited TEXT
                 )
                 """
             )
@@ -304,6 +306,8 @@ def create_base_table(table_name: str, description: str, title_field: str) -> bo
             defaults = [
                 (table_name, "id", "hidden", None, None, 0, 0, 0, 0),
                 (table_name, title_field, "title", None, None, 0, 0, 0, 0),
+                (table_name, "date_created", "date", None, None, 0, 0, 0, 0),
+                (table_name, "last_edited", "hidden", None, None, 0, 0, 0, 0),
             ]
             cur.executemany(
                 """


### PR DESCRIPTION
## Summary
- add `date_created` and `last_edited` columns on new tables
- track record modification time
- update relationship helpers to refresh `last_edited`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4c8b608c83338ef57eea8f3f1962