### PR TITLE
Improve relation visibility toggle

### DIFF
--- a/static/js/layout_editor.js
+++ b/static/js/layout_editor.js
@@ -84,6 +84,7 @@ function handleSaveLayout() {
   const saveLayoutBtn       = document.getElementById('save-layout');
   const resetLayoutBtn      = document.getElementById('reset-layout');
   const headerToggleWrap    = document.getElementById('special-visibility-wrapper');
+  const relationToggleWrap  = document.getElementById('relation-visibility-wrapper');
   toggleEditLayoutBtn.classList.remove('hidden');
   layoutGrid.classList.remove('editing');
   document.getElementById('field-style-menu')?.classList.add('hidden');
@@ -91,6 +92,7 @@ function handleSaveLayout() {
     document.querySelectorAll('.resize-handle')
 .forEach(h => h.classList.add('hidden'));
   if (headerToggleWrap) headerToggleWrap.classList.add('hidden');
+  if (relationToggleWrap) relationToggleWrap.classList.add('hidden');
   const table = layoutGrid.dataset.table;
   const layoutEntries = Object.entries(layoutCache)
     .filter(([field]) => document.querySelector(`.draggable-field[data-field=\"${field}\"]`))
@@ -123,12 +125,14 @@ function editModeButtons() {
   const saveLayoutBtn       = document.getElementById('save-layout');
   const layoutGrid          = document.getElementById('layout-grid');
   const headerToggleWrap    = document.getElementById('special-visibility-wrapper');
+  const relationToggleWrap  = document.getElementById('relation-visibility-wrapper');
   layoutGrid.classList.add('editing');
   resetLayoutBtn.classList.remove('hidden');
   addFieldBtn.classList.add('hidden');
   toggleEditLayoutBtn.classList.add('hidden');
   saveLayoutBtn.classList.remove('hidden');
   if (headerToggleWrap) headerToggleWrap.classList.remove('hidden');
+  if (relationToggleWrap) relationToggleWrap.classList.remove('hidden');
 }
 
 function enableVanillaDrag() {

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -80,29 +80,6 @@
             <span class="text-sm">Last Edited</span>
           </label>
         </div>
-        <button id="toggle-relation-visibility" data-table="{{ table }}" type="button" class="inline-flex items-center px-2 py-1 bg-gray-200 rounded ml-2 space-x-1">
-          <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-            <path d="M4 4h12v12H4z" />
-          </svg>
-          <span class="truncate max-w-[6rem] sm:max-w-none text-sm">Relations</span>
-          <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-          </svg>
-        </button>
-        <div id="relation-visibility-popover" class="absolute right-0 z-20 hidden mt-2 bg-white border rounded shadow-lg p-2 space-y-2 w-64">
-          {% for sec, grp, vis in related %}
-            <div class="space-y-1">
-              <label class="flex items-center space-x-2">
-                <input type="checkbox" class="relation-visible" value="{{ sec }}">
-                <span class="text-sm">{{ grp.label }}</span>
-              </label>
-              <label class="flex items-center space-x-2 ml-6 text-xs">
-                <input type="checkbox" class="relation-force" data-section="{{ sec }}">
-                <span>Hide if content</span>
-              </label>
-            </div>
-          {% endfor %}
-        </div>
       </div>
     </div>
 
@@ -181,7 +158,34 @@
 
   <!-- Right: Related Content -->
   <div id="related-pages" class="w-full md:w-1/3 lg:w-1/4 xl:w-64 border-l-2 border-blue-200 pl-6 flex-shrink-0">
-    <h2 class="text-xl font-semibold mb-2">Related Pages</h2>
+    <div class="flex items-center mb-2">
+      <h2 class="text-xl font-semibold">Related Pages</h2>
+      <div id="relation-visibility-wrapper" class="relative inline-block text-left ml-2 hidden">
+        <button id="toggle-relation-visibility" data-table="{{ table }}" type="button" class="inline-flex items-center px-2 py-1 bg-gray-200 rounded space-x-1">
+          <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M10 12.5C11.3807 12.5 12.5 11.3807 12.5 10C12.5 8.61929 11.3807 7.5 10 7.5C8.61929 7.5 7.5 8.61929 7.5 10C7.5 11.3807 8.61929 12.5 10 12.5Z" />
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M0.664255 10.5904C0.517392 10.2087 0.517518 9.78563 0.66461 9.40408C2.10878 5.65788 5.7433 3 9.99859 3C14.256 3 17.892 5.66051 19.3347 9.40962C19.4816 9.79127 19.4814 10.2144 19.3344 10.5959C17.8902 14.3421 14.2557 17 10.0004 17C5.74298 17 2.10698 14.3395 0.664255 10.5904ZM14.0004 10C14.0004 12.2091 12.2095 14 10.0004 14C7.79123 14 6.00037 12.2091 6.00037 10C6.00037 7.79086 7.79123 6 10.0004 6C12.2095 6 14.0004 7.79086 14.0004 10Z" />
+          </svg>
+          <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+        <div id="relation-visibility-popover" class="absolute right-0 z-20 hidden mt-2 bg-white border rounded shadow-lg p-2 space-y-2 w-64">
+          {% for sec, grp, vis in related %}
+            <div class="space-y-1">
+              <label class="flex items-center space-x-2">
+                <input type="checkbox" class="relation-visible" value="{{ sec }}">
+                <span class="text-sm">{{ grp.label }}</span>
+              </label>
+              <label class="flex items-center space-x-2 ml-6 text-xs">
+                <input type="checkbox" class="relation-force" data-section="{{ sec }}">
+                <span>even if full?</span>
+              </label>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
     <ul id="related-pages-list" class="space-y-2 text-blue-700 text-sm">
       {% for section, group, vis in related %}
         {% set has_items = group['items']|length > 0 %}


### PR DESCRIPTION
## Summary
- move the relation visibility controls next to the related pages heading
- use an eye icon instead of a square
- update layout editor to show/hide the new wrapper
- reword the force-hide label

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504d31503083339e27e5a5701f7e77