### PR TITLE
Track relationship edits

### DIFF
--- a/db/records.py
+++ b/db/records.py
@@ -366,14 +366,19 @@ def revert_edit(entry: dict) -> bool:
 
             rel_table = field[len("relation_") :]
             if old_val is None and new_val is not None:
-                add_relationship(table, record_id, rel_table, int(new_val))
+                add_relationship(
+                    table, record_id, rel_table, int(new_val), actor="undo"
+                )
             elif new_val is None and old_val is not None:
-                remove_relationship(table, record_id, rel_table, int(old_val))
+                remove_relationship(
+                    table, record_id, rel_table, int(old_val), actor="undo"
+                )
             else:
                 return False
         else:
             update_field_value(table, record_id, field, old_val)
-        append_edit_log(table, record_id, field, new_val, old_val, actor="undo")
+        if not field.startswith("relation_"):
+            append_edit_log(table, record_id, field, new_val, old_val, actor="undo")
     except Exception:
         logger.exception("Failed to revert edit")
         return False

--- a/db/relationships.py
+++ b/db/relationships.py
@@ -65,7 +65,7 @@ def get_related_records(source_table, record_id):
     return related
 
 
-def add_relationship(table_a, id_a, table_b, id_b):
+def add_relationship(table_a, id_a, table_b, id_b, *, actor: str | None = None):
     validate_table(table_a)
     validate_table(table_b)
     ordered = sorted([(table_a, id_a), (table_b, id_b)], key=lambda t: t[0])
@@ -86,10 +86,27 @@ def add_relationship(table_a, id_a, table_b, id_b):
         if success:
             touch_last_edited(table_a, id_a)
             touch_last_edited(table_b, id_b)
+            from db.records import append_edit_log
+            append_edit_log(
+                table_a,
+                id_a,
+                f"relation_{table_b}",
+                None,
+                str(id_b),
+                actor=actor,
+            )
+            append_edit_log(
+                table_b,
+                id_b,
+                f"relation_{table_a}",
+                None,
+                str(id_a),
+                actor=actor,
+            )
         return success
 
 
-def remove_relationship(table_a, id_a, table_b, id_b):
+def remove_relationship(table_a, id_a, table_b, id_b, *, actor: str | None = None):
     validate_table(table_a)
     validate_table(table_b)
     ordered = sorted([(table_a, id_a), (table_b, id_b)], key=lambda t: t[0])
@@ -110,4 +127,21 @@ def remove_relationship(table_a, id_a, table_b, id_b):
         if success:
             touch_last_edited(table_a, id_a)
             touch_last_edited(table_b, id_b)
+            from db.records import append_edit_log
+            append_edit_log(
+                table_a,
+                id_a,
+                f"relation_{table_b}",
+                str(id_b),
+                None,
+                actor=actor,
+            )
+            append_edit_log(
+                table_b,
+                id_b,
+                f"relation_{table_a}",
+                str(id_a),
+                None,
+                actor=actor,
+            )
         return success

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -59,3 +59,62 @@ def test_add_get_remove_relationship():
     assert not related.get('location') or not any(
         item['id'] == 1 for item in related['location']['items']
     )
+
+
+def test_edit_history_for_relationship_changes():
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "DELETE FROM relationships WHERE table_a=? AND id_a=? AND table_b=? AND id_b=?",
+            ("character", 1, "location", 1),
+        )
+        conn.execute(
+            "DELETE FROM edit_history WHERE table_name IN ('character','location') AND record_id=1 AND field_name LIKE 'relation_%'"
+        )
+        max_id = conn.execute("SELECT COALESCE(MAX(id), 0) FROM edit_history").fetchone()[0]
+        conn.commit()
+
+    resp = client.post(
+        "/relationship",
+        json={
+            "table_a": "character",
+            "id_a": 1,
+            "table_b": "location",
+            "id_b": 1,
+            "action": "add",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["success"]
+
+    with sqlite3.connect(DB_PATH) as conn:
+        rows = conn.execute(
+            "SELECT table_name, record_id, field_name, old_value, new_value FROM edit_history WHERE id > ? ORDER BY id",
+            (max_id,),
+        ).fetchall()
+        assert len(rows) == 2
+        assert ("character", 1, "relation_location", None, "1") in rows
+        assert ("location", 1, "relation_character", None, "1") in rows
+        max_id = conn.execute("SELECT MAX(id) FROM edit_history").fetchone()[0]
+
+    resp = client.post(
+        "/relationship",
+        json={
+            "table_a": "character",
+            "id_a": 1,
+            "table_b": "location",
+            "id_b": 1,
+            "action": "remove",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["success"]
+
+    with sqlite3.connect(DB_PATH) as conn:
+        rows = conn.execute(
+            "SELECT table_name, record_id, field_name, old_value, new_value FROM edit_history WHERE id > ? ORDER BY id",
+            (max_id,),
+        ).fetchall()
+        assert len(rows) == 2
+        assert ("character", 1, "relation_location", "1", None) in rows
+        assert ("location", 1, "relation_character", "1", None) in rows
+

--- a/views/records.py
+++ b/views/records.py
@@ -458,24 +458,8 @@ def manage_relationship():
     id_b = data.get('id_b')
     if action == 'add':
         success = add_relationship(table_a, id_a, table_b, id_b)
-        if success:
-            append_edit_log(
-                table_a,
-                id_a,
-                f'relation_{table_b}',
-                None,
-                str(id_b),
-            )
     elif action == 'remove':
         success = remove_relationship(table_a, id_a, table_b, id_b)
-        if success:
-            append_edit_log(
-                table_a,
-                id_a,
-                f'relation_{table_b}',
-                str(id_b),
-                None,
-            )
     else:
         abort(400, 'Invalid action')
     if not success:


### PR DESCRIPTION
## Summary
- log relationship changes from `add_relationship` and `remove_relationship`
- adjust `revert_edit` to use new logging
- simplify `manage_relationship` route
- test that relationship edits appear in edit history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff82dfc0883339309d05908db95da