### PR TITLE
Add search/limit API querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Filtered Records Widget:** Table widget showing records from any table matching a search filter, with optional sort and limit.
 * **Dashboard Grid Editing:** Widgets can be dragged, resized, and saved using `/dashboard/layout`.
 * **Numerical Summaries:** `/<table>/sum-field` returns the sum for numeric columns, used by dashboard charts.
-* **List API:** `/api/<table>/list` provides ID and label data for dropdowns.
+* **List API:** `/api/<table>/list` provides ID and label data for dropdowns. It
+  accepts optional `search` and `limit` query parameters to filter results.
 * **CSV Import Workflow:** Upload a CSV on `/import`, map fields, then start a background job via `/import-start` and poll `/import-status` for progress.
 
 ## Project Structure
@@ -267,7 +268,7 @@ The following functions encapsulate the application logic:
 | `update_field(table, record_id)`              | **Route:** POST `/<table>/<int:record_id>/update` – Handles inline edits from the detail page. This is called when a user submits a field edit form. It first ensures the table is valid and the record exists. It then reads `field` (the field name to update) and the new value from the form data (`new_value` or `new_value_override`). Certain fields are protected: attempting to edit the primary `id` or the `edit_log` directly will result in a 403 Forbidden. For other fields, it determines the expected data type from the field schema and **coerces** the input accordingly: booleans are converted to "1" or "0", numbers to int (default 0 if parse fails), and all other types are treated as strings. It then executes an `UPDATE ... SET field = ?` query to save the new value. If the value changed, it appends a timestamped entry describing the change to the record’s `edit_log` field (this is done by concatenating text). After updating, it commits the transaction and redirects the user back to the detail view page for that record. |
 | `manage_relationship()`                       | **Route:** POST `/relationship` – AJAX endpoint for adding or removing a relationship between two records. It expects a JSON payload with `table_a`, `id_a`, `table_b`, `id_b`, and an `action` ("add" or "remove"). Depending on the action, it inserts or deletes a row in the `relationships` table using `INSERT OR IGNORE` for adds. On success, the endpoint returns JSON `{"success": True}`. Missing fields or invalid actions yield a 400 error and database errors return status 500. *(This function uses its own sqlite3 connection for simplicity.)* |
 | `dashboard()` | **Route:** GET `/dashboard` – Displays the dashboard page with draggable widgets.
-| `api_list(table)` | **Route:** GET `/api/<table>/list` – Returns JSON with `id` and `label` values for dropdowns. |
+| `api_list(table)` | **Route:** GET `/api/<table>/list` – Returns JSON with `id` and `label` values for dropdowns. Supports optional `search` and `limit` query params. |
 
 | `add_field_route(table, record_id)` | **Route:** POST `/<table>/<int:record_id>/add-field` – Adds a new column to the table and updates the field schema. |
 | `remove_field_route(table, record_id)` | **Route:** POST `/<table>/<int:record_id>/remove-field` – Removes a column from the table and refreshes the schema. |

--- a/static/js/relationship_dropdown.js
+++ b/static/js/relationship_dropdown.js
@@ -3,25 +3,37 @@ export function toggleAddRelation(tableA, idA, tableB) {
   if (!container) return;
   container.classList.toggle('hidden');
   const select = container.querySelector('select');
-  if (!container.dataset.loaded) {
-    fetch(`/api/${tableB}/list`)
-      .then(r => r.json())
-      .then(options => {
-        if (tableB !== 'content') {
-          options.sort((a, b) => a.label.localeCompare(b.label));
-        }
-        select.innerHTML = '';
-        options.forEach(opt => {
-          const o = document.createElement('option');
-          o.value = opt.id;
-          o.textContent = tableB === 'content' ? `#${opt.id} – ${opt.label}` : opt.label;
-          select.appendChild(o);
-        });
-        container.dataset.loaded = '1';
-      });
-  }
+  const search = container.querySelector('input');
   select.dataset.tableA = tableA;
   select.dataset.idA = idA;
+  if (!container.dataset.loaded) {
+    fetchRelationOptions(tableB, '', select);
+    container.dataset.loaded = '1';
+  }
+  search.focus();
+}
+
+function fetchRelationOptions(table, term, select) {
+  fetch(`/api/${table}/list?search=${encodeURIComponent(term)}&limit=20`)
+    .then(r => r.json())
+    .then(options => {
+      if (table !== 'content') {
+        options.sort((a, b) => a.label.localeCompare(b.label));
+      }
+      select.innerHTML = '';
+      options.forEach(opt => {
+        const o = document.createElement('option');
+        o.value = opt.id;
+        o.textContent = table === 'content' ? `#${opt.id} – ${opt.label}` : opt.label;
+        select.appendChild(o);
+      });
+    });
+}
+
+export function searchRelation(tableB, input) {
+  const select = document.getElementById(`rel-options-${tableB}`);
+  if (!select) return;
+  fetchRelationOptions(tableB, input.value, select);
 }
 
 export function submitRelation(tableB) {
@@ -60,3 +72,4 @@ export function removeRelation(tableA, idA, tableB, idB) {
 window.toggleAddRelation = toggleAddRelation;
 window.submitRelation = submitRelation;
 window.removeRelation = removeRelation;
+window.searchRelation = searchRelation;

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -189,6 +189,7 @@
             <span class="text-gray-400">None</span>
           {% endif %}
           <div id="add-rel-{{ section }}" class="mt-2 hidden">
+            <input type="text" placeholder="Search..." class="border px-2 py-1 text-sm rounded w-full mb-1" oninput="searchRelation('{{ section }}', this)">
             <select id="rel-options-{{ section }}" class="border px-2 py-1 text-sm rounded w-full mb-1"></select>
             <button onclick="submitRelation('{{ section }}')" class="btn-primary px-2 py-1 text-sm rounded">Add</button>
           </div>

--- a/tests/test_api_list.py
+++ b/tests/test_api_list.py
@@ -1,0 +1,19 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from main import app
+from db.database import init_db_path
+
+init_db_path('data/crossbook.db')
+app.testing = True
+client = app.test_client()
+
+
+def test_api_list_search_limit():
+    resp = client.get('/api/character/list', query_string={'search': 'Aji', 'limit': 1})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['label'].startswith('Aji')
+
+


### PR DESCRIPTION
## Summary
- add search and limit parameters to `/api/<table>/list`
- skip `update_foreign_field_options` for very large tables
- make relationship dropdown fetch results as you type
- document new list API parameters
- test list API search and limit support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685002d9c85883338680d88de184bc66