### PR TITLE
Add flask fixtures for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import shutil
+import pytest
+
+# Ensure repository root is in path
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from db.database import init_db_path
+from views.admin import reload_app_state
+
+@pytest.fixture
+def db_path(tmp_path):
+    """Copy the sample database to a temporary location and initialize DB_PATH."""
+    src = os.path.join(ROOT_DIR, 'data', 'crossbook.db')
+    dst = tmp_path / 'test.db'
+    shutil.copy(src, dst)
+    init_db_path(str(dst))
+    return str(dst)
+
+@pytest.fixture
+def app(db_path):
+    """Create and configure a new app instance for tests."""
+    import main
+    flask_app = main.app
+    init_db_path(db_path)
+    flask_app.testing = True
+    with flask_app.app_context():
+        reload_app_state()
+    return flask_app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/test_admin_config.py
+++ b/tests/test_admin_config.py
@@ -1,16 +1,7 @@
-import os
-import sys
 import re
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from main import app
-from db.database import init_db_path
 
-init_db_path('data/crossbook.db')
 
-app.testing = True
-client = app.test_client()
-
-def test_log_level_field_is_select():
+def test_log_level_field_is_select(client):
     resp = client.get('/admin/config')
     assert resp.status_code == 200
     html = resp.data.decode()

--- a/tests/test_api_list.py
+++ b/tests/test_api_list.py
@@ -1,15 +1,4 @@
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from main import app
-from db.database import init_db_path
-
-init_db_path('data/crossbook.db')
-app.testing = True
-client = app.test_client()
-
-
-def test_api_list_search_limit():
+def test_api_list_search_limit(client):
     resp = client.get('/api/character/list', query_string={'search': 'Aji', 'limit': 1})
     assert resp.status_code == 200
     data = resp.get_json()

