### PR TITLE
Fix readability on white backgrounds

### DIFF
--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -48,7 +48,7 @@
     <button id="toggle-columns" type="button" data-dropdown-toggle="column-dropdown" class="px-2 py-1 bg-gray-200 rounded">
       Columns
     </button>
-    <div id="column-dropdown" class="z-10 hidden mt-2 bg-white border rounded shadow p-2 space-y-1 w-48">
+    <div id="column-dropdown" class="z-10 hidden mt-2 bg-white text-black border rounded shadow p-2 space-y-1 w-48">
       {% for field in fields if not field.startswith('_') and field != 'edit_log' %}
         <label class="flex items-center space-x-2">
           <input type="checkbox" class="column-toggle" value="{{ field }}" checked>
@@ -62,7 +62,7 @@
     <button type="button" id="toggle-filters" data-dropdown-toggle="filter-dropdown" class="px-2 py-1 bg-gray-200 rounded">
       Filters
     </button>
-    <div id="filter-dropdown" class="z-10 hidden mt-2 bg-white border rounded shadow p-2 space-y-1 w-48">
+    <div id="filter-dropdown" class="z-10 hidden mt-2 bg-white text-black border rounded shadow p-2 space-y-1 w-48">
     </div>
   </div>
   

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -69,11 +69,11 @@
         {% endfor %}
       </div>
 
-      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
+      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
         Choose Tags
       </button>
 
-      <div class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1" data-options>
+      <div class="absolute z-10 mt-1 w-full bg-white text-black border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1" data-options>
         <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)))">
 
         {% for option in field_schema[table][field].options %}
@@ -141,11 +141,11 @@
         {% endfor %}
       </div>
 
-      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
+      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
         Choose Tags
       </button>
 
-      <div class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1" data-options>
+      <div class="absolute z-10 mt-1 w-full bg-white text-black border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1" data-options>
         <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)))">
 
         {% for option in field_schema[table][field].options %}

--- a/templates/macros/filter_controls.html
+++ b/templates/macros/filter_controls.html
@@ -55,7 +55,7 @@
   </button>
 
   <div
-  class="multi-select-popover absolute z-20 mt-1 bg-white border rounded shadow p-2 hidden overflow-scroll "
+  class="multi-select-popover absolute z-20 mt-1 bg-white text-black border rounded shadow p-2 hidden overflow-scroll "
   data-field="{{ field }}">
     <div class="text-right mb-1 text-xs">
       <label class="mr-1">Mode:</label>

--- a/templates/modals/add_table_modal.html
+++ b/templates/modals/add_table_modal.html
@@ -1,5 +1,5 @@
 <div id="addTableModal" class="modal-container hidden" onclick="if(event.target.id === 'addTableModal') closeAddTableModal()">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+  <div class="bg-white text-black p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button type="button" onclick="closeAddTableModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <h3 class="text-lg font-bold mb-4">Add new base table</h3>
     <div id="tableError" class="text-red-600 hidden"></div>

--- a/templates/modals/bulk_edit_modal.html
+++ b/templates/modals/bulk_edit_modal.html
@@ -1,6 +1,6 @@
 <div id="bulkEditModal" class="modal-container hidden"
      onclick="if(event.target.id === 'bulkEditModal') closeBulkEditModal()">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+  <div class="bg-white text-black p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button type="button" onclick="closeBulkEditModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <h3 class="text-lg font-bold">Bulk Edit {{ table }}</h3>
     <p id="bulk-edit-count" class="text-sm text-gray-600 mb-4"></p>

--- a/templates/modals/create_db_modal.html
+++ b/templates/modals/create_db_modal.html
@@ -1,5 +1,5 @@
 <div id="createDbModal" class="modal-container hidden" onclick="if(event.target.id === 'createDbModal') closeCreateDbModal()">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+  <div class="bg-white text-black p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button type="button" onclick="closeCreateDbModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <h3 class="text-lg font-bold mb-4">Create New Database</h3>
     <div id="create-db-error" class="text-red-600 hidden mb-2"></div>

