### PR TITLE
Add debug logging for grid actions

### DIFF
--- a/db/dashboard.py
+++ b/db/dashboard.py
@@ -98,6 +98,15 @@ def update_widget_layout(layout_items: list[dict]) -> int:
                 row_span = float(item.get("rowSpan", 0))
             except (TypeError, ValueError):
                 continue
+
+            logger.debug(
+                "[update_widget_layout] id=%s col=%s span=%s row=%s span=%s",
+                widget_id,
+                col_start,
+                col_span,
+                row_start,
+                row_span,
+            )
             cur.execute(
                 """
                 UPDATE dashboard_widget

--- a/db/schema.py
+++ b/db/schema.py
@@ -209,6 +209,16 @@ def update_layout(table: str, layout_items: list[dict]) -> int:
             except (TypeError, ValueError):
                 continue
 
+            logger.debug(
+                "[update_layout] %s.%s -> col=%s span=%s row=%s span=%s",
+                table,
+                field,
+                col_start,
+                col_span,
+                row_start,
+                row_span,
+            )
+
             # Perform the SQL UPDATE
             cur.execute(
                 """

--- a/static/js/dashboard_grid.js
+++ b/static/js/dashboard_grid.js
@@ -85,6 +85,7 @@ function enableDashboardDrag() {
     widgetEl = e.target.closest('.draggable-field');
     widgetId = widgetEl?.dataset.widget;
     if (!widgetEl || !widgetId) return;
+    console.debug('[dashboard] drag start', widgetId);
     widgetEl._prevRect = { ...widgetLayout[widgetId] };
     const rect = widgetEl.getBoundingClientRect();
     widgetEl.style.width  = `${rect.width}px`;
@@ -120,6 +121,7 @@ function enableDashboardDrag() {
     isDragging = false;
     if (!grid.classList.contains('editing')) {
       revertPosition(widgetEl);
+      console.debug('[dashboard] drag revert', widgetId);
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
       return;
@@ -143,6 +145,7 @@ function enableDashboardDrag() {
     );
     if (hasOverlap) {
       revertPosition(widgetEl);
+      console.debug('[dashboard] drag revert', widgetId);
     } else {
       widgetEl.style.left = '';
       widgetEl.style.top = '';
@@ -154,6 +157,7 @@ function enableDashboardDrag() {
     }
     document.removeEventListener('mousemove', onMove);
     document.removeEventListener('mouseup', onUp);
+    console.debug('[dashboard] drag end', widgetId, widgetLayout[widgetId]);
   }
 }
 
@@ -171,6 +175,7 @@ function enableDashboardResize() {
                    .find(c => e.target.classList.contains(c));
     widgetEl = e.target.closest('.draggable-field');
     widgetId = widgetEl.dataset.widget;
+    console.debug('[dashboard] resize start', widgetId, handleType);
     startX = e.clientX;
     startY = e.clientY;
     startRect = { ...widgetLayout[widgetId] };
@@ -222,6 +227,7 @@ function enableDashboardResize() {
     isResizing = false;
     if (!grid.classList.contains('editing')) {
       revertPosition(widgetEl);
+      console.debug('[dashboard] resize revert', widgetId);
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
       return;
@@ -242,9 +248,11 @@ function enableDashboardResize() {
     );
     if (hasOverlap) {
       revertPosition(widgetEl);
+      console.debug('[dashboard] resize revert', widgetId);
     } else {
       widgetLayout[widgetId] = newRect;
     }
+    console.debug('[dashboard] resize end', widgetId, widgetLayout[widgetId]);
   }
 }
 

--- a/static/js/layout_editor.js
+++ b/static/js/layout_editor.js
@@ -145,6 +145,7 @@ function enableVanillaDrag() {
     fieldEl = e.target.closest('.draggable-field');
     field = fieldEl?.dataset.field;
     if (!fieldEl || !field) return;
+    console.debug('[layout] drag start', field);
     fieldEl._prevRect = { ...layoutCache[field] };
     const rect = fieldEl.getBoundingClientRect();
     fieldEl.style.width  = `${rect.width}px`;
@@ -207,6 +208,7 @@ function enableVanillaDrag() {
     if (hasOverlap) {
       // snap back
       revertPosition(fieldEl);
+      console.debug('[layout] drag revert', field);
       return;
     }
 
@@ -227,6 +229,7 @@ function enableVanillaDrag() {
     if (window.initAutosizeText) {
       window.initAutosizeText();
     }
+    console.debug('[layout] drag end', field, layoutCache[field]);
   }
 }
 
@@ -248,6 +251,7 @@ function enableVanillaResize() {
                    .find(c => e.target.classList.contains(c));
     fieldEl = e.target.closest('.draggable-field');
     field   = fieldEl.dataset.field;
+    console.debug('[layout] resize start', field, handleType);
     startX  = e.clientX;
     startY  = e.clientY;
     startRect = { ...layoutCache[field] };
@@ -318,12 +322,14 @@ function enableVanillaResize() {
     );
     if (hasOverlap) {
       revertPosition(fieldEl);
+      console.debug('[layout] resize revert', field);
     } else {
       layoutCache[field] = newRect;
     }
     if (window.initAutosizeText) {
       window.initAutosizeText();
     }
+    console.debug('[layout] resize end', field, layoutCache[field]);
   }
 }
 


### PR DESCRIPTION
## Summary
- log parsed layout in schema updates
- add widget layout debugging
- track drag/resize events on layout and dashboard grids

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685139200a3c8333937aa24cd27a7cbe