### PR TITLE
Hide reset filters until needed

### DIFF
--- a/static/js/filter_visibility.js
+++ b/static/js/filter_visibility.js
@@ -3,10 +3,22 @@ document.addEventListener("DOMContentLoaded", () => {
   const toggleBtn = document.getElementById("toggle-filters");
   const dropdown = document.getElementById("filter-dropdown");
   const clearBtn = document.getElementById("reset-filters");
+  const filterContainerId = "filter-container";
   const tableName = document.getElementById("records-table").dataset.table;
   const tbody = document.getElementById("records-body");
   const pagerWrap = document.getElementById("pagination-wrapper");
   const loading = document.getElementById("loading-indicator");
+
+    function updateResetFiltersVisibility() {
+      const container = document.getElementById(filterContainerId);
+      if (!container) return;
+      const hasFilters = container.querySelectorAll(".filter-chip").length > 0;
+      if (hasFilters) {
+        clearBtn.classList.remove("hidden");
+      } else {
+        clearBtn.classList.add("hidden");
+      }
+    }
 
     function fetchRecords(params) {
       loading.classList.remove("hidden");
@@ -31,6 +43,7 @@ document.addEventListener("DOMContentLoaded", () => {
               bindSelectMulti();
             }
           }
+          updateResetFiltersVisibility();
         })
         .catch(err => console.error("fetchRecords", err))
         .finally(() => loading.classList.add("hidden"));
@@ -292,4 +305,5 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     bindSelectMulti();
+    updateResetFiltersVisibility();
   });

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -38,7 +38,7 @@
     <button
       type="button"
       id="reset-filters"
-      class="text-sm text-red-600 underline"
+      class="text-sm text-red-600 underline{% if not has_filters %} hidden{% endif %}"
     >
       Reset Filters
     </button>

--- a/views/records.py
+++ b/views/records.py
@@ -130,6 +130,7 @@ def _build_list_context(table):
         'per_page': per_page,
         'base_qs': base_qs,
         'base_qs_no_sort': base_qs_no_sort,
+        'has_filters': bool(filters),
     }
 
 @records_bp.route('/<table>')


### PR DESCRIPTION
## Summary
- pass `has_filters` to list view templates
- only render Reset Filters button when filters are present
- toggle button visibility in JavaScript

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd863d3f083339f21296852594c91