--- a/templates/modals/dashboard_modal.html
+++ b/templates/modals/dashboard_modal.html
@@ -1,7 +1,7 @@
 <!-- Dashboard Add Modal -->
 <div id="dashboardModal" class="modal-container hidden"
      onclick="if(event.target.id === 'dashboardModal') closeDashboardModal()">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-fit min-w-[24rem] max-w-full relative">
+  <div class="bg-white text-black p-6 rounded-lg shadow-lg w-fit min-w-[24rem] max-w-full relative">
     <button onclick="closeDashboardModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <div class="mb-4 border-b border-gray-200">
       <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="dashboardTab" data-tabs-toggle="#dashboardTabContent" role="tablist">
@@ -33,10 +33,10 @@
 
         <div id="mathField1" class="flex items-start gap-2 mb-2 hidden">
           <div class="relative flex-grow">
-            <button id="mathSelect1Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left flex items-center justify-between">
+            <button id="mathSelect1Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="mathSelect1Options" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+            <div id="mathSelect1Options" class="absolute z-10 mt-1 w-full bg-white text-black border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
           </div>
           <div id="aggToggle1" class="flex">
             <label class="cursor-pointer">
@@ -63,10 +63,10 @@
 
         <div id="mathField2" class="flex items-start gap-2 mb-2 hidden">
           <div class="relative flex-grow">
-            <button id="mathSelect2Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left flex items-center justify-between">
+            <button id="mathSelect2Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="mathSelect2Options" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+            <div id="mathSelect2Options" class="absolute z-10 mt-1 w-full bg-white text-black border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
           </div>
           <div id="aggToggle2" class="flex">
             <label class="cursor-pointer">
@@ -80,8 +80,8 @@
           </div>
         </div>
 
-        <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-teal-600 hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>
-        <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+        <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left focus:outline-none focus:ring-2 focus:ring-teal-600 hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>
+        <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full bg-white text-black border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
         <div id="resultRow" class="mt-4 flex items-center justify-center gap-2 hidden">
           <input id="valueTitleInput" type="text" class="px-3 py-2 border rounded flex-grow" />
           <div id="valueResult" class="font-semibold"></div>
@@ -119,18 +119,18 @@
         </div>
         <div id="selectCountFieldContainer" class="mb-4 hidden">
           <div class="relative">
-            <button id="selectCountFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left flex items-center justify-between">
+            <button id="selectCountFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="selectCountFieldOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+            <div id="selectCountFieldOptions" class="absolute z-10 mt-1 w-full bg-white text-black border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
           </div>
         </div>
         <div id="topNumericFieldContainer" class="mb-4 hidden">
           <div class="relative">
-            <button id="topNumericFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left flex items-center justify-between">
+            <button id="topNumericFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="topNumericFieldOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+            <div id="topNumericFieldOptions" class="absolute z-10 mt-1 w-full bg-white text-black border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
           </div>
         </div>
         <div id="topNumericDirection" class="flex gap-2 mb-4 hidden">
@@ -145,17 +145,17 @@
         </div>
         <div id="filteredRecordsContainer" class="mb-4 hidden">
           <div class="relative mb-2">
-            <button id="filteredTableToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left flex items-center justify-between">
+            <button id="filteredTableToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
               <span class="selected-label">Select Table</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="filteredTableOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+            <div id="filteredTableOptions" class="absolute z-10 mt-1 w-full bg-white text-black border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
           </div>
           <input id="filteredSearchInput" type="text" placeholder="Search" class="w-full px-3 py-2 border rounded mb-2" />
           <div class="relative mb-2">
