### PR TITLE
Fix revert_edit None handling

### DIFF
--- a/db/records.py
+++ b/db/records.py
@@ -358,6 +358,9 @@ def revert_edit(entry: dict) -> bool:
     new_val = entry["new_value"]
 
     try:
+        if not field:
+            logger.warning("revert_edit: no field_name provided")
+            return False
         if field.startswith("relation_"):
             from db.relationships import add_relationship, remove_relationship
 

--- a/tests/test_revert_edit.py
+++ b/tests/test_revert_edit.py
@@ -1,0 +1,16 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from db.records import revert_edit
+
+
+def test_revert_edit_returns_false_for_none_field():
+    entry = {
+        'table_name': 'character',
+        'record_id': 1,
+        'field_name': None,
+        'old_value': None,
+        'new_value': None,
+    }
+    assert revert_edit(entry) is False
+


### PR DESCRIPTION
## Summary
- guard against `None` `field_name` in `revert_edit`
- add regression test for reverting an entry with a missing field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fec7919008333a30dbc4d5dccdf32