### PR TITLE
Improve header layout

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -39,7 +39,7 @@
     <div id="sidebar-handle" class="hidden fixed top-0 left-0 h-screen w-3 bg-gray-800 text-gray-100 flex items-center justify-center cursor-pointer">&raquo;</div>
 
     <div id="content-wrapper" class="flex-1 flex flex-col md:ml-64">
-      <header id="page-header" class="bg-gray-800 text-gray-100 p-4 flex items-center justify-between sticky top-0 z-40 shadow-md">
+      <header id="page-header" class="bg-gray-800 text-gray-100 p-4 flex items-center justify-between fixed top-0 left-0 w-full z-40 shadow-md md:pl-64">
         <div class="flex items-center space-x-2">
           {% block nav_buttons %}{% endblock %}
         </div>


### PR DESCRIPTION
## Summary
- make the page header span the entire viewport width so buttons on either side remain visible

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f4f1d3e98833381f5f15edcccfd97