-            <button id="filteredSortToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left flex items-center justify-between">
+            <button id="filteredSortToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
               <span class="selected-label">Sort Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="filteredSortOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+            <div id="filteredSortOptions" class="absolute z-10 mt-1 w-full bg-white text-black border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
           </div>
           <input id="filteredLimitInput" type="number" value="10" min="1" class="w-full px-3 py-2 border rounded" />
         </div>
@@ -175,7 +175,7 @@
       <form id="chartWidgetForm" class="relative w-full" onsubmit="event.preventDefault();">
         <div class="mb-4">
           <label for="chartTypeSelect" class="block text-sm font-medium mb-1">Chart Type</label>
-          <select id="chartTypeSelect" class="w-full px-3 py-2 border rounded shadow-sm bg-white">
+          <select id="chartTypeSelect" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black">
             <option value="" selected disabled>Select Chart Type</option>
             <option value="bar">Bar</option>
             <option value="line">Line</option>
@@ -185,10 +185,10 @@
         <div id="chartXFieldContainer" class="mb-4 hidden">
           <label id="chartXFieldLabel" class="block text-sm font-medium mb-1">X Field</label>
           <div class="relative">
-            <button id="chartXFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left flex items-center justify-between">
+            <button id="chartXFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="chartXFieldOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+            <div id="chartXFieldOptions" class="absolute z-10 mt-1 w-full bg-white text-black border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
           </div>
         </div>
         <div id="chartOrientContainer" class="flex mb-4 hidden">
@@ -204,10 +204,10 @@
         <div id="chartYFieldContainer" class="mb-4 hidden">
           <label class="block text-sm font-medium mb-1">Y Field</label>
           <div class="relative">
-            <button id="chartYFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left flex items-center justify-between">
+            <button id="chartYFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="chartYFieldOptions" class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
+            <div id="chartYFieldOptions" class="absolute z-10 mt-1 w-full bg-white text-black border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1"></div>
           </div>
         </div>
         <div id="chartAggContainer" class="flex mb-4 hidden">

--- a/templates/modals/edit_fields_modal.html
+++ b/templates/modals/edit_fields_modal.html
@@ -1,6 +1,6 @@
 <div id="layoutModal" class="modal-container hidden"
      onclick="if(event.target.id === 'layoutModal') closeLayoutModal()">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+  <div class="bg-white text-black p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button type="button" onclick="closeLayoutModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <div class="mb-4 border-b border-gray-200">
       <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="editFieldsTabs" data-tabs-toggle="#editFieldsContent" role="tablist">

--- a/templates/modals/validation_modal.html
+++ b/templates/modals/validation_modal.html
@@ -1,5 +1,5 @@
 <div id="validationOverlay" class="modal-container hidden" onclick="if(event.target.id === 'validationOverlay') this.classList.add('hidden')">
-  <div id="validation-popup" class="bg-white p-6 rounded-lg shadow-lg w-auto max-w-[70vw] max-h-[66vh] overflow-auto relative">
+  <div id="validation-popup" class="bg-white text-black p-6 rounded-lg shadow-lg w-auto max-w-[70vw] max-h-[66vh] overflow-auto relative">
     <button type="button" onclick="document.getElementById('validationOverlay').classList.add('hidden')" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <!-- Validation messages get injected here -->
   </div>

--- a/templates/wizard/wizard_table.html
+++ b/templates/wizard/wizard_table.html
@@ -27,7 +27,7 @@
 
 <!-- Add Field Modal -->
 <div id="addFieldModal" class="modal-container hidden" onclick="if(event.target.id === 'addFieldModal') hideAddFieldModal()">
-  <div class="bg-white p-6 rounded-lg shadow-lg w-96 max-w-full relative">
+  <div class="bg-white text-black p-6 rounded-lg shadow-lg w-96 max-w-full relative">
     <button type="button" onclick="hideAddFieldModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
     <form id="field-form" class="space-y-4">
       <div>


### PR DESCRIPTION
## Summary
- make text visible on dropdowns
- ensure modals use dark text over white background

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68514a2ce8e883339bb07ac3e89a245d