### PR TITLE
Handle extra spaces in editable multiselect fields

### DIFF
--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -57,7 +57,8 @@
   {% if request.args.get('edit') == field %}
     <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="relative w-full multiselect" data-multiselect-dropdown onsubmit="event.preventDefault();">
       <input type="hidden" name="field" value="{{ field }}">
-      {% set selected_options = (value or '').split(', ') %}
+      {% set selected_options = (value or '').split(',') %}
+      {% set selected_options = selected_options | map('trim') | reject('equalto', '') | list %}
 
       <div class="flex flex-wrap gap-1 mb-2">
         {% for tag in selected_options if tag %}
@@ -91,7 +92,8 @@
       </div>
     </form>
   {% else %}
-    {% set selected_options = (value or '').split(', ') %}
+    {% set selected_options = (value or '').split(',') %}
+    {% set selected_options = selected_options | map('trim') | reject('equalto', '') | list %}
     <div class="flex flex-wrap gap-1" data-field="{{ field }}">
       {% for tag in selected_options if tag %}
         <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">{{ tag }}</span>
@@ -127,7 +129,8 @@
   {% if request.args.get('edit') == field %}
     <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="relative w-full" data-multiselect-dropdown onsubmit="event.preventDefault();">
       <input type="hidden" name="field" value="{{ field }}">
-      {% set selected_options = (value or '').split(', ') %}
+      {% set selected_options = (value or '').split(',') %}
+      {% set selected_options = selected_options | map('trim') | reject('equalto', '') | list %}
 
       <div class="flex flex-wrap gap-1 mb-2">
         {% for tag in selected_options if tag %}
@@ -161,7 +164,8 @@
       </div>
     </form>
   {% else %}
-    {% set selected_options = (value or '').split(', ') %}
+    {% set selected_options = (value or '').split(',') %}
+    {% set selected_options = selected_options | map('trim') | reject('equalto', '') | list %}
     <div class="flex flex-wrap gap-1" data-field="{{ field }}">
       {% for tag in selected_options if tag %}
         <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">{{ tag }}</span>


### PR DESCRIPTION
## Summary
- strip whitespace when parsing selected options for multi-select and foreign key fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6b63c92c8333bde2e1a260f8104a