### PR TITLE
Support one-way relationships

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -39,6 +39,12 @@ def init_db_path(path: str | None = None) -> None:
     except Exception:
         pass
 
+    try:
+        from db.bootstrap import ensure_relationships_table
+        ensure_relationships_table(DB_PATH)
+    except Exception:
+        pass
+
 
 @contextmanager
 def get_connection():

--- a/static/js/relationship_dropdown.js
+++ b/static/js/relationship_dropdown.js
@@ -42,6 +42,8 @@ export function submitRelation(tableB) {
   const tableA = select.dataset.tableA;
   const idA = parseInt(select.dataset.idA, 10);
   const idB = parseInt(select.value, 10);
+  const dir = document.querySelector(`input[name="rel-dir-${tableB}"]:checked`);
+  const twoWay = dir ? dir.value === 'two' : true;
   fetch('/relationship', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -50,7 +52,8 @@ export function submitRelation(tableB) {
       id_a: idA,
       table_b: tableB,
       id_b: idB,
-      action: 'add'
+      action: 'add',
+      two_way: twoWay
     })
   }).then(() => location.reload());
 }

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -203,17 +203,18 @@
           </div>
           {% if group['items'] %}
             {% for item in group['items'] %}
-              <div class="flex justify-between items-center">
-                <a href="/{{ section }}/{{ item.id }}" class="underline">
-                  {% if section == 'content' %}{{ item.id }}{% else %}{{ item.name }}{% endif %}
-                </a>
-                <button
-                  onclick="removeRelation('{{ table }}', {{ record.id }}, '{{ section }}', {{ item.id }})"
-                  class="text-red-500 text-sm"
-                >
-                  ✖
-                </button>
-              </div>
+                <div class="flex justify-between items-center">
+                  <a href="/{{ section }}/{{ item.id }}" class="underline">
+                    {% if section == 'content' %}{{ item.id }}{% else %}{{ item.name }}{% endif %}
+                  </a>
+                  <span class="mx-1 text-xs text-gray-500">{% if item.two_way %}&lt;-&gt;{% else %}-&gt;{% endif %}</span>
+                  <button
+                    onclick="removeRelation('{{ table }}', {{ record.id }}, '{{ section }}', {{ item.id }})"
+                    class="text-red-500 text-sm"
+                  >
+                    ✖
+                  </button>
+                </div>
             {% endfor %}
           {% else %}
             <span class="text-gray-400">None</span>
@@ -221,6 +222,16 @@
           <div id="add-rel-{{ section }}" class="mt-2 hidden">
             <input type="text" placeholder="Search..." class="border px-2 py-1 text-sm rounded w-full mb-1" oninput="searchRelation('{{ section }}', this)">
             <select id="rel-options-{{ section }}" class="border px-2 py-1 text-sm rounded w-full mb-1"></select>
+            <div class="flex space-x-1 items-center mb-1 text-xs">
+              <label class="flex items-center space-x-1">
+                <input type="radio" name="rel-dir-{{ section }}" value="one" class="rel-dir" checked>
+                <span>-&gt;</span>
+              </label>
+              <label class="flex items-center space-x-1">
+                <input type="radio" name="rel-dir-{{ section }}" value="two" class="rel-dir">
+                <span>&lt;-&gt;</span>
+              </label>
+            </div>
             <button onclick="submitRelation('{{ section }}')" class="btn-primary px-2 py-1 text-sm rounded">Add</button>
           </div>
         </li>

--- a/tests/test_one_way_relationship.py
+++ b/tests/test_one_way_relationship.py
@@ -1,0 +1,60 @@
+import os, sys, sqlite3
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from main import app
+from db.database import init_db_path
+from db.relationships import get_related_records
+
+init_db_path('data/crossbook.db')
+app.testing = True
+client = app.test_client()
+
+DB_PATH = 'data/crossbook.db'
+
+
+def test_add_one_way_relationship():
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "DELETE FROM relationships WHERE table_a=? AND id_a=? AND table_b=? AND id_b=?",
+            ('character', 1, 'location', 1),
+        )
+        conn.commit()
+
+    resp = client.post(
+        '/relationship',
+        json={
+            'table_a': 'character',
+            'id_a': 1,
+            'table_b': 'location',
+            'id_b': 1,
+            'action': 'add',
+            'two_way': False,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()['success']
+
+    with sqlite3.connect(DB_PATH) as conn:
+        row = conn.execute(
+            "SELECT two_way FROM relationships WHERE table_a=? AND id_a=? AND table_b=? AND id_b=?",
+            ('character', 1, 'location', 1),
+        ).fetchone()
+        assert row is not None and row[0] == 0
+
+    related = get_related_records('character', 1)
+    assert 'location' in related
+    item = next(i for i in related['location']['items'] if i['id'] == 1)
+    assert item['two_way'] is False
+
+    resp = client.post(
+        '/relationship',
+        json={
+            'table_a': 'character',
+            'id_a': 1,
+            'table_b': 'location',
+            'id_b': 1,
+            'action': 'remove',
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()['success']

--- a/views/records/record_views.py
+++ b/views/records/record_views.py
@@ -222,8 +222,9 @@ def manage_relationship():
     id_a = data.get('id_a')
     table_b = data.get('table_b')
     id_b = data.get('id_b')
+    two_way = data.get('two_way', True)
     if action == 'add':
-        success = add_relationship(table_a, id_a, table_b, id_b)
+        success = add_relationship(table_a, id_a, table_b, id_b, two_way=bool(two_way))
     elif action == 'remove':
         success = remove_relationship(table_a, id_a, table_b, id_b)
     else:


### PR DESCRIPTION
## Summary
- add a `two_way` column to relationships table if missing
- ensure DB initialization upgrades the table
- store relationship type in `add_relationship`
- expose arrow indicator in detail view and allow selecting direction
- extend JS logic for relationship creation
- update API to accept `two_way`
- test new one-way relationship behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511e7cd0f083338f8dbc243907e5a1