### PR TITLE
Make URL fields clickable in list view

### DIFF
--- a/templates/_record_rows.html
+++ b/templates/_record_rows.html
@@ -7,6 +7,8 @@
     <td class="px-4 py-2 whitespace-nowrap" data-field="{{ field }}">
       {% if field_schema[table][field].type == "textarea" %}
         {{ record[field]|striptags|truncate(100) }}
+      {% elif field_schema[table][field].type == "url" %}
+        <a href="{{ record[field] }}" target="_blank" rel="noopener" onclick="event.stopPropagation()">{{ record[field] }}</a>
       {% else %}
         {{ record[field] }}
       {% endif %}


### PR DESCRIPTION
## Summary
- show `<a>` tags for `url` field types in list rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685002cd228083339c1e89390f627e5a