### PR TITLE
Improve dark mode colors

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,8 +1,10 @@
 :root {
   --font-sans: 'Inter', 'IBM Plex Sans', sans-serif;
   --font-mono: 'JetBrains Mono', 'Menlo', monospace;
-  --color-primary: #0D9488; /* teal */
-  --color-secondary: #7C3AED; /* purple */
+  --color-primary: #7C3AED; /* purple */
+  --color-secondary: #0D9488; /* teal */
+  --color-primary-light: #E9D5FF;
+  --color-secondary-light: #99F6E4;
   --color-danger: #dc2626;
   --bg-dark: #111827;
   --bg-card: #1f2937;
@@ -137,6 +139,11 @@ a:hover {
   color: #fff;
 }
 
+.text-primary { color: var(--color-primary); }
+.text-secondary { color: var(--color-secondary); }
+.bg-primary-light { background-color: var(--color-primary-light); }
+.bg-secondary-light { background-color: var(--color-secondary-light); }
+
 .bg-primary { background-color: var(--color-primary); }
 .bg-secondary { background-color: var(--color-secondary); }
 .bg-dark { background-color: var(--bg-dark); }
@@ -174,3 +181,16 @@ a:hover {
   backdrop-filter: blur(4px); /* blur-sm */
   z-index: 50;
 }
+
+.draggable-field {
+  color: var(--field-color, inherit);
+  font-size: var(--field-size, inherit);
+}
+
+/* Override Tailwind accent classes to use CSS variables */
+.text-teal-600, .text-purple-600 { color: var(--color-primary); }
+.text-teal-700, .text-teal-800 { color: var(--color-primary); }
+.bg-teal-600, .bg-purple-500 { background-color: var(--color-primary); }
+.bg-teal-100 { background-color: var(--color-primary-light); }
+.border-teal-600, .border-purple-600 { border-color: var(--color-primary); }
+.border-teal-200 { border-color: var(--color-primary-light); }

--- a/static/js/field_styling.js
+++ b/static/js/field_styling.js
@@ -4,8 +4,16 @@ function applyStyling(el, styling) {
   el.classList.toggle('font-bold', !!styling.bold);
   el.classList.toggle('italic', !!styling.italic);
   el.classList.toggle('underline', !!styling.underline);
-  el.style.color = styling.color || '';
-  el.style.fontSize = styling.size ? `${styling.size}px` : '';
+  if (styling.color) {
+    el.style.setProperty('--field-color', styling.color);
+  } else {
+    el.style.removeProperty('--field-color');
+  }
+  if (styling.size) {
+    el.style.setProperty('--field-size', `${styling.size}px`);
+  } else {
+    el.style.removeProperty('--field-size');
+  }
   const label = el.querySelector('div.text-sm.font-bold.capitalize.mb-1');
   if (label) label.classList.remove('hidden');
 }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -90,14 +90,10 @@
       {% else %}
         <div class="text-gray-500">{{ widget.widget_type }} widget</div>
       {% endif %}
-      <span class="resize-handle hidden top-left"
-            style="position:absolute; top:0; left:0; width:8px; height:8px; background:#333; cursor:nwse-resize; "></span>
-      <span class="resize-handle hidden top-right"
-            style="position:absolute; top:0; right:0; width:8px; height:8px; background:#333; cursor:nwse-resize; "></span>
-      <span class="resize-handle hidden bottom-left"
-            style="position:absolute; bottom:0; left:0; width:8px; height:8px; background:#333; cursor:nwse-resize; "></span>
-      <span class="resize-handle hidden bottom-right"
-            style="position:absolute; bottom:0; right:0; width:8px; height:8px; background:#333; cursor:nwse-resize; "></span>
+      <span class="resize-handle hidden top-left"></span>
+      <span class="resize-handle hidden top-right"></span>
+      <span class="resize-handle hidden bottom-left"></span>
+      <span class="resize-handle hidden bottom-right"></span>
     </div>
   {% endfor %}
 </div>

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -107,8 +107,8 @@
             'grid-column: ' ~ col_start ~ ' / span ' ~ col_span,
             'grid-row: ' ~ row_start ~ ' / span ' ~ row_span
           ] %}
-          {% if styling.color %}{% set _ = style_parts.append('color: ' ~ styling.color) %}{% endif %}
-          {% if styling.size %}{% set _ = style_parts.append('font-size: ' ~ styling.size ~ 'px') %}{% endif %}
+          {% if styling.color %}{% set _ = style_parts.append('--field-color:' ~ styling.color) %}{% endif %}
+          {% if styling.size %}{% set _ = style_parts.append('--field-size:' ~ styling.size ~ 'px') %}{% endif %}
           <div id="draggable-field-{{ field }}"
                class="draggable-field border p-2 rounded shadow bg-gray-50{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }}"
                data-field="{{ field }}"
@@ -121,18 +121,10 @@
                 'record_id', field_schema[table][field].type, table,
                  field_schema, field_macro_map) }}
             <!-- resize handles (hidden until edit mode) -->
-            <span class="resize-handle hidden top-left"
-                  style="position:absolute; top:0; left:0; width:8px; height:8px;
-                         background:#333; cursor:nwse-resize; "></span>
-            <span class="resize-handle hidden top-right"
-                  style="position:absolute; top:0; right:0; width:8px; height:8px;
-                         background:#333; cursor:nwse-resize; "></span>
-            <span class="resize-handle hidden bottom-left"
-                  style="position:absolute; bottom:0; left:0; width:8px; height:8px;
-                         background:#333; cursor:nwse-resize; "></span>
-            <span class="resize-handle hidden bottom-right"
-                  style="position:absolute; bottom:0; right:0; width:8px; height:8px;
-                         background:#333; cursor:nwse-resize; "></span>
+            <span class="resize-handle hidden top-left"></span>
+            <span class="resize-handle hidden top-right"></span>
+            <span class="resize-handle hidden bottom-left"></span>
+            <span class="resize-handle hidden bottom-right"></span>
           </div>
         {% endif %}
       {% endfor %}

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -202,11 +202,7 @@
 {% macro render_editable_field(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema, field_macro_map=None) %}
   {% set edit_param = request.args.get('edit') %}
   {% set styling = field_schema[table][field].styling or {} %}
-  {% set style_parts = [] %}
-  {% if styling.color %}{% set _ = style_parts.append('color: ' ~ styling.color) %}{% endif %}
-  {% if styling.size %}{% set _ = style_parts.append('font-size: ' ~ styling.size ~ 'px') %}{% endif %}
-  <div class="mt-2 h-full{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }}"
-       {% if style_parts %}style="{{ style_parts|join('; ') }}"{% endif %}
+  <div class="mt-2 h-full{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }} draggable-field"
        data-styling='{{ styling | tojson }}'>
     {% do current_app.logger.debug('[render] field=%s type=%s edit_param=%s', field, field_type, edit_param) %}
     <label class="block text-sm font-medium capitalize">{{ field }}</label>


### PR DESCRIPTION
## Summary
- swap teal/purple palette
- add new CSS variables and text utilities
- override Tailwind accent classes
- remove inline color styling from handles and fields
- apply field colors via CSS variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68513cc36c5c8333b99ea714643cd9d9