### PR TITLE
Add wizard settings tests for boolean and date inputs

### DIFF
--- a/templates/wizard/wizard_settings.html
+++ b/templates/wizard/wizard_settings.html
@@ -21,6 +21,11 @@
       </select>
     {% elif typ in ('integer', 'number') %}
       <input type="number" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full" {% if item.required %}required{% endif %}>
+    {% elif typ == 'boolean' %}
+      <input type="checkbox" name="{{ key }}" id="{{ key }}" value="1" {% if config.get(key, default) in ('1', 1, True, 'true') %}checked{% endif %}>
+      <input type="hidden" name="{{ key }}" value="0">
+    {% elif typ == 'date' %}
+      <input type="date" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full" {% if item.required %}required{% endif %}>
     {% else %}
       <input type="text" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full" {% if item.required %}required{% endif %}>
     {% endif %}
@@ -48,6 +53,11 @@
       </select>
     {% elif typ in ('integer', 'number') %}
       <input type="number" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full" {% if item.required %}required{% endif %}>
+    {% elif typ == 'boolean' %}
+      <input type="checkbox" name="{{ key }}" id="{{ key }}" value="1" {% if config.get(key, default) in ('1', 1, True, 'true') %}checked{% endif %}>
+      <input type="hidden" name="{{ key }}" value="0">
+    {% elif typ == 'date' %}
+      <input type="date" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full" {% if item.required %}required{% endif %}>
     {% else %}
       <input type="text" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full" {% if item.required %}required{% endif %}>
     {% endif %}

--- a/tests/test_wizard_settings.py
+++ b/tests/test_wizard_settings.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import sqlite3
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from main import app
+from db.database import init_db_path
+
+init_db_path('data/crossbook.db')
+app.testing = True
+client = app.test_client()
+
+DB_PATH = 'data/crossbook.db'
+
+
+def test_boolean_and_date_inputs_render_correctly():
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO config (key, value, section, type) VALUES ('bool_setting', '1', 'general', 'boolean')"
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO config (key, value, section, type) VALUES ('date_setting', '2025-01-01', 'general', 'date')"
+        )
+        conn.commit()
+    try:
+        with client.session_transaction() as sess:
+            sess['wizard_progress'] = {'database': True}
+        resp = client.get('/wizard/settings')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert '<input type="checkbox" name="bool_setting"' in html
+        assert '<input type="date" name="date_setting"' in html
+    finally:
+        with sqlite3.connect(DB_PATH) as conn:
+            conn.execute("DELETE FROM config WHERE key IN ('bool_setting', 'date_setting')")
+            conn.commit()


### PR DESCRIPTION
## Summary
- support boolean and date types in wizard settings template
- add tests verifying the wizard renders checkbox and date inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685122e9ce0483339a8bcd29a61cec01