--- a/tests/test_dashboard_utils.py
+++ b/tests/test_dashboard_utils.py
@@ -1,14 +1,7 @@
-import os
-import sys
 import sqlite3
 import json
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
-
-from db.database import init_db_path
 from db.dashboard import (
     sum_field,
     create_widget,
@@ -16,19 +9,15 @@ from db.dashboard import (
     update_widget_styling,
 )
 
-DB_PATH = "data/crossbook.db"
-init_db_path(DB_PATH)
-
-
-def fetch_value(sql, params=()):
-    with sqlite3.connect(DB_PATH) as conn:
+def fetch_value(db_path, sql, params=()):
+    with sqlite3.connect(db_path) as conn:
         cur = conn.execute(sql, params)
         row = cur.fetchone()
         return row[0] if row else None
 
 
-def test_sum_field_returns_correct_sum():
-    expected = fetch_value("SELECT SUM(linenumber) FROM content")
+def test_sum_field_returns_correct_sum(db_path):
+    expected = fetch_value(db_path, "SELECT SUM(linenumber) FROM content")
     assert sum_field("content", "linenumber") == expected
 
 
@@ -37,22 +26,18 @@ def test_sum_field_raises_for_non_numeric():
         sum_field("content", "content")  # 'content' field is not numeric
 
 
-def test_create_widget_auto_row_start_and_id():
-    start = fetch_value(
-        "SELECT COALESCE(MAX(row_start + row_span), 0) FROM dashboard_widget"
-    )
+def test_create_widget_auto_row_start_and_id(db_path):
+    start = fetch_value(db_path, "SELECT COALESCE(MAX(row_start + row_span), 0) FROM dashboard_widget")
     widget_id = create_widget("Temp", "{}", "value", 1, 1, None, 1)
     assert isinstance(widget_id, int)
-    row_start = fetch_value(
-        "SELECT row_start FROM dashboard_widget WHERE id=?", (widget_id,)
-    )
+    row_start = fetch_value(db_path, "SELECT row_start FROM dashboard_widget WHERE id=?", (widget_id,))
     assert row_start == start
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(db_path) as conn:
         conn.execute("DELETE FROM dashboard_widget WHERE id=?", (widget_id,))
         conn.commit()
 
 
-def test_update_widget_layout_multiple_and_ignore_invalid():
+def test_update_widget_layout_multiple_and_ignore_invalid(db_path):
     id1 = create_widget("L1", "{}", "value", 1, 1, None, 1)
     id2 = create_widget("L2", "{}", "value", 1, 1, None, 1)
     layout = [
@@ -76,33 +61,25 @@ def test_update_widget_layout_multiple_and_ignore_invalid():
     ]
     updated = update_widget_layout(layout)
     assert updated == 2
-    vals1 = fetch_value(
-        "SELECT col_start FROM dashboard_widget WHERE id=?", (id1,)
-    )
-    vals2 = fetch_value(
-        "SELECT row_span FROM dashboard_widget WHERE id=?", (id2,)
-    )
+    vals1 = fetch_value(db_path, "SELECT col_start FROM dashboard_widget WHERE id=?", (id1,))
+    vals2 = fetch_value(db_path, "SELECT row_span FROM dashboard_widget WHERE id=?", (id2,))
     assert vals1 == 2
     assert vals2 == 2
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(db_path) as conn:
         conn.execute(
             "DELETE FROM dashboard_widget WHERE id IN (?, ?)", (id1, id2)
         )
         conn.commit()
 
 
-def test_update_widget_styling_valid_and_invalid():
+def test_update_widget_styling_valid_and_invalid(db_path):
     wid = create_widget("Style", "{}", "value", 1, 1, None, 1)
     assert update_widget_styling(wid, {"color": "red"}) is True
-    stored = fetch_value(
-        "SELECT styling FROM dashboard_widget WHERE id=?", (wid,)
-    )
+    stored = fetch_value(db_path, "SELECT styling FROM dashboard_widget WHERE id=?", (wid,))
     assert json.loads(stored) == {"color": "red"}
     assert update_widget_styling(wid, {"bad": {1}}) is False
-    stored_after = fetch_value(
-        "SELECT styling FROM dashboard_widget WHERE id=?", (wid,)
-    )
+    stored_after = fetch_value(db_path, "SELECT styling FROM dashboard_widget WHERE id=?", (wid,))
     assert stored_after == stored
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(db_path) as conn:
         conn.execute("DELETE FROM dashboard_widget WHERE id=?", (wid,))
         conn.commit()

--- a/tests/test_html_injection.py
+++ b/tests/test_html_injection.py
@@ -1,25 +1,14 @@
-import os
-import sys
 import sqlite3
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from main import app
-from db.database import init_db_path
 
-init_db_path('data/crossbook.db')
-app.testing = True
-client = app.test_client()
-
-DB_PATH = 'data/crossbook.db'
-
-def test_textarea_update_sanitizes_html():
-    with sqlite3.connect(DB_PATH) as conn:
+def test_textarea_update_sanitizes_html(client, db_path):
+    with sqlite3.connect(db_path) as conn:
         record_id = conn.execute('SELECT id FROM character LIMIT 1').fetchone()[0]
 
     payload = "<script>alert(1)</script><p>Hello</p>"
     resp = client.post(f'/character/{record_id}/update', data={'field': 'description', 'new_value': payload})
     assert resp.status_code in (200, 302)
 
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(db_path) as conn:
         value = conn.execute('SELECT description FROM character WHERE id = ?', (record_id,)).fetchone()[0]
 
     assert '<script>' not in value

--- a/tests/test_import_jobs.py
+++ b/tests/test_import_jobs.py
@@ -1,14 +1,7 @@
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from main import app
 from imports import tasks as import_tasks
 
-app.testing = True
-client = app.test_client()
 
-
-def test_import_start_and_status():
+def test_import_start_and_status(client):
     import_tasks.huey.immediate = True
     payload = {
         'table': 'character',

--- a/tests/test_query_filters.py
+++ b/tests/test_query_filters.py
@@ -1,16 +1,8 @@
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-from db.database import init_db_path
 from db.query_filters import _build_filters
 from db.schema import get_field_schema
 
-init_db_path('data/crossbook.db')
 
-
-def test_build_filters_search_clause():
+def test_build_filters_search_clause(db_path):
     fields = [
         f
         for f, meta in get_field_schema()['character'].items()
@@ -25,13 +17,13 @@ def test_build_filters_search_clause():
     assert params == ['%foo%'] * len(fields)
 
 
-def test_build_filters_multiple_values_any_mode():
+def test_build_filters_multiple_values_any_mode(db_path):
     clauses, params = _build_filters('content', filters={'tags': ['magic', 'quest']})
     assert clauses == ['(tags LIKE ? OR tags LIKE ?)']
     assert params == ['%magic%', '%quest%']
 
 
-def test_build_filters_multiple_values_all_equals():
+def test_build_filters_multiple_values_all_equals(db_path):
     clauses, params = _build_filters(
         'content',
         filters={'linenumber': [1, 2]},
@@ -42,7 +34,7 @@ def test_build_filters_multiple_values_all_equals():
     assert params == [1, 2]
 
 
-def test_build_filters_regex_operator():
+def test_build_filters_regex_operator(db_path):
     clauses, params = _build_filters(
         'content',
         filters={'chapter': '^Intro'},
@@ -52,7 +44,7 @@ def test_build_filters_regex_operator():
     assert params == ['^Intro']
 
 
-def test_apply_date_ranges():
+def test_apply_date_ranges(db_path):
     clauses, params = _build_filters(
         'content',
         filters={'date_created_start': '2023-01-01', 'date_created_end': '2023-01-31'},

--- a/tests/test_record_ops.py
+++ b/tests/test_record_ops.py
@@ -1,8 +1,4 @@
-import os
-import sys
 from unittest.mock import patch, call
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from utils.record_ops import _normalize_value, update_record_field, bulk_update_records
 

--- a/tests/test_relationship_visibility.py
+++ b/tests/test_relationship_visibility.py
@@ -1,16 +1,7 @@
-import os, sys, sqlite3, json
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from main import app
-from db.database import init_db_path
+import json
 from db.config import get_relationship_visibility
 
-init_db_path('data/crossbook.db')
-app.testing = True
-client = app.test_client()
-
-DB_PATH = 'data/crossbook.db'
-
-def test_update_relationship_visibility():
+def test_update_relationship_visibility(client):
     resp = client.post('/character/relationships', json={'visibility': {'location': {'hidden': True, 'force': True}}})
     assert resp.status_code == 200
     assert resp.get_json()['success']

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -1,24 +1,10 @@
-import os
-import sys
 import sqlite3
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-from main import app
-from db.database import init_db_path
 from db.relationships import get_related_records
 
-init_db_path('data/crossbook.db')
 
-app.testing = True
-client = app.test_client()
-
-DB_PATH = 'data/crossbook.db'
-
-
-def test_add_get_remove_relationship():
+def test_add_get_remove_relationship(client, db_path):
     # ensure starting state has no character 1 -> location 1 relationship
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(db_path) as conn:
         conn.execute(
             "DELETE FROM relationships WHERE table_a=? AND id_a=? AND table_b=? AND id_b=?",
             ('character', 1, 'location', 1),
@@ -61,8 +47,8 @@ def test_add_get_remove_relationship():
     )
 
 
-def test_edit_history_for_relationship_changes():
-    with sqlite3.connect(DB_PATH) as conn:
+def test_edit_history_for_relationship_changes(client, db_path):
+    with sqlite3.connect(db_path) as conn:
         conn.execute(
             "DELETE FROM relationships WHERE table_a=? AND id_a=? AND table_b=? AND id_b=?",
             ("character", 1, "location", 1),
@@ -86,7 +72,7 @@ def test_edit_history_for_relationship_changes():
     assert resp.status_code == 200
     assert resp.get_json()["success"]
 
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(db_path) as conn:
         rows = conn.execute(
             "SELECT table_name, record_id, field_name, old_value, new_value FROM edit_history WHERE id > ? ORDER BY id",
             (max_id,),
@@ -109,7 +95,7 @@ def test_edit_history_for_relationship_changes():
     assert resp.status_code == 200
     assert resp.get_json()["success"]
 
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(db_path) as conn:
         rows = conn.execute(
             "SELECT table_name, record_id, field_name, old_value, new_value FROM edit_history WHERE id > ? ORDER BY id",
             (max_id,),

--- a/tests/test_revert_edit.py
+++ b/tests/test_revert_edit.py
@@ -1,13 +1,5 @@
-import os
-import sys
 import sqlite3
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from db.edit_history import revert_edit
-from db.database import init_db_path
-
-init_db_path('data/crossbook.db')
-DB_PATH = 'data/crossbook.db'
 
 
 def test_revert_edit_returns_false_for_none_field():
@@ -21,8 +13,8 @@ def test_revert_edit_returns_false_for_none_field():
     assert revert_edit(entry) is False
 
 
-def test_revert_edit_restores_value_and_logs_entry():
-    with sqlite3.connect(DB_PATH) as conn:
+def test_revert_edit_restores_value_and_logs_entry(db_path):
+    with sqlite3.connect(db_path) as conn:
         original = conn.execute(
             'SELECT character FROM character WHERE id = 1'
         ).fetchone()[0]
@@ -44,7 +36,7 @@ def test_revert_edit_restores_value_and_logs_entry():
     }
     assert revert_edit(entry)
 
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(db_path) as conn:
         value = conn.execute(
             'SELECT character FROM character WHERE id = 1'
         ).fetchone()[0]
@@ -60,8 +52,8 @@ def test_revert_edit_restores_value_and_logs_entry():
         conn.commit()
 
 
-def test_revert_edit_adds_and_removes_relationships():
-    with sqlite3.connect(DB_PATH) as conn:
+def test_revert_edit_adds_and_removes_relationships(db_path):
+    with sqlite3.connect(db_path) as conn:
         # ensure no existing relationship
         conn.execute(
             "DELETE FROM relationships WHERE table_a='character' AND id_a=1 AND table_b='location' AND id_b=1"
@@ -80,7 +72,7 @@ def test_revert_edit_adds_and_removes_relationships():
     }
     assert revert_edit(add_entry)
 
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(db_path) as conn:
         count = conn.execute(
             "SELECT COUNT(*) FROM relationships WHERE table_a='character' AND id_a=1 AND table_b='location' AND id_b=1"
         ).fetchone()[0]
@@ -96,7 +88,7 @@ def test_revert_edit_adds_and_removes_relationships():
     }
     assert revert_edit(remove_entry)
 
-    with sqlite3.connect(DB_PATH) as conn:
+    with sqlite3.connect(db_path) as conn:
         count = conn.execute(
             "SELECT COUNT(*) FROM relationships WHERE table_a='character' AND id_a=1 AND table_b='location' AND id_b=1"
         ).fetchone()[0]

--- a/tests/test_validation_helpers.py
+++ b/tests/test_validation_helpers.py
@@ -1,7 +1,4 @@
-import os
-import sys
 import csv
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from utils.validation import (
     validate_text_column,

--- a/tests/test_wizard_database.py
+++ b/tests/test_wizard_database.py
@@ -1,15 +1,9 @@
 import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from main import app
 import db.database as db_database
 from db.config import get_config_rows
 
-app.testing = True
-client = app.test_client()
 
-
-def test_settings_step_after_db_creation():
+def test_settings_step_after_db_creation(client):
     new_name = 'test_created.db'
     # ensure file removed if exists from prior runs
     try:
@@ -39,11 +33,11 @@ def test_settings_step_after_db_creation():
     init_db_path('data/crossbook.db')
     update_config('db_path', 'data/crossbook.db')
     from views.admin import reload_app_state
-    with app.app_context():
+    with client.application.app_context():
         reload_app_state()
 
 
-def test_filename_prefix_added_on_settings_post():
+def test_filename_prefix_added_on_settings_post(client):
     with client.session_transaction() as sess:
         sess['wizard_progress'] = {'database': True}
 

--- a/tests/test_wizard_skip.py
+++ b/tests/test_wizard_skip.py
@@ -1,13 +1,7 @@
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from main import app
-
-app.testing = True
-client = app.test_client()
 
 
-def test_skip_import_route():
+
+def test_skip_import_route(client):
     with client.session_transaction() as sess:
         sess['wizard_progress'] = {'database': True, 'settings': True, 'table': True}
     resp = client.get('/wizard/skip-import', follow_redirects=True)

--- a/tests/test_wizard_start.py
+++ b/tests/test_wizard_start.py
@@ -1,13 +1,7 @@
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from main import app
-
-app.testing = True
-client = app.test_client()
 
 
-def test_wizard_start_without_progress_redirects_home():
+
+def test_wizard_start_without_progress_redirects_home(client):
     resp = client.get('/wizard/')
     assert resp.status_code == 302
     assert resp.headers['Location'].endswith('/')


### PR DESCRIPTION
## Summary
- add pytest `conftest` with fixtures for `db_path`, `app` and `client`
- update all tests to use the new fixtures instead of creating the app themselves
- refresh database state for wizard tests using `client.application`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511d2dbfa08333910bc0e12998d139