### PR TITLE
Fix edit history imports

### DIFF
--- a/utils/record_ops.py
+++ b/utils/record_ops.py
@@ -4,8 +4,8 @@ from typing import Any, Iterable
 from db.records import (
     get_record_by_id,
     update_field_value,
-    append_edit_log,
 )
+from db.edit_history import append_edit_log
 from db.schema import get_field_schema
 
 logger = logging.getLogger(__name__)

--- a/views/records/record_views.py
+++ b/views/records/record_views.py
@@ -8,12 +8,13 @@ from db.records import (
     delete_record,
     count_nonnull as db_count_nonnull,
     field_distribution,
+)
+from db.edit_history import (
+    append_edit_log,
     get_edit_history,
     get_edit_entry,
     revert_edit,
-
 )
-from db.edit_history import append_edit_log, get_edit_history, get_edit_entry, revert_edit
 from db.relationships import get_related_records, add_relationship, remove_relationship
 from db.edit_fields import add_column_to_table, add_field_to_schema, drop_column_from_table, remove_field_from_schema
 from db.schema import (


### PR DESCRIPTION
## Summary
- import edit history helpers from the correct module
- adjust record_ops to use append_edit_log from edit_history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685066b86d108333825d0b7f68e1b3c4