### PR TITLE
Add relationship visibility controls

### DIFF
--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -30,6 +30,7 @@ DEFAULT_CONFIGS = [
     ),
     ("filename", "logs/crossbook.log", "general", "string"),
     ("heading", "", "home", "string"),
+    ("relationship_visibility", "{}", "general", "json"),
 ]
 
 LAYOUT_DEFAULTS = {

--- a/db/config.py
+++ b/db/config.py
@@ -59,10 +59,27 @@ def get_layout_defaults() -> dict:
 
     if not row:
         return {}
+
+
+def get_relationship_visibility() -> dict:
+    """Return per-table relationship visibility settings."""
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT value FROM config WHERE key = 'relationship_visibility'")
+        row = cur.fetchone()
+    if not row:
+        return {}
     try:
         return json.loads(row[0])
     except Exception:
         return {}
+
+
+def update_relationship_visibility(table: str, visibility: dict) -> None:
+    """Update visibility settings for a specific base table."""
+    current = get_relationship_visibility()
+    current[table] = visibility
+    update_config("relationship_visibility", json.dumps(current))
 
 
 def update_config(key: str, value: str) -> int:

--- a/static/js/relation_visibility.js
+++ b/static/js/relation_visibility.js
@@ -1,0 +1,62 @@
+// Toggle visibility of related record sections
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('toggle-relation-visibility');
+  const pop = document.getElementById('relation-visibility-popover');
+  if (!btn || !pop) return;
+
+  const table = btn.dataset.table;
+  let config = window.RELATION_VISIBILITY || {};
+
+  function sendConfig() {
+    fetch(`/${table}/relationships`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ visibility: config })
+    }).catch(() => {});
+  }
+
+  function updateSection(section) {
+    const settings = config[section] || {};
+    const hidden = settings.hidden;
+    const force = settings.force;
+    document.querySelectorAll(`li.related-group[data-section="${section}"]`).forEach(el => {
+      const hasItems = parseInt(el.dataset.hasItems, 10) > 0;
+      const hide = hidden && (force || !hasItems);
+      el.classList.toggle('hidden', hide);
+    });
+  }
+
+  function initCheckboxes() {
+    pop.querySelectorAll('.relation-visible').forEach(cb => {
+      const sec = cb.value;
+      cb.checked = !(config[sec] && config[sec].hidden);
+      cb.addEventListener('change', () => {
+        config[sec] = config[sec] || {};
+        config[sec].hidden = !cb.checked;
+        sendConfig();
+        updateSection(sec);
+      });
+    });
+    pop.querySelectorAll('.relation-force').forEach(cb => {
+      const sec = cb.dataset.section;
+      cb.checked = !!(config[sec] && config[sec].force);
+      cb.addEventListener('change', () => {
+        config[sec] = config[sec] || {};
+        config[sec].force = cb.checked;
+        sendConfig();
+        updateSection(sec);
+      });
+    });
+  }
+
+  btn.addEventListener('click', e => {
+    e.stopPropagation();
+    pop.classList.toggle('hidden');
+  });
+  document.addEventListener('click', () => pop.classList.add('hidden'));
+  pop.addEventListener('click', e => e.stopPropagation());
+
+  initCheckboxes();
+  Object.keys(config).forEach(updateSection);
+});

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -80,6 +80,29 @@
             <span class="text-sm">Last Edited</span>
           </label>
         </div>
+        <button id="toggle-relation-visibility" data-table="{{ table }}" type="button" class="inline-flex items-center px-2 py-1 bg-gray-200 rounded ml-2 space-x-1">
+          <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M4 4h12v12H4z" />
+          </svg>
+          <span class="truncate max-w-[6rem] sm:max-w-none text-sm">Relations</span>
+          <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+        <div id="relation-visibility-popover" class="absolute right-0 z-20 hidden mt-2 bg-white border rounded shadow-lg p-2 space-y-2 w-64">
+          {% for sec, grp, vis in related %}
+            <div class="space-y-1">
+              <label class="flex items-center space-x-2">
+                <input type="checkbox" class="relation-visible" value="{{ sec }}">
+                <span class="text-sm">{{ grp.label }}</span>
+              </label>
+              <label class="flex items-center space-x-2 ml-6 text-xs">
+                <input type="checkbox" class="relation-force" data-section="{{ sec }}">
+                <span>Hide if content</span>
+              </label>
+            </div>
+          {% endfor %}
+        </div>
       </div>
     </div>
 
@@ -160,8 +183,10 @@
   <div id="related-pages" class="w-full md:w-1/3 lg:w-1/4 xl:w-64 border-l-2 border-blue-200 pl-6 flex-shrink-0">
     <h2 class="text-xl font-semibold mb-2">Related Pages</h2>
     <ul id="related-pages-list" class="space-y-2 text-blue-700 text-sm">
-      {% for section, group in related %}
-        <li>
+      {% for section, group, vis in related %}
+        {% set has_items = group['items']|length > 0 %}
+        {% set hide = vis.hidden and (vis.force or not has_items) %}
+        <li class="related-group{% if hide %} hidden{% endif %}" data-section="{{ section }}" data-has-items="{{ 1 if has_items else 0 }}">
           <div class="flex items-center justify-between">
             <strong>{{ group.label }}:</strong>
             <button
@@ -201,6 +226,7 @@
 
 <script>const layoutCache = {{ field_schema_layout | tojson }};</script>
 <script>window.FIELD_LAYOUT_DEFAULTS = {{ field_layout_defaults | tojson }};</script>
+<script>window.RELATION_VISIBILITY = {{ relationship_visibility | tojson }};</script>
 <script>
     document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('.draggable-field').forEach(el => {
@@ -225,6 +251,7 @@
 <script src="{{ url_for('static', filename='js/layout_editor.js') }}"></script>
 <script src="{{ url_for('static', filename='js/field_styling.js') }}"></script>
 <script src="{{ url_for('static', filename='js/header_field_visibility.js') }}"></script>
+<script src="{{ url_for('static', filename='js/relation_visibility.js') }}"></script>
 
 <script type="module">
   window.openLayoutModal = function () {

--- a/tests/test_relationship_visibility.py
+++ b/tests/test_relationship_visibility.py
@@ -1,0 +1,19 @@
+import os, sys, sqlite3, json
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from main import app
+from db.database import init_db_path
+from db.config import get_relationship_visibility
+
+init_db_path('data/crossbook.db')
+app.testing = True
+client = app.test_client()
+
+DB_PATH = 'data/crossbook.db'
+
+def test_update_relationship_visibility():
+    resp = client.post('/character/relationships', json={'visibility': {'location': {'hidden': True, 'force': True}}})
+    assert resp.status_code == 200
+    assert resp.get_json()['success']
+    vis = get_relationship_visibility()
+    assert vis['character']['location']['hidden'] is True
+    assert vis['character']['location']['force'] is True


### PR DESCRIPTION
## Summary
- allow controlling visibility of related sections per base table
- store visibility settings in config under `relationship_visibility`
- expose `/ <table>/relationships` endpoint to save options
- show Relations dropdown in edit mode on detail view
- add JS to toggle section display and persist preferences
- test relationship visibility persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685033b0c9f88333a5f0bba731854267