### PR TITLE
Add utility and DB operation tests

### DIFF
--- a/tests/test_db_records.py
+++ b/tests/test_db_records.py
@@ -1,0 +1,66 @@
+import os
+import sqlite3
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from db.database import init_db_path
+from db.records import (
+    create_record,
+    delete_record,
+    count_nonnull,
+    field_distribution,
+    get_record_by_id,
+)
+from db.edit_fields import (
+    add_column_to_table,
+    drop_column_from_table,
+    add_field_to_schema,
+    remove_field_from_schema,
+)
+
+DB_PATH = 'data/crossbook.db'
+init_db_path(DB_PATH)
+
+
+def column_names(table):
+    with sqlite3.connect(DB_PATH) as conn:
+        return [r[1] for r in conn.execute(f"PRAGMA table_info('{table}')").fetchall()]
+
+
+def test_create_delete_and_counts():
+    baseline = count_nonnull('location', 'location')
+    dist_before = field_distribution('location', 'location')
+
+    data = {
+        'location': 'UnitTestPlace',
+        'description': '<p>Hi</p><script>bad()</script>',
+    }
+    rec_id = create_record('location', data)
+    assert isinstance(rec_id, int)
+
+    rec = get_record_by_id('location', rec_id)
+    assert rec['location'] == 'UnitTestPlace'
+    assert '<script>' not in rec['description']
+
+    assert count_nonnull('location', 'location') == baseline + 1
+    dist_mid = field_distribution('location', 'location')
+    assert dist_mid.get('UnitTestPlace') == 1
+
+    assert delete_record('location', rec_id) is True
+    assert count_nonnull('location', 'location') == baseline
+    dist_after = field_distribution('location', 'location')
+    assert 'UnitTestPlace' not in dist_after
+
+
+def test_add_and_drop_column():
+    col = 'temp_testcol'
+    if col in column_names('character'):
+        drop_column_from_table('character', col)
+        remove_field_from_schema('character', col)
+    add_column_to_table('character', col, 'text')
+    add_field_to_schema('character', col, 'text')
+    assert col in column_names('character')
+
+    drop_column_from_table('character', col)
+    remove_field_from_schema('character', col)
+    assert col not in column_names('character')

--- a/tests/test_field_registry.py
+++ b/tests/test_field_registry.py
@@ -1,0 +1,21 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils.field_registry import register_type, get_field_type, get_type_size_map, FIELD_TYPES
+
+
+def test_register_get_and_size_map():
+    # ensure clean state
+    if 'tmp_test' in FIELD_TYPES:
+        FIELD_TYPES.pop('tmp_test')
+    register_type('tmp_test', sql_type='INTEGER', default_width=7, default_height=9)
+
+    ft = get_field_type('tmp_test')
+    assert ft.name == 'tmp_test'
+    assert ft.sql_type == 'INTEGER'
+
+    size_map = get_type_size_map()
+    assert size_map['tmp_test'] == (7, 9)
+
+    FIELD_TYPES.pop('tmp_test', None)

--- a/tests/test_html_sanitizer.py
+++ b/tests/test_html_sanitizer.py
@@ -1,0 +1,21 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils.html_sanitizer import sanitize_html
+
+
+def test_sanitize_removes_disallowed_tags():
+    html = "<p>Hello <strong>World</strong><script>alert(1)</script></p>"
+    cleaned = sanitize_html(html)
+    assert "<strong>World</strong>" in cleaned
+    assert cleaned.startswith("<p>")
+    assert "<script>" not in cleaned
+
+
+def test_sanitize_allows_basic_attributes():
+    html = '<img src="/x.png" alt="pic" onclick="evil"><a href="/a" target="_blank" rel="noopener" onclick="bad">link</a>'
+    cleaned = sanitize_html(html)
+    assert '<img src="/x.png" alt="pic">' in cleaned
+    assert '<a href="/a" target="_blank" rel="noopener">link</a>' in cleaned
+    assert 'onclick' not in cleaned

--- a/tests/test_parse_list_params.py
+++ b/tests/test_parse_list_params.py
@@ -1,0 +1,23 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from main import app
+from db.database import init_db_path
+from utils.records_helpers import parse_list_params
+
+init_db_path('data/crossbook.db')
+app.testing = True
+
+
+def test_parse_list_params_basic():
+    query = '/?search=test&RACE=Elf&race_op=equals&notes_mode=all&sort=character&dir=desc&extra=1'
+    with app.test_request_context(query):
+        params = parse_list_params('character')
+    assert params['search'] == 'test'
+    assert params['filters'] == {'race': ['Elf']}
+    assert params['ops'] == {'race': 'equals'}
+    assert params['modes'] == {'notes': 'all'}
+    assert params['sort_field'] == 'character'
+    assert params['direction'] == 'desc'
+    assert 'extra' not in params['filters']


### PR DESCRIPTION
## Summary
- ensure sanitizer keeps and strips correct HTML
- test registry helpers
- test record CRUD helpers and column editing
- add parse_list_params test

## Testing
- `pytest -q tests/test_html_sanitizer.py tests/test_field_registry.py tests/test_db_records.py tests/test_parse_list_params.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511d43c5bc8333a5a9e76fe7710b19