### PR TITLE
Fix sidebar overlap order

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -219,4 +219,9 @@ input[type=number] {
   background-repeat: repeat, repeat;
 }
 
+/* Ensure sidebar overlays the header */
+#sidebar {
+  z-index: 100;
+}
+
 


### PR DESCRIPTION
## Summary
- increase sidebar z-index so that it overlays the page header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f52b4f3dc8333b3e2478435a43e96