### PR TITLE
Apply new teal and purple branding

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -242,4 +242,27 @@ input[type=number] {
   z-index: 100;
 }
 
+/* Utility button and component styles */
+.btn-primary {
+  background-color: #0D9488;
+  color: #fff;
+}
+.btn-secondary {
+  background-color: #7C3AED;
+  color: #fff;
+}
+.btn-danger {
+  background-color: #dc2626;
+  color: #fff;
+}
+.card {
+  background-color: #fff;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.modal-container {
+  background-color: rgba(0,0,0,0.5);
+  backdrop-filter: blur(4px);
+}
+
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,8 +1,8 @@
 :root {
   --font-sans: 'Inter', 'IBM Plex Sans', sans-serif;
   --font-mono: 'JetBrains Mono', 'Menlo', monospace;
-  --color-primary: #2563eb;
-  --color-secondary: #64748b;
+  --color-primary: #0D9488; /* teal-600 */
+  --color-secondary: #7C3AED; /* accent purple */
   --color-danger: #dc2626;
 }
 
@@ -127,7 +127,8 @@ a:hover {
   border-radius: 0.25rem;
 }
 .nav-link:hover {
-  background-color: #374151; /* gray-700 */
+  background-color: #7C3AED; /* accent */
+  color: #fff;
 }
 
 .card-link {

--- a/static/js/dashboard_charts.js
+++ b/static/js/dashboard_charts.js
@@ -2,12 +2,8 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   const FLOWBITE_COLORS = [
-    '#2563eb', // blue-600
-    '#db2777', // pink-600
-    '#059669', // emerald-600
-    '#f59e0b', // amber-500
-    '#8b5cf6', // violet-500
-    '#ef4444'  // red-500
+    '#0D9488', // teal
+    '#7C3AED'  // purple
   ];
 
   const chartWidgets = document.querySelectorAll('[data-type="chart"]');
@@ -74,7 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const values = Object.values(data);
         new Chart(canvas, {
           type: 'line',
-          data: { labels, datasets: [{ data: values, borderColor: FLOWBITE_COLORS[0], backgroundColor: 'rgba(37,99,235,0.2)', fill: false }] },
+          data: { labels, datasets: [{ data: values, borderColor: FLOWBITE_COLORS[0], backgroundColor: 'rgba(13,148,136,0.2)', fill: false }] },
           options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } } }
         });
       } catch (err) {
@@ -105,7 +101,7 @@ document.addEventListener('DOMContentLoaded', () => {
         datasets: [{
           label: aggregation === 'count' ? 'Count' : 'Sum',
           data: values,
-          backgroundColor: ['#3b82f6', '#d946ef']
+          backgroundColor: [FLOWBITE_COLORS[0], FLOWBITE_COLORS[1]]
         }]
       },
       options: {

--- a/static/js/dashboard_modal/table.js
+++ b/static/js/dashboard_modal/table.js
@@ -115,7 +115,7 @@ export function initTableWidgets() {
       input.type = 'radio';
       input.name = 'filteredTable';
       input.value = tbl;
-      input.className = 'rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500';
+      input.className = 'rounded border-gray-300 text-teal-600 shadow-sm focus:ring-teal-500';
       input.addEventListener('change', () => {
         filteredTable = tbl;
         if (filteredTableToggleLabel) filteredTableToggleLabel.textContent = tbl;
@@ -161,7 +161,7 @@ export function initTableWidgets() {
       input.type = 'radio';
       input.name = 'filteredSort';
       input.value = fld;
-      input.className = 'rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500';
+      input.className = 'rounded border-gray-300 text-teal-600 shadow-sm focus:ring-teal-500';
       input.addEventListener('change', () => {
         filteredSort = fld;
         if (filteredSortToggleLabel) filteredSortToggleLabel.textContent = fld;
@@ -271,7 +271,7 @@ export function updateTablePreview() {
         tableData = rows || [];
         tableData.forEach(r => {
           const tr = document.createElement('tr');
-          tr.innerHTML = `<td class="px-2 py-1"><a href="/${tbl}/${r.id}" class="text-blue-600 underline">${r.id}</a></td><td class="px-2 py-1">${r.value}</td>`;
+          tr.innerHTML = `<td class="px-2 py-1"><a href="/${tbl}/${r.id}" class="text-teal-600 underline">${r.id}</a></td><td class="px-2 py-1">${r.value}</td>`;
           tablePreviewBodyEl.appendChild(tr);
         });
         tablePreviewEl.classList.remove('hidden');
@@ -308,7 +308,7 @@ export function updateTablePreview() {
         tableData.forEach(r => {
           const tr = document.createElement('tr');
           const label = r[labelField];
-          tr.innerHTML = `<td class="px-2 py-1"><a href="/${filteredTable}/${r.id}" class="text-blue-600 underline">${r.id}</a></td><td class="px-2 py-1">${label ?? ''}</td>`;
+          tr.innerHTML = `<td class="px-2 py-1"><a href="/${filteredTable}/${r.id}" class="text-teal-600 underline">${r.id}</a></td><td class="px-2 py-1">${label ?? ''}</td>`;
           tablePreviewBodyEl.appendChild(tr);
         });
         tablePreviewEl.classList.remove('hidden');

--- a/static/js/dashboard_modal/value.js
+++ b/static/js/dashboard_modal/value.js
@@ -266,14 +266,14 @@ export function populateFieldDropdown(dropdown, restrictNumeric, allowedTypes, c
       input.type = 'radio';
       input.name = 'fieldSelect';
       input.value = val;
-      input.className = 'rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500';
+      input.className = 'rounded border-gray-300 text-teal-600 shadow-sm focus:ring-teal-500';
       input.addEventListener('change', () => {
         callback(val);
         dropdown.classList.add('hidden');
       });
       const span = document.createElement('span');
       span.className = 'text-sm';
-      span.innerHTML = `<strong>${table}</strong>: ${field} <span class="text-blue-600 text-xs">(${type})</span>`;
+      span.innerHTML = `<strong>${table}</strong>: ${field} <span class="text-teal-600 text-xs">(${type})</span>`;
       label.appendChild(input);
       label.appendChild(span);
       dropdown.appendChild(label);

--- a/static/js/field_ajax.js
+++ b/static/js/field_ajax.js
@@ -90,11 +90,11 @@ function updateSelectedTagsDOM(formEl) {
   checkboxes.forEach(cb => {
     if (cb.checked) {
       const span = document.createElement('span');
-      span.className = 'inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full';
+      span.className = 'inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full';
       span.textContent = cb.value;
       const btn = document.createElement('button');
       btn.type = 'button';
-      btn.className = 'ml-1 text-blue-500 hover:text-red-500';
+      btn.className = 'ml-1 text-teal-600 hover:text-red-500';
       btn.textContent = '×';
       btn.onclick = () => {
         cb.checked = false;

--- a/static/js/tag_selector.js
+++ b/static/js/tag_selector.js
@@ -5,14 +5,14 @@
 
     <div class="flex flex-wrap gap-1 mb-2">
       {% for tag in selected_options if tag %}
-        <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">
+        <span class="inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full">
           {{ tag }}
-          <button type="button" class="ml-1 text-blue-500 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=' + JSON.stringify('{{ tag }}') + ']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
+          <button type="button" class="ml-1 text-teal-600 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=' + JSON.stringify('{{ tag }}') + ']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
         </span>
       {% endfor %}
     </div>
 
-    <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500" onclick="this.nextElementSibling.classList.toggle('hidden')">
+    <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
       Choose Tags
     </button>
 
@@ -26,7 +26,7 @@
             value="{{ option }}"
             {% if option in selected_options %}checked{% endif %}
             onchange="submitMultiSelectAuto(this.form)"
-            class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500"
+            class="rounded border-gray-300 text-teal-600 shadow-sm focus:ring-teal-600"
           >
           <span class="text-sm">{{ option }}</span>
         </label>

--- a/templates/_pagination.html
+++ b/templates/_pagination.html
@@ -6,13 +6,13 @@
     {% endif %}
     {% for p in range(1, total_pages + 1) %}
       {% if p == page %}
-        <span class="px-2 py-1 bg-blue-500 text-white rounded">{{ p }}</span>
+        <span class="px-2 py-1 bg-teal-600 text-white rounded">{{ p }}</span>
       {% else %}
         <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ p }}" class="px-2 py-1 bg-gray-200 rounded">{{ p }}</a>
       {% endif %}
     {% endfor %}
     {% if page < total_pages %}
-      <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ page + 1 }}" class="px-2 py-1 bg-blue-500 text-white rounded">Next</a>
+      <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ page + 1 }}" class="px-2 py-1 bg-teal-600 text-white rounded">Next</a>
     {% endif %}
   </div>
 </div>

--- a/templates/admin/config_admin.html
+++ b/templates/admin/config_admin.html
@@ -30,18 +30,18 @@
                       class="{% if item.type == 'json' %}flex flex-col items-start space-y-2 w-full{% else %}flex items-center space-x-2{% endif %}"
                       {% if item.type == 'json' %}data-json-key="{{ item.key }}"{% endif %}>
                 {% if item.type == 'select' or item.options %}
-                  <select name="value" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-blue-500 focus:border-blue-500">
+                  <select name="value" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-teal-600 focus:border-teal-600">
                     {% for opt in item.options %}
                       <option value="{{ opt }}" {% if item.value == opt %}selected{% endif %}>{{ opt }}</option>
                     {% endfor %}
                   </select>
                 {% elif item.type in ('integer', 'number') %}
-                  <input type="number" name="value" value="{{ item.value }}" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-blue-500 focus:border-blue-500">
+                  <input type="number" name="value" value="{{ item.value }}" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-teal-600 focus:border-teal-600">
                 {% elif item.type == 'boolean' %}
-                  <input type="checkbox" name="value" value="1" {% if item.value in ('1', 1, True, 'true') %}checked{% endif %} class="h-4 w-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500">
+                  <input type="checkbox" name="value" value="1" {% if item.value in ('1', 1, True, 'true') %}checked{% endif %} class="h-4 w-4 text-teal-600 bg-gray-100 border-gray-300 rounded focus:ring-teal-600">
                   <input type="hidden" name="value" value="0">
                 {% elif item.type == 'date' %}
-                  <input type="date" name="value" value="{{ item.value }}" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-blue-500 focus:border-blue-500">
+                  <input type="date" name="value" value="{{ item.value }}" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-teal-600 focus:border-teal-600">
                 {% elif item.type == 'json' and item.key == 'layout_defaults' %}
                   <div class="space-y-2 w-full" data-layout-defaults>
                     <div>
@@ -69,7 +69,7 @@
                     <input type="hidden" name="value" value="{{ item.value }}">
                   </div>
                 {% else %}
-                  <input type="text" name="value" value="{{ item.value }}" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-blue-500 focus:border-blue-500">
+                  <input type="text" name="value" value="{{ item.value }}" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-teal-600 focus:border-teal-600">
                 {% endif %}
                 <button type="submit" class="btn-primary px-3 py-1 rounded">Save</button>
               </form>

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,13 +12,13 @@
   {# Dashboard views load chart libraries explicitly #}
   <title>{% block title %}Crossbook{% endblock %}</title>
 </head>
-<body class="bg-white text-gray-900 {% block body_class %}{% endblock %}">
+<body class="bg-gray-100 text-gray-900 dark:bg-[#111827] dark:text-white {% block body_class %}{% endblock %}">
     {% set segments = request.path.strip('/').split('/') %}
     {% set current_table = segments[0] %}
     {% set current_id = segments[1] if segments|length > 1 else None %}
 
   <div id="app-container" class="flex min-h-screen">
-    <aside id="sidebar" class="fixed top-0 left-0 z-40 w-56 h-screen pt-4 bg-gray-800 text-gray-100 hidden md:block flex flex-col flex-shrink-0">
+    <aside id="sidebar" class="fixed top-0 left-0 z-40 w-56 h-screen pt-4 bg-teal-600 text-white hidden md:block flex flex-col flex-shrink-0">
       <div class="flex items-center justify-between px-2">
         <a href="/" class="p-2 text-gray-100 flex items-center space-x-1" aria-label="Home">
           <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
@@ -26,20 +26,20 @@
           </svg>
           <span>Home</span>
         </a>
-        <button id="sidebarCollapse" class="p-2 text-lg bg-gray-800 text-gray-100 rounded" aria-label="Toggle sidebar">&laquo;</button>
+        <button id="sidebarCollapse" class="p-2 text-lg bg-teal-600 text-white rounded" aria-label="Toggle sidebar">&laquo;</button>
       </div>
       <nav class="flex-1 overflow-y-auto px-3 space-y-2">
         {# Home link moved next to icon above #}
         {% for nav in nav_cards if nav.table_name != 'dashboard' %}
-          <a href="/{{ nav.table_name }}" class="nav-link {{ 'bg-gray-700' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
+          <a href="/{{ nav.table_name }}" class="nav-link {{ 'bg-purple-700 text-white' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
         {% endfor %}
       </nav>
       <!-- Sidebar action buttons removed -->
       </aside>
-    <div id="sidebar-handle" class="hidden fixed top-0 left-0 h-screen w-3 bg-gray-800 text-gray-100 flex items-center justify-center cursor-pointer">&raquo;</div>
+    <div id="sidebar-handle" class="hidden fixed top-0 left-0 h-screen w-3 bg-teal-600 text-white flex items-center justify-center cursor-pointer">&raquo;</div>
 
     <div id="content-wrapper" class="flex-1 flex flex-col md:ml-56">
-      <header id="page-header" class="bg-gray-800 text-gray-100 p-4 flex items-center justify-between fixed top-0 left-0 w-full z-40 shadow-md md:pl-56">
+      <header id="page-header" class="bg-teal-600 text-white p-4 flex items-center justify-between fixed top-0 left-0 w-full z-40 shadow-md md:pl-56">
         <div class="flex items-center space-x-2">
           {% block nav_buttons %}{% endblock %}
         </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -71,13 +71,13 @@
             {% elif widget.parsed.type == 'top-numeric' %}
               {% set tbl = widget.parsed.table %}
               {% for row in widget.parsed.data if widget.parsed %}
-                <tr><td class="px-2 py-1"><a href="/{{ tbl }}/{{ row.id }}" class="text-blue-600 underline">{{ row.id }}</a></td><td class="px-2 py-1">{{ row.value }}</td></tr>
+                <tr><td class="px-2 py-1"><a href="/{{ tbl }}/{{ row.id }}" class="text-teal-600 underline">{{ row.id }}</a></td><td class="px-2 py-1">{{ row.value }}</td></tr>
               {% endfor %}
             {% elif widget.parsed.type == 'filtered-records' %}
               {% set tbl = widget.parsed.table %}
               {% set label_field = get_title_field(tbl) or tbl %}
               {% for row in widget.parsed.data if widget.parsed %}
-                <tr><td class="px-2 py-1"><a href="/{{ tbl }}/{{ row.id }}" class="text-blue-600 underline">{{ row.id }}</a></td><td class="px-2 py-1">{{ row[label_field] }}</td></tr>
+                <tr><td class="px-2 py-1"><a href="/{{ tbl }}/{{ row.id }}" class="text-teal-600 underline">{{ row.id }}</a></td><td class="px-2 py-1">{{ row[label_field] }}</td></tr>
               {% endfor %}
             {% else %}
               {% for row in widget.parsed.data if widget.parsed %}

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -141,14 +141,14 @@
 
     {% if edit_history %}
       <details class="mt-6 text-sm text-gray-600">
-        <summary class="cursor-pointer font-medium text-blue-600">
+        <summary class="cursor-pointer font-medium text-teal-600">
           Edit History
         </summary>
-        <ul class="mt-2 space-y-1 text-blue-800">
+        <ul class="mt-2 space-y-1 text-teal-800">
         {% for row in edit_history %}
           <li>
             [{{ row.timestamp }}] {{ row.field_name }}: {{ row.old_value }} → {{ row.new_value }}{% if row.actor %} ({{ row.actor }}){% endif %}
-            <button class="ml-2 text-sm text-blue-600 underline" onclick="undoEdit({{ row.id }}, '{{ table }}', {{ record.id }})">Undo</button>
+            <button class="ml-2 text-sm text-teal-600 underline" onclick="undoEdit({{ row.id }}, '{{ table }}', {{ record.id }})">Undo</button>
           </li>
         {% endfor %}
         </ul>
@@ -157,7 +157,7 @@
   </div>
 
   <!-- Right: Related Content -->
-  <div id="related-pages" class="w-full md:w-1/3 lg:w-1/4 xl:w-64 border-l-2 border-blue-200 pl-6 flex-shrink-0">
+  <div id="related-pages" class="w-full md:w-1/3 lg:w-1/4 xl:w-64 border-l-2 border-teal-200 pl-6 flex-shrink-0">
     <div class="flex items-center mb-2">
       <h2 class="text-xl font-semibold">Related Pages</h2>
       <div id="relation-visibility-wrapper" class="relative inline-block text-left ml-2 hidden">
@@ -187,7 +187,7 @@
         </div>
       </div>
     </div>
-    <ul id="related-pages-list" class="space-y-2 text-blue-700 text-sm">
+    <ul id="related-pages-list" class="space-y-2 text-teal-700 text-sm">
       {% for section, group, vis in related %}
         {% set has_items = group['items']|length > 0 %}
         {% set hide = vis.hidden and (vis.force or not has_items) %}

--- a/templates/import_view.html
+++ b/templates/import_view.html
@@ -24,7 +24,7 @@
       </form>
       {% endif %}
       {% if num_records is defined %}
-      <div class="bg-blue-100 text-blue-800 px-4 py-2 rounded whitespace-nowrap">
+      <div class="bg-teal-100 text-teal-800 px-4 py-2 rounded whitespace-nowrap">
         Total Records: {{ num_records if num_records is not none else 'None' }}
       </div>
       {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,7 +22,7 @@
   </a>
   {% endfor %}
   <a href="#" onclick="openAddTableModal()" class="card-link flex items-center justify-center">
-    <span class="text-blue-500 text-5xl font-bold">+</span>
+    <span class="text-teal-600 text-5xl font-bold">+</span>
   </a>
 </div>
 

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -62,14 +62,14 @@
 
       <div class="flex flex-wrap gap-1 mb-2">
         {% for tag in selected_options if tag %}
-          <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">
+          <span class="inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full">
             {{ tag }}
-            <button type="button" class="ml-1 text-blue-500 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=\'{{ tag }}\']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
+            <button type="button" class="ml-1 text-teal-600 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=\'{{ tag }}\']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
           </span>
         {% endfor %}
       </div>
 
-      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500" onclick="this.nextElementSibling.classList.toggle('hidden')">
+      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
         Choose Tags
       </button>
 
@@ -84,7 +84,7 @@
               value="{{ option }}"
               {% if option in selected_options %}checked{% endif %}
               onchange="submitMultiSelectAuto(this.form)"
-              class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500"
+              class="rounded border-gray-300 text-teal-600 shadow-sm focus:ring-teal-600"
             >
             <span class="text-sm">{{ option }}</span>
           </label>
@@ -96,7 +96,7 @@
     {% set selected_options = selected_options | map('trim') | reject('equalto', '') | list %}
     <div class="flex flex-wrap gap-1" data-field="{{ field }}">
       {% for tag in selected_options if tag %}
-        <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">{{ tag }}</span>
+        <span class="inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full">{{ tag }}</span>
       {% endfor %}
       {% if selected_options|reject('equalto', '')|list|length == 0 %}
         <span class="text-gray-500">None</span>
@@ -134,14 +134,14 @@
 
       <div class="flex flex-wrap gap-1 mb-2">
         {% for tag in selected_options if tag %}
-          <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">
+          <span class="inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full">
             {{ tag }}
-            <button type="button" class="ml-1 text-blue-500 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=\'{{ tag }}\']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
+            <button type="button" class="ml-1 text-teal-600 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=\'{{ tag }}\']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
           </span>
         {% endfor %}
       </div>
 
-      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500" onclick="this.nextElementSibling.classList.toggle('hidden')">
+      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
         Choose Tags
       </button>
 
@@ -156,7 +156,7 @@
               value="{{ option }}"
               {% if option in selected_options %}checked{% endif %}
               onchange="submitMultiSelectAuto(this.form)"
-              class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500"
+              class="rounded border-gray-300 text-teal-600 shadow-sm focus:ring-teal-600"
             >
             <span class="text-sm">{{ option }}</span>
           </label>
@@ -168,7 +168,7 @@
     {% set selected_options = selected_options | map('trim') | reject('equalto', '') | list %}
     <div class="flex flex-wrap gap-1" data-field="{{ field }}">
       {% for tag in selected_options if tag %}
-        <span class="inline-flex items-center bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full">{{ tag }}</span>
+        <span class="inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full">{{ tag }}</span>
       {% endfor %}
       {% if selected_options|reject('equalto', '')|list|length == 0 %}
         <span class="text-gray-500">None</span>

--- a/templates/macros/filter_controls.html
+++ b/templates/macros/filter_controls.html
@@ -4,7 +4,7 @@
   <div class="filter-chip flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1 border border-gray-300">
     <select
       name="{{ field }}_op"
-      class="operator-select appearance-none text-xs rounded-full border-0 bg-transparent text-center text-blue-600 cursor-pointer w-auto"
+      class="operator-select appearance-none text-xs rounded-full border-0 bg-transparent text-center text-teal-600 cursor-pointer w-auto"
       title="Operator"
     >
       <option value="contains"    title="Contains"      {% if operator=='contains'    %}selected{% endif %}>Contains</option>

--- a/templates/modals/dashboard_modal.html
+++ b/templates/modals/dashboard_modal.html
@@ -6,7 +6,7 @@
     <div class="mb-4 border-b border-gray-200">
       <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="dashboardTab" data-tabs-toggle="#dashboardTabContent" role="tablist">
         <li class="mr-2" role="presentation">
-          <button id="tab-value" data-tabs-target="#pane-value" type="button" role="tab" aria-controls="pane-value" aria-selected="true" class="inline-block p-2 rounded-t-lg border-b-2 text-blue-600 border-blue-600">Value</button>
+          <button id="tab-value" data-tabs-target="#pane-value" type="button" role="tab" aria-controls="pane-value" aria-selected="true" class="inline-block p-2 rounded-t-lg border-b-2 text-teal-600 border-teal-600">Value</button>
         </li>
         <li class="mr-2" role="presentation">
           <button id="tab-table" data-tabs-target="#pane-table" type="button" role="tab" aria-controls="pane-table" aria-selected="false" class="inline-block p-2 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300">Table</button>
@@ -24,7 +24,7 @@
           {% for op in ['Sum', 'Count', 'Math'] %}
           <label class="flex-1 cursor-pointer">
             <input type="radio" name="dashboardOperation" value="{{ op|lower }}" class="sr-only peer">
-            <div class="p-2 border rounded text-center peer-checked:bg-blue-500 peer-checked:text-white">
+            <div class="p-2 border rounded text-center peer-checked:bg-teal-600 peer-checked:text-white">
               {{ op }}
             </div>
           </label>
@@ -41,11 +41,11 @@
           <div id="aggToggle1" class="flex">
             <label class="cursor-pointer">
               <input type="radio" name="agg1" value="sum" class="sr-only peer" checked>
-              <div class="p-1 border rounded-l text-center peer-checked:bg-blue-500 peer-checked:text-white">Sum</div>
+              <div class="p-1 border rounded-l text-center peer-checked:bg-teal-600 peer-checked:text-white">Sum</div>
             </label>
             <label class="cursor-pointer">
               <input type="radio" name="agg1" value="count" class="sr-only peer">
-              <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-blue-500 peer-checked:text-white">Count</div>
+              <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-teal-600 peer-checked:text-white">Count</div>
             </label>
           </div>
         </div>
@@ -54,7 +54,7 @@
           {% for op in ['Add', 'Subtract', 'Multiply', 'Divide', 'Average'] %}
           <label class="flex-1 cursor-pointer">
             <input type="radio" name="mathOperation" value="{{ op|lower }}" class="sr-only peer">
-            <div class="p-2 border rounded text-center peer-checked:bg-blue-500 peer-checked:text-white">
+            <div class="p-2 border rounded text-center peer-checked:bg-teal-600 peer-checked:text-white">
               {{ op }}
             </div>
           </label>
@@ -71,16 +71,16 @@
           <div id="aggToggle2" class="flex">
             <label class="cursor-pointer">
               <input type="radio" name="agg2" value="sum" class="sr-only peer" checked>
-              <div class="p-1 border rounded-l text-center peer-checked:bg-blue-500 peer-checked:text-white">Sum</div>
+              <div class="p-1 border rounded-l text-center peer-checked:bg-teal-600 peer-checked:text-white">Sum</div>
             </label>
             <label class="cursor-pointer">
               <input type="radio" name="agg2" value="count" class="sr-only peer">
-              <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-blue-500 peer-checked:text-white">Count</div>
+              <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-teal-600 peer-checked:text-white">Count</div>
             </label>
           </div>
         </div>
 
-        <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>
+        <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-teal-600 hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>
         <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
         <div id="resultRow" class="mt-4 flex items-center justify-center gap-2 hidden">
           <input id="valueTitleInput" type="text" class="px-3 py-2 border rounded flex-grow" />
@@ -194,11 +194,11 @@
         <div id="chartOrientContainer" class="flex mb-4 hidden">
           <label class="cursor-pointer">
             <input type="radio" name="chartOrient" value="x" class="sr-only peer" checked>
-            <div class="p-1 border rounded-l text-center peer-checked:bg-blue-500 peer-checked:text-white">X Axis</div>
+            <div class="p-1 border rounded-l text-center peer-checked:bg-teal-600 peer-checked:text-white">X Axis</div>
           </label>
           <label class="cursor-pointer">
             <input type="radio" name="chartOrient" value="y" class="sr-only peer">
-            <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-blue-500 peer-checked:text-white">Y Axis</div>
+            <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-teal-600 peer-checked:text-white">Y Axis</div>
           </label>
         </div>
         <div id="chartYFieldContainer" class="mb-4 hidden">
@@ -213,15 +213,15 @@
         <div id="chartAggContainer" class="flex mb-4 hidden">
           <label class="cursor-pointer">
             <input type="radio" name="chartAgg" value="" class="sr-only peer" checked>
-            <div class="p-1 border rounded-l text-center peer-checked:bg-blue-500 peer-checked:text-white">None</div>
+            <div class="p-1 border rounded-l text-center peer-checked:bg-teal-600 peer-checked:text-white">None</div>
           </label>
           <label class="cursor-pointer">
             <input type="radio" name="chartAgg" value="sum" class="sr-only peer">
-            <div class="p-1 border border-l-0 text-center peer-checked:bg-blue-500 peer-checked:text-white">Sum</div>
+            <div class="p-1 border border-l-0 text-center peer-checked:bg-teal-600 peer-checked:text-white">Sum</div>
           </label>
           <label class="cursor-pointer">
             <input type="radio" name="chartAgg" value="count" class="sr-only peer">
-            <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-blue-500 peer-checked:text-white">Count</div>
+            <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-teal-600 peer-checked:text-white">Count</div>
           </label>
         </div>
         <input id="chartTitleInput" type="text" placeholder="Widget Title" class="px-3 py-2 border rounded w-full mb-4 hidden" />

--- a/templates/modals/edit_fields_modal.html
+++ b/templates/modals/edit_fields_modal.html
@@ -5,7 +5,7 @@
     <div class="mb-4 border-b border-gray-200">
       <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="editFieldsTabs" data-tabs-toggle="#editFieldsContent" role="tablist">
         <li class="mr-2" role="presentation">
-          <button id="tab-add" data-tabs-target="#pane-add" type="button" role="tab" aria-controls="pane-add" aria-selected="true" class="inline-block p-2 rounded-t-lg border-b-2 text-blue-600 border-blue-600">
+          <button id="tab-add" data-tabs-target="#pane-add" type="button" role="tab" aria-controls="pane-add" aria-selected="true" class="inline-block p-2 rounded-t-lg border-b-2 text-purple-600 border-purple-600">
             Add Field
           </button>
         </li>

--- a/templates/wizard/wizard_import.html
+++ b/templates/wizard/wizard_import.html
@@ -16,7 +16,7 @@
     <input type="file" name="file" accept=".csv" class="border rounded px-2 py-1">
   </div>
   <button type="submit" class="btn-primary px-4 py-2 rounded">Import</button>
-  <a href="{{ url_for('wizard.table_step') }}" class="ml-4 text-blue-600 underline">Back</a>
+  <a href="{{ url_for('wizard.table_step') }}" class="ml-4 text-teal-600 underline">Back</a>
   <a href="{{ url_for('wizard.skip_import') }}" class="ml-4 underline">Skip</a>
   </form>
 {% endblock %}

--- a/templates/wizard/wizard_settings.html
+++ b/templates/wizard/wizard_settings.html
@@ -67,7 +67,7 @@
   </div>
   {% endfor %}
   <button type="submit" class="btn-primary px-4 py-2 rounded">Continue</button>
-  <a href="{{ url_for('wizard.database_step') }}" class="ml-4 text-blue-600 underline">Back</a>
+  <a href="{{ url_for('wizard.database_step') }}" class="ml-4 text-teal-600 underline">Back</a>
 </form>
 <script src="{{ url_for('static', filename='js/wizard_settings.js') }}"></script>
 {% endblock %}

--- a/templates/wizard/wizard_table.html
+++ b/templates/wizard/wizard_table.html
@@ -22,7 +22,7 @@
     <button type="button" onclick="showAddFieldModal()" class="bg-gray-200 px-2 py-1 rounded">Add Field</button>
   </div>
   <button type="submit" class="btn-primary px-4 py-2 rounded">Continue</button>
-  <a href="{{ url_for('wizard.settings_step') }}" class="ml-4 text-blue-600 underline">Back</a>
+  <a href="{{ url_for('wizard.settings_step') }}" class="ml-4 text-teal-600 underline">Back</a>
   </form>
 
 <!-- Add Field Modal -->


### PR DESCRIPTION
## Summary
- update base template background colors and sidebar styles
- adjust buttons, cards and modals in overrides
- switch Tailwind utility classes to teal/purple across templates
- recolor Flowbite chart datasets
- update JS modules for new color classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851377e0aa483338b88df2331665412