### PR TITLE
Fix search text color and select filter binding

### DIFF
--- a/static/js/filter_visibility.js
+++ b/static/js/filter_visibility.js
@@ -37,6 +37,7 @@ document.addEventListener("DOMContentLoaded", () => {
               cur.outerHTML = data.filters_html;
               bindDebounceToFilters();
               bindOperatorListeners();
+              bindSelectFilters();
               bindNumberFilters();
               bindDateFilters();
               bindMultiSelectPopovers();
@@ -189,15 +190,19 @@ document.addEventListener("DOMContentLoaded", () => {
         });
       });
     }
-    // Bind change handlers for non-operator selects (i.e. our select filters)
-    document.querySelectorAll("#filter-container select:not(.operator-select)")
-    .forEach(sel =>
-        sel.addEventListener("change", e => {
-        const params = new URLSearchParams(window.location.search);
-        params.set(sel.name, sel.value);
-        updateState(params);
-        })
-    );
+
+    // Bind change handlers for single select filters
+    function bindSelectFilters() {
+      document
+        .querySelectorAll("#filter-container select:not(.operator-select):not(.multi-select-mode)")
+        .forEach(sel => {
+          sel.addEventListener("change", () => {
+            const params = new URLSearchParams(window.location.search);
+            params.set(sel.name, sel.value);
+            updateState(params);
+          });
+        });
+    }
 
   
     // Toggle dropdown visibility
@@ -224,6 +229,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // Initial binding for inputs and operators
     bindDebounceToFilters();
     bindOperatorListeners();
+    bindSelectFilters();
     bindNumberFilters();
     bindDateFilters();
 

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -14,7 +14,7 @@
     name="search"
     placeholder="Search..."
     value="{{ request.args.get('search','') }}"
-    class="border rounded px-2 py-1 w-64"
+    class="border rounded px-2 py-1 w-64 text-black"
   />
   <button type="submit" class="btn-primary px-3 py-1 rounded">
     Search


### PR DESCRIPTION
## Summary
- show typed search text by setting the input text color to black
- add a `bindSelectFilters()` helper
- call `bindSelectFilters()` whenever filters are initialized or refreshed so single select filters work

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe759b734833395f9bb9b2d06dd29