### PR TITLE
Add export selected CSV

### DIFF
--- a/static/js/bulk_edit_modal.js
+++ b/static/js/bulk_edit_modal.js
@@ -23,6 +23,7 @@ export function closeBulkEditModal() {
 
 let tableName;
 let bulkBtn;
+let exportBtn;
 
 function updateSelectedCount() {
   const count = document.querySelectorAll('.row-select:checked').length;
@@ -37,6 +38,10 @@ function updateBulkButtonState() {
   if (bulkBtn) {
     bulkBtn.disabled = !any;
     bulkBtn.classList.toggle('opacity-50', !any);
+  }
+  if (exportBtn) {
+    exportBtn.disabled = !any;
+    exportBtn.classList.toggle('opacity-50', !any);
   }
   updateSelectedCount();
 }
@@ -70,9 +75,18 @@ function buildInput() {
   container.innerHTML = html;
 }
 
+function exportSelected() {
+  const ids = Array.from(document.querySelectorAll('.row-select:checked')).map(cb => cb.value);
+  if (ids.length === 0) return;
+  const params = new URLSearchParams();
+  params.set('ids', ids.join(','));
+  window.location = `/${tableName}/export?` + params.toString();
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   tableName = document.getElementById('records-table').dataset.table;
   bulkBtn = document.getElementById('bulk_edit');
+  exportBtn = document.getElementById('export_csv');
   buildInput();
   document.getElementById('bulk-field').addEventListener('change', buildInput);
 
@@ -90,6 +104,10 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
   updateBulkButtonState();
+
+  if (exportBtn) {
+    exportBtn.addEventListener('click', exportSelected);
+  }
 
   document.getElementById('bulk-edit-form').addEventListener('submit', e => {
     e.preventDefault();
@@ -130,3 +148,4 @@ document.addEventListener('DOMContentLoaded', () => {
 
 window.openBulkEditModal = openBulkEditModal;
 window.closeBulkEditModal = closeBulkEditModal;
+window.exportSelected = exportSelected;

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -5,6 +5,7 @@
 {% block body_class %}list-view-page{% endblock %}
 {% block nav_buttons %}
 <button id="bulk_edit" onclick="openBulkEditModal()" class="btn-primary px-3 py-1 rounded opacity-50" disabled>Bulk Edit</button>
+<button id="export_csv" class="btn-primary px-3 py-1 rounded opacity-50 ml-2" disabled>Export CSV</button>
 {% endblock %}
 {% block content %}
 <div id="list-view-container" class="w-full bg-white p-6 rounded shadow-md">
@@ -36,12 +37,6 @@
       >
         Reset Filters
       </button>
-      <a
-        href="{{ url_for('records.export_csv', table=table) }}{{ '?' if base_qs else '' }}{{ base_qs }}"
-        class="btn-primary text-sm px-2 py-1 rounded"
-      >
-        Export CSV
-      </a>
     </div>
   </form>
   <!-- Visibility control -->

--- a/views/records.py
+++ b/views/records.py
@@ -192,15 +192,29 @@ def export_csv(table):
     """Stream CSV of records using current filters and search."""
     params = _parse_list_params(table)
     fields = [f for f in params['fields'] if not f.startswith('_')]
-    records = get_all_records(
-        table,
-        search=params['search'],
-        filters=params['filters'],
-        ops=params['ops'],
-        modes=params['modes'],
-        sort_field=params['sort_field'],
-        direction=params['direction'],
-    )
+    ids_param = request.args.getlist('ids') or request.args.get('ids', '')
+    if isinstance(ids_param, str):
+        ids = [i for i in ids_param.split(',') if i]
+    else:
+        ids = ids_param
+    ids = [int(i) for i in ids if str(i).isdigit()]
+    if ids:
+        records = get_all_records(
+            table,
+            filters={'id': ids},
+            ops={'id': 'equals'},
+            modes={'id': 'any'},
+        )
+    else:
+        records = get_all_records(
+            table,
+            search=params['search'],
+            filters=params['filters'],
+            ops=params['ops'],
+            modes=params['modes'],
+            sort_field=params['sort_field'],
+            direction=params['direction'],
+        )
 
     def generate():
         buf = io.StringIO()


### PR DESCRIPTION
## Summary
- move the Export CSV action beside Bulk Edit on list view
- disable both buttons until rows are selected and export chosen rows
- support exporting selected ids via `/table/export?ids=`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd4be95988333b61169420d9c02db