### PR TITLE
Fix textarea editors height

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -75,6 +75,12 @@ input[type=number] {
   height: 100% !important;
 }
 
+/* Stretch Quill editors to the full height of the card */
+#layout-grid .draggable-field .quill-editor,
+#dashboard-grid .draggable-field .quill-editor {
+  height: 100% !important;
+}
+
 /* Dashboard grid defaults */
 #dashboard-grid .draggable-field {
   border: none !important;

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -23,11 +23,11 @@
   {% if request.args.get('edit') == field %}
     <form method="POST"
           action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}"
-          class="w-full mb-2"
+          class="w-full mb-2 h-full"
           data-autosave>
         <input type="hidden" name="field" value="{{ field }}">
         <input type="hidden" name="new_value" value="{{ value|e }}">
-        <div class="quill-editor" data-quill>{{ value|safe }}</div>
+        <div class="quill-editor h-full" data-quill>{{ value|safe }}</div>
         <span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>
     </form>
   {% else %}


### PR DESCRIPTION
## Summary
- keep Quill textarea forms stretched to the height of draggable fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6696be8c833381f2d4879615935d