### PR TITLE
Update dark mode theme

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -244,11 +244,11 @@ input[type=number] {
 
 /* Utility button and component styles */
 .btn-primary {
-  background-color: #0D9488;
+  background-color: var(--color-primary);
   color: #fff;
 }
 .btn-secondary {
-  background-color: #7C3AED;
+  background-color: var(--color-secondary);
   color: #fff;
 }
 .btn-danger {
@@ -256,9 +256,10 @@ input[type=number] {
   color: #fff;
 }
 .card {
-  background-color: #fff;
+  background-color: var(--bg-card);
   border-radius: 0.5rem;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  color: var(--text-light);
 }
 .modal-container {
   background-color: rgba(0,0,0,0.5);

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,13 +1,18 @@
 :root {
   --font-sans: 'Inter', 'IBM Plex Sans', sans-serif;
   --font-mono: 'JetBrains Mono', 'Menlo', monospace;
-  --color-primary: #0D9488; /* teal-600 */
-  --color-secondary: #7C3AED; /* accent purple */
+  --color-primary: #0D9488; /* teal */
+  --color-secondary: #7C3AED; /* purple */
   --color-danger: #dc2626;
+  --bg-dark: #111827;
+  --bg-card: #1f2937;
+  --text-light: #f3f4f6;
 }
 
 body {
   font-family: var(--font-sans);
+  background-color: var(--bg-dark);
+  color: var(--text-light);
 }
 
 a {
@@ -103,9 +108,10 @@ a:hover {
 
 /* Card component */
 .card {
-  background-color: #fff;
+  background-color: var(--bg-card);
   border-radius: 0.5rem;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  color: var(--text-light);
 }
 
 /* Modal container */
@@ -127,20 +133,35 @@ a:hover {
   border-radius: 0.25rem;
 }
 .nav-link:hover {
-  background-color: #7C3AED; /* accent */
+  background-color: var(--color-secondary);
   color: #fff;
 }
 
+.bg-primary { background-color: var(--color-primary); }
+.bg-secondary { background-color: var(--color-secondary); }
+.bg-dark { background-color: var(--bg-dark); }
+.bg-card { background-color: var(--bg-card); }
+.text-light { color: var(--text-light); }
+
+.table-row-odd { background-color: #1f2937; }
+.table-row-even { background-color: #273043; }
+.table-row-hover:hover { background-color: #374151; }
+
+.dark-table tbody tr:nth-child(odd) { background-color: #1f2937; }
+.dark-table tbody tr:nth-child(even) { background-color: #273043; }
+.dark-table tbody tr:hover { background-color: #374151; }
+
 .card-link {
   display: block;
-  background-color: #fff;
+  background-color: var(--bg-card);
+  color: var(--text-light);
   border-radius: 0.75rem; /* rounded-xl */
   box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1);
   padding: 1.5rem; /* p-6 */
   transition: background-color 0.2s;
 }
 .card-link:hover {
-  background-color: #f9fafb; /* gray-50 */
+  background-color: #374151;
 }
 
 .modal-container {

--- a/templates/_record_rows.html
+++ b/templates/_record_rows.html
@@ -1,5 +1,5 @@
 {% for record in records %}
-<tr id="record-{{ record.id }}" class="odd:bg-white even:bg-gray-50 hover:bg-gray-100 cursor-pointer" onclick="window.location.href='/{{ table }}/{{ record.id }}'">
+<tr id="record-{{ record.id }}" class="cursor-pointer" onclick="window.location.href='/{{ table }}/{{ record.id }}'">
   <td class="px-2 py-2" data-static onclick="event.stopPropagation()">
     <input type="checkbox" class="row-select" value="{{ record.id }}">
   </td>

--- a/templates/admin/config_admin.html
+++ b/templates/admin/config_admin.html
@@ -7,13 +7,13 @@
 
 <div class="mx-auto w-11/12 max-w-screen-2xl space-y-6">
   {% for section, items in sections.items() %}
-  <details class="bg-white rounded shadow" {% if loop.first %}open{% endif %}>
-    <summary class="cursor-pointer px-4 py-2 bg-gray-100 rounded-t font-semibold text-lg">
+  <details class="card" {% if loop.first %}open{% endif %}>
+  <summary class="cursor-pointer px-4 py-2 bg-card rounded-t font-semibold text-lg text-light">
       {{ section|capitalize }}
     </summary>
     <div class="p-4 overflow-x-auto">
-      <table class="min-w-full text-sm text-left text-gray-700 divide-y divide-gray-200">
-        <thead class="text-xs uppercase bg-gray-50">
+      <table class="min-w-full text-sm text-left text-light divide-y">
+        <thead class="text-xs uppercase bg-card">
           <tr>
             <th class="w-56 px-2 py-1">Key</th>
             <th class="px-2 py-1">Value</th>
@@ -38,7 +38,7 @@
                 {% elif item.type in ('integer', 'number') %}
                   <input type="number" name="value" value="{{ item.value }}" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-teal-600 focus:border-teal-600">
                 {% elif item.type == 'boolean' %}
-                  <input type="checkbox" name="value" value="1" {% if item.value in ('1', 1, True, 'true') %}checked{% endif %} class="h-4 w-4 text-teal-600 bg-gray-100 border-gray-300 rounded focus:ring-teal-600">
+                  <input type="checkbox" name="value" value="1" {% if item.value in ('1', 1, True, 'true') %}checked{% endif %} class="h-4 w-4 text-teal-600 bg-dark border-gray-300 rounded focus:ring-teal-600">
                   <input type="hidden" name="value" value="0">
                 {% elif item.type == 'date' %}
                   <input type="date" name="value" value="{{ item.value }}" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-teal-600 focus:border-teal-600">

--- a/templates/admin/database_admin.html
+++ b/templates/admin/database_admin.html
@@ -5,7 +5,7 @@
 {% block content %}
 <h1 class="text-2xl font-bold mb-6">Database</h1>
 <div class="mx-auto w-11/12 max-w-screen-md space-y-6">
-  <div class="bg-white rounded shadow p-4 space-y-4">
+  <div class="card p-4 space-y-4">
     <div id="db-path-display" class="px-2 py-1 text-sm font-mono rounded {{ 'text-green-600' if db_status == 'valid' else 'text-red-600' }}">{{ db_path }}</div>
     <form id="db-upload-form" class="flex items-center space-x-2" enctype="multipart/form-data">
       <input type="file" name="file" accept=".db" class="text-sm border border-gray-300 rounded" />

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,13 +12,13 @@
   {# Dashboard views load chart libraries explicitly #}
   <title>{% block title %}Crossbook{% endblock %}</title>
 </head>
-<body class="bg-gray-100 text-gray-900 dark:bg-[#111827] dark:text-white {% block body_class %}{% endblock %}">
+<body class="bg-dark text-light {% block body_class %}{% endblock %}">
     {% set segments = request.path.strip('/').split('/') %}
     {% set current_table = segments[0] %}
     {% set current_id = segments[1] if segments|length > 1 else None %}
 
   <div id="app-container" class="flex min-h-screen">
-    <aside id="sidebar" class="fixed top-0 left-0 z-40 w-56 h-screen pt-4 bg-teal-600 text-white hidden md:block flex flex-col flex-shrink-0">
+    <aside id="sidebar" class="fixed top-0 left-0 z-40 w-56 h-screen pt-4 bg-primary text-white hidden md:block flex flex-col flex-shrink-0">
       <div class="flex items-center justify-between px-2">
         <a href="/" class="p-2 text-gray-100 flex items-center space-x-1" aria-label="Home">
           <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
@@ -26,20 +26,20 @@
           </svg>
           <span>Home</span>
         </a>
-        <button id="sidebarCollapse" class="p-2 text-lg bg-teal-600 text-white rounded" aria-label="Toggle sidebar">&laquo;</button>
+        <button id="sidebarCollapse" class="p-2 text-lg bg-primary text-white rounded" aria-label="Toggle sidebar">&laquo;</button>
       </div>
       <nav class="flex-1 overflow-y-auto px-3 space-y-2">
         {# Home link moved next to icon above #}
         {% for nav in nav_cards if nav.table_name != 'dashboard' %}
-          <a href="/{{ nav.table_name }}" class="nav-link {{ 'bg-purple-700 text-white' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
+          <a href="/{{ nav.table_name }}" class="nav-link {{ 'bg-secondary text-white' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
         {% endfor %}
       </nav>
       <!-- Sidebar action buttons removed -->
       </aside>
-    <div id="sidebar-handle" class="hidden fixed top-0 left-0 h-screen w-3 bg-teal-600 text-white flex items-center justify-center cursor-pointer">&raquo;</div>
+    <div id="sidebar-handle" class="hidden fixed top-0 left-0 h-screen w-3 bg-primary text-white flex items-center justify-center cursor-pointer">&raquo;</div>
 
     <div id="content-wrapper" class="flex-1 flex flex-col md:ml-56">
-      <header id="page-header" class="bg-teal-600 text-white p-4 flex items-center justify-between fixed top-0 left-0 w-full z-40 shadow-md md:pl-56">
+      <header id="page-header" class="bg-primary text-white p-4 flex items-center justify-between fixed top-0 left-0 w-full z-40 shadow-md md:pl-56">
         <div class="flex items-center space-x-2">
           {% block nav_buttons %}{% endblock %}
         </div>

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -7,7 +7,7 @@
 {# Define the percentage snap constant (# of % per grid column) #}
 {% set PCT_SNAP = 5 %}
 
-<div class="max-w-6xl mx-auto bg-white p-6 rounded shadow-md flex space-x-6">
+<div class="max-w-6xl mx-auto card p-6 flex space-x-6">
 
   <!-- Left: Main Details -->
   <div class="flex-1">
@@ -62,7 +62,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
           </svg>
         </button>
-        <div id="header-field-popover" class="absolute right-0 z-20 hidden mt-2 bg-white border rounded shadow-lg p-2 space-y-1 w-48">
+        <div id="header-field-popover" class="absolute right-0 z-20 hidden mt-2 bg-card border rounded shadow-lg p-2 space-y-1 w-48 text-light">
           <label class="flex items-center space-x-2">
             <input type="checkbox" class="header-field-toggle" value="title" checked>
             <span class="text-sm">Title</span>
@@ -170,7 +170,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
           </svg>
         </button>
-        <div id="relation-visibility-popover" class="absolute right-0 z-20 hidden mt-2 bg-white border rounded shadow-lg p-2 space-y-2 w-64">
+        <div id="relation-visibility-popover" class="absolute right-0 z-20 hidden mt-2 bg-card border rounded shadow-lg p-2 space-y-2 w-64 text-light">
           <div class="font-semibold text-sm border-b pb-1 mb-1">Relations Visibility</div>
           {% for sec, grp, vis in related %}
             <div class="space-y-1">

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,13 +12,13 @@
 <div id="card-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
   <a href="/dashboard" class="card-link">
     <h2 class="text-2xl font-bold mb-2">Dashboard</h2>
-    <p class="text-gray-600">View overall summary and stats</p>
+    <p class="text-light">View overall summary and stats</p>
   </a>
   {% for card in cards %}
   <a href="/{{ card.table_name }}"
      class="card-link">
     <h2 class="text-2xl font-bold mb-2">{{ card.display_name }}</h2>
-    <p class="text-gray-600">{{ card.description }}</p>
+    <p class="text-light">{{ card.description }}</p>
   </a>
   {% endfor %}
   <a href="#" onclick="openAddTableModal()" class="card-link flex items-center justify-center">

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -29,7 +29,7 @@
 </form>
 {% endblock %}
 {% block content %}
-<div id="list-view-container" class="w-full bg-white p-6 rounded shadow-md">
+<div id="list-view-container" class="w-full card p-6 shadow-md">
   <h1 class="text-2xl font-bold mb-4">{{ table|capitalize }}s</h1>
 
   <!-- Filters bar -->
@@ -67,11 +67,11 @@
   </div>
   
   {% if records %}
-  <div id="loading-indicator" class="hidden text-sm text-gray-600 mb-2">Loading...</div>
+  <div id="loading-indicator" class="hidden text-sm text-light mb-2">Loading...</div>
   {% include '_record_count.html' %}
-  <div class="records-table-wrapper overflow-x-auto rounded-lg border border-gray-200 w-full">
-    <table id="records-table" data-table="{{ table }}" class="min-w-full text-sm text-left text-gray-900 divide-y divide-gray-200">
-      <thead class="bg-gray-50">
+  <div class="records-table-wrapper overflow-x-auto rounded-lg border w-full">
+    <table id="records-table" data-table="{{ table }}" class="min-w-full text-sm text-left text-light dark-table divide-y">
+      <thead class="bg-card">
         <tr>
           <th scope="col" class="px-2 py-2" data-static>
             <input type="checkbox" id="select-all-rows">
@@ -79,7 +79,7 @@
           {% for field in fields if not field.startswith('_') and field != 'edit_log' %}
             {% set is_current = sort_field == field %}
             {% set new_dir = 'desc' if is_current and direction == 'asc' else 'asc' %}
-            <th scope="col" class="px-4 py-2 text-left text-xs font-medium text-gray-700 uppercase tracking-wider" data-field="{{ field }}">
+            <th scope="col" class="px-4 py-2 text-left text-xs font-medium text-light uppercase tracking-wider" data-field="{{ field }}">
               <a href="?{{ base_qs_no_sort }}{{ '&' if base_qs_no_sort else '' }}sort={{ field }}&dir={{ new_dir }}" class="flex items-center space-x-1">
                 <span>{{ field }}</span>
                 {% if is_current %}
@@ -94,7 +94,7 @@
           {% endfor %}
         </tr>
       </thead>
-      <tbody id="records-body" class="divide-y divide-gray-200">
+      <tbody id="records-body" class="divide-y">
         {% include '_record_rows.html' %}
       </tbody>
     </table>
@@ -103,7 +103,7 @@
     {% include '_pagination.html' %}
   </div>
 {% else %}
-  <p class="text-gray-600">No records found.</p>
+  <p class="text-light">No records found.</p>
 {% endif %}
 </div>
 


### PR DESCRIPTION
## Summary
- refresh custom color variables and classes
- set body and card backgrounds for dark mode
- overhaul base template to use new color classes
- adapt index, list, and detail views for darker UI
- style admin pages and tables for new theme
- adjust row styles via CSS instead of Tailwind utility classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68513ae0bd308333b048deba88c803e5