### PR TITLE
Enable toggling of special fields on detail view

### DIFF
--- a/static/js/layout_editor.js
+++ b/static/js/layout_editor.js
@@ -87,6 +87,9 @@ function handleSaveLayout() {
   layoutGrid.classList.remove('editing');
   document.getElementById('field-style-menu')?.classList.add('hidden');
   addFieldBtn.classList.remove('hidden');
+  if (window.showSpecialFieldToggles) {
+    window.showSpecialFieldToggles(false);
+  }
     document.querySelectorAll('.resize-handle')
 .forEach(h => h.classList.add('hidden'));
   const table = layoutGrid.dataset.table;
@@ -125,6 +128,9 @@ function editModeButtons() {
   addFieldBtn.classList.add('hidden');
   toggleEditLayoutBtn.classList.add('hidden');
   saveLayoutBtn.classList.remove('hidden');
+  if (window.showSpecialFieldToggles) {
+    window.showSpecialFieldToggles(true);
+  }
 }
 
 function enableVanillaDrag() {

--- a/static/js/special_field_visibility.js
+++ b/static/js/special_field_visibility.js
@@ -1,0 +1,26 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    const wrapper = document.getElementById('special-fields-wrapper');
+    if(!wrapper) return;
+    const titleCb = document.getElementById('toggle-title');
+    const idCb = document.getElementById('toggle-id');
+    const createdCb = document.getElementById('toggle-date-created');
+
+    function apply(){
+      const titleEl = document.getElementById('record-title');
+      if(titleEl) titleEl.classList.toggle('hidden', !titleCb.checked);
+      const idEl = document.getElementById('record-id');
+      if(idEl) idEl.classList.toggle('hidden', !idCb.checked);
+      const createdEl = document.getElementById('draggable-field-date_created');
+      if(createdEl) createdEl.classList.toggle('hidden', !createdCb.checked);
+    }
+
+    [titleCb, idCb, createdCb].forEach(cb => cb && cb.addEventListener('change', apply));
+
+    window.showSpecialFieldToggles = function(show){
+      wrapper.classList.toggle('hidden', !show);
+    };
+
+    apply();
+  });
+})();

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -23,7 +23,7 @@
             data-record-id="{{ record.id }}"
             data-field="{{ title_field }}"
             {% endif %}>{{ display_value }}</span>
-      <span class="text-gray-500 text-base">(ID {{ record.id }})</span>
+      <span id="record-id" class="text-gray-500 text-base">(ID {{ record.id }})</span>
     </h1>
 
     <div id="detail-button-container" class="flex space-x-2 mb-4">
@@ -43,6 +43,27 @@
       >
         Edit Fields
       </button>
+      <div id="special-fields-wrapper" class="relative inline-block text-left ml-2 hidden">
+        <button id="toggle-special-fields" type="button" data-dropdown-toggle="special-fields-dropdown" class="px-2 py-1 bg-gray-200 rounded text-sm">
+          Special Fields
+        </button>
+        <div id="special-fields-dropdown" class="z-10 hidden mt-2 bg-white border rounded shadow p-2 space-y-1 text-sm">
+          <label class="flex items-center space-x-1">
+            <input type="checkbox" id="toggle-title" checked>
+            <span>Title</span>
+          </label>
+          <label class="flex items-center space-x-1">
+            <input type="checkbox" id="toggle-id" checked>
+            <span>ID</span>
+          </label>
+          {% if 'date_created' in record %}
+          <label class="flex items-center space-x-1">
+            <input type="checkbox" id="toggle-date-created" checked>
+            <span>Date Created</span>
+          </label>
+          {% endif %}
+        </div>
+      </div>
     </div>
 
     <!-- Layout container with computed initial height -->
@@ -200,6 +221,7 @@
       }
     });
   </script>
+<script src="{{ url_for('static', filename='js/special_field_visibility.js') }}"></script>
 <script src="{{ url_for('static', filename='js/layout_editor.js') }}"></script>
 <script src="{{ url_for('static', filename='js/field_styling.js') }}"></script>
 


### PR DESCRIPTION
## Summary
- let users hide or show title, ID and created date while editing layout
- expose a dropdown with checkboxes for these fields
- show/hide the dropdown when switching edit mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f51a09e248333bef18644b884cfd8