### PR TITLE
Add header field toggle

### DIFF
--- a/static/js/header_field_visibility.js
+++ b/static/js/header_field_visibility.js
@@ -1,0 +1,45 @@
+// Toggle visibility of header fields (title, id, dates)
+
+document.addEventListener('DOMContentLoaded', () => {
+  const toggleBtn = document.getElementById('toggle-header-fields');
+  const dropdown = document.getElementById('header-field-dropdown');
+  const wrapper = document.getElementById('special-visibility-wrapper');
+  if (!toggleBtn || !dropdown) return;
+
+  const elements = {
+    title: document.getElementById('record-title'),
+    id: document.getElementById('record-id'),
+    date_added: document.getElementById('record-date-added'),
+    last_edited: document.getElementById('record-last-edited'),
+    separator: document.getElementById('record-date-separator')
+  };
+
+  function updateSeparator() {
+    if (!elements.separator) return;
+    const show = !elements.date_added?.classList.contains('hidden') &&
+                 !elements.last_edited?.classList.contains('hidden');
+    elements.separator.classList.toggle('hidden', !show);
+  }
+
+  function updateVisibility() {
+    dropdown.querySelectorAll('.header-field-toggle').forEach(cb => {
+      const el = elements[cb.value];
+      if (el) el.classList.toggle('hidden', !cb.checked);
+    });
+    updateSeparator();
+  }
+
+  toggleBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    dropdown.classList.toggle('hidden');
+  });
+
+  document.addEventListener('click', () => dropdown.classList.add('hidden'));
+  dropdown.addEventListener('click', e => e.stopPropagation());
+
+  dropdown.querySelectorAll('.header-field-toggle').forEach(cb => {
+    cb.addEventListener('change', updateVisibility);
+  });
+
+  updateVisibility();
+});

--- a/static/js/layout_editor.js
+++ b/static/js/layout_editor.js
@@ -83,12 +83,14 @@ function handleSaveLayout() {
   const addFieldBtn         = document.getElementById('add-field');
   const saveLayoutBtn       = document.getElementById('save-layout');
   const resetLayoutBtn      = document.getElementById('reset-layout');
+  const headerToggleWrap    = document.getElementById('special-visibility-wrapper');
   toggleEditLayoutBtn.classList.remove('hidden');
   layoutGrid.classList.remove('editing');
   document.getElementById('field-style-menu')?.classList.add('hidden');
   addFieldBtn.classList.remove('hidden');
     document.querySelectorAll('.resize-handle')
 .forEach(h => h.classList.add('hidden'));
+  if (headerToggleWrap) headerToggleWrap.classList.add('hidden');
   const table = layoutGrid.dataset.table;
   const layoutEntries = Object.entries(layoutCache)
     .filter(([field]) => document.querySelector(`.draggable-field[data-field=\"${field}\"]`))
@@ -120,11 +122,13 @@ function editModeButtons() {
   const addFieldBtn         = document.getElementById('add-field');
   const saveLayoutBtn       = document.getElementById('save-layout');
   const layoutGrid          = document.getElementById('layout-grid');
+  const headerToggleWrap    = document.getElementById('special-visibility-wrapper');
   layoutGrid.classList.add('editing');
   resetLayoutBtn.classList.remove('hidden');
   addFieldBtn.classList.add('hidden');
   toggleEditLayoutBtn.classList.add('hidden');
   saveLayoutBtn.classList.remove('hidden');
+  if (headerToggleWrap) headerToggleWrap.classList.remove('hidden');
 }
 
 function enableVanillaDrag() {

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -23,14 +23,14 @@
             data-record-id="{{ record.id }}"
             data-field="{{ title_field }}"
             {% endif %}>{{ display_value }}</span>
-      <span class="text-gray-500 text-base">(ID {{ record.id }})</span>
+      <span id="record-id" class="text-gray-500 text-base">(ID {{ record.id }})</span>
       {% set date_added = record.get('date_added') or record.get('date_created') %}
       {% set last_updated = record.get('last_updated') or record.get('last_edited') %}
       {% if date_added or last_updated %}
         <span class="text-gray-500 text-sm font-mono ml-2">
-          {% if date_added %}Added {{ date_added }}{% endif %}
-          {% if date_added and last_updated %} | {% endif %}
-          {% if last_updated %}Updated {{ last_updated }}{% endif %}
+          {% if date_added %}<span id="record-date-added">Added {{ date_added }}</span>{% endif %}
+          {% if date_added and last_updated %}<span id="record-date-separator"> | </span>{% endif %}
+          {% if last_updated %}<span id="record-last-edited">Updated {{ last_updated }}</span>{% endif %}
         </span>
       {% endif %}
     </h1>
@@ -52,6 +52,29 @@
       >
         Edit Fields
       </button>
+      <div id="special-visibility-wrapper" class="relative inline-block text-left hidden">
+        <button id="toggle-header-fields" type="button" class="px-2 py-1 bg-gray-200 rounded ml-2">
+          Header Fields
+        </button>
+        <div id="header-field-dropdown" class="z-10 hidden mt-2 bg-white border rounded shadow p-2 space-y-1 w-48">
+          <label class="flex items-center space-x-2">
+            <input type="checkbox" class="header-field-toggle" value="title" checked>
+            <span class="text-sm">Title</span>
+          </label>
+          <label class="flex items-center space-x-2">
+            <input type="checkbox" class="header-field-toggle" value="id" checked>
+            <span class="text-sm">ID</span>
+          </label>
+          <label class="flex items-center space-x-2">
+            <input type="checkbox" class="header-field-toggle" value="date_added" checked>
+            <span class="text-sm">Date Added</span>
+          </label>
+          <label class="flex items-center space-x-2">
+            <input type="checkbox" class="header-field-toggle" value="last_edited" checked>
+            <span class="text-sm">Last Edited</span>
+          </label>
+        </div>
+      </div>
     </div>
 
     <!-- Layout container with computed initial height -->
@@ -211,6 +234,7 @@
   </script>
 <script src="{{ url_for('static', filename='js/layout_editor.js') }}"></script>
 <script src="{{ url_for('static', filename='js/field_styling.js') }}"></script>
+<script src="{{ url_for('static', filename='js/header_field_visibility.js') }}"></script>
 
 <script type="module">
   import {


### PR DESCRIPTION
## Summary
- allow toggling visibility of title/ID/date metadata while editing
- implement header field dropdown in detail view
- show dropdown only in layout edit mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f63c903b48333902f7b9f6d628327