### PR TITLE
Enhance new DB creation modal

### DIFF
--- a/static/js/database_admin.js
+++ b/static/js/database_admin.js
@@ -51,35 +51,72 @@ function initDatabaseControls() {
     });
   }
 
-  const createBtn = document.getElementById('create-db-btn');
-  if (createBtn) {
-    createBtn.addEventListener('click', () => {
-      const name = prompt('Filename for new database (.db):');
-      if (!name) return;
-      const fd = new FormData();
-      fd.append('create_name', name);
-      fetch('/admin/config/db', { method: 'POST', body: fd, headers: { 'Accept': 'application/json' } })
-        .then(r => r.json())
-        .then(data => {
-          if (data.redirect) {
-            window.location.href = data.redirect;
-            return;
-          }
-          if (data.db_path) {
-            const disp = document.getElementById('db-path-display');
-            if (disp) {
-              disp.textContent = data.db_path;
-              disp.classList.remove('text-red-600', 'text-green-600');
-              const color = data.status === 'valid' ? 'text-green-600' : 'text-red-600';
-              disp.classList.add(color);
-            }
-            window.location.reload();
-          }
-        });
-    });
+}
+
+let createDbTrigger = null;
+const escHandler = (e) => {
+  if (e.key === 'Escape') {
+    closeCreateDbModal();
   }
+};
+
+export function openCreateDbModal() {
+  createDbTrigger = document.activeElement;
+  document.getElementById('createDbModal').classList.remove('hidden');
+  document.addEventListener('keydown', escHandler);
+}
+
+export function closeCreateDbModal() {
+  document.getElementById('createDbModal').classList.add('hidden');
+  document.removeEventListener('keydown', escHandler);
+  if (createDbTrigger) {
+    createDbTrigger.focus();
+    createDbTrigger = null;
+  }
+  const err = document.getElementById('create-db-error');
+  if (err) {
+    err.textContent = '';
+    err.classList.add('hidden');
+  }
+}
+
+export function submitCreateDb(event) {
+  if (event) event.preventDefault();
+  const nameInput = document.getElementById('create-db-name');
+  const name = nameInput.value.trim();
+  if (!name) return;
+  const fd = new FormData();
+  fd.append('create_name', name);
+  fetch('/admin/config/db', { method: 'POST', body: fd, headers: { 'Accept': 'application/json' } })
+    .then(r => r.json())
+    .then(data => {
+      if (data.redirect) {
+        window.location.href = data.redirect;
+        return;
+      }
+      if (data.db_path) {
+        const disp = document.getElementById('db-path-display');
+        if (disp) {
+          disp.textContent = data.db_path;
+          disp.classList.remove('text-red-600', 'text-green-600');
+          const color = data.status === 'valid' ? 'text-green-600' : 'text-red-600';
+          disp.classList.add(color);
+        }
+        window.location.reload();
+      } else if (data.error) {
+        const err = document.getElementById('create-db-error');
+        if (err) {
+          err.textContent = data.error;
+          err.classList.remove('hidden');
+        }
+      }
+    });
 }
 
 document.addEventListener('DOMContentLoaded', () => {
   initDatabaseControls();
 });
+
+window.openCreateDbModal = openCreateDbModal;
+window.closeCreateDbModal = closeCreateDbModal;
+window.submitCreateDb = submitCreateDb;

--- a/templates/admin/database_admin.html
+++ b/templates/admin/database_admin.html
@@ -11,8 +11,9 @@
       <input type="file" name="file" accept=".db" class="text-sm border border-gray-300 rounded" />
       <button type="submit" class="btn-danger px-3 py-1 rounded">Change Database</button>
     </form>
-    <button id="create-db-btn" type="button" class="btn-primary px-3 py-1 rounded">Create New DB</button>
+    <button id="create-db-btn" type="button" class="btn-primary px-3 py-1 rounded" onclick="openCreateDbModal()">Create New DB</button>
   </div>
 </div>
+{% include "modals/create_db_modal.html" %}
 <script type="module" src="{{ url_for('static', filename='js/database_admin.js') }}"></script>
 {% endblock %}

--- a/templates/modals/create_db_modal.html
+++ b/templates/modals/create_db_modal.html
@@ -1,0 +1,16 @@
+<div id="createDbModal" class="modal-container hidden" onclick="if(event.target.id === 'createDbModal') closeCreateDbModal()">
+  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+    <button type="button" onclick="closeCreateDbModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
+    <h3 class="text-lg font-bold mb-4">Create New Database</h3>
+    <div id="create-db-error" class="text-red-600 hidden mb-2"></div>
+    <form id="create-db-form" onsubmit="submitCreateDb(event)" class="space-y-4">
+      <div>
+        <label for="create-db-name" class="block mb-1">Filename (.db)</label>
+        <input id="create-db-name" type="text" class="w-full border rounded p-2" required>
+      </div>
+      <div class="flex justify-end">
+        <button type="submit" class="btn-primary px-4 py-2 rounded">Create</button>
+      </div>
+    </form>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add a proper modal for creating a new database
- wire new modal up in admin page
- support open/close/submit functions in JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506de028388333a5254ca164125622