### PR TITLE
Add missing tests for import CSV and dashboard

### DIFF
--- a/tests/test_dashboard_extra.py
+++ b/tests/test_dashboard_extra.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import sqlite3
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from main import app
+from db.database import init_db_path
+from db.dashboard import (
+    get_dashboard_widgets,
+    get_base_table_counts,
+    get_top_numeric_values,
+    get_filtered_records,
+)
+from db.records import count_records
+
+DB_PATH = 'data/crossbook.db'
+init_db_path(DB_PATH)
+
+
+def test_get_dashboard_widgets_list():
+    widgets = get_dashboard_widgets()
+    assert any(w["title"] == "Sum of linenumber" for w in widgets)
+    assert set(widgets[0].keys()) >= {"id", "title", "content", "widget_type", "col_start"}
+
+
+def test_get_base_table_counts_matches_record_counts():
+    with app.app_context():
+        app.config['BASE_TABLES'] = ['content', 'character']
+        counts = get_base_table_counts()
+    expected = [
+        {'table': 'content', 'count': count_records('content')},
+        {'table': 'character', 'count': count_records('character')},
+    ]
+    assert counts == expected
+
+
+def test_get_top_numeric_values_ascending_and_descending():
+    desc = get_top_numeric_values('content', 'linenumber', limit=3)
+    with sqlite3.connect(DB_PATH) as conn:
+        rows = conn.execute('SELECT id, linenumber FROM content WHERE linenumber IS NOT NULL ORDER BY linenumber DESC LIMIT 3').fetchall()
+    assert [(r['id'], r['value']) for r in desc] == [(row[0], row[1]) for row in rows]
+
+    asc = get_top_numeric_values('content', 'linenumber', limit=3, ascending=True)
+    with sqlite3.connect(DB_PATH) as conn:
+        rows_asc = conn.execute('SELECT id, linenumber FROM content WHERE linenumber IS NOT NULL ORDER BY linenumber ASC LIMIT 3').fetchall()
+    assert [(r['id'], r['value']) for r in asc] == [(row[0], row[1]) for row in rows_asc]
+
+
+def test_get_filtered_records_with_search_limit():
+    records = get_filtered_records('content', 'Shade', order_by='id', limit=5)
+    assert len(records) == 5
+    assert all('Shade' in r.get('chapter', '') for r in records)
+

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from db.database import check_db_status
+
+DB_PATH = 'data/crossbook.db'
+
+
+def test_check_db_status_valid_missing_corrupted():
+    assert check_db_status(DB_PATH) == 'valid'
+    assert check_db_status('nonexistent.db') == 'missing'
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(b'not a database')
+        corrupt_path = tmp.name
+    try:
+        assert check_db_status(corrupt_path) == 'corrupted'
+    finally:
+        os.remove(corrupt_path)
+

--- a/tests/test_import_csv.py
+++ b/tests/test_import_csv.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import io
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from imports.import_csv import parse_csv
+import csv
+
+
+def test_parse_csv_decodes_and_parses_rows():
+    sample = b"col1,col2\nA,1\nB,2\n"
+    original_limit = csv.field_size_limit()
+    headers, rows = parse_csv(io.BytesIO(sample))
+    csv.field_size_limit(original_limit)
+    assert headers == ["col1", "col2"]
+    assert rows == [{"col1": "A", "col2": "1"}, {"col1": "B", "col2": "2"}]
+
+


### PR DESCRIPTION
## Summary
- add test for CSV parsing
- add test for `check_db_status`
- add additional dashboard tests for widgets and numeric values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685120fd6e648333a3e8e3ff53293f37