### PR TITLE
Fix dashboard layout edit overlay

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -101,7 +101,7 @@ input[type=number] {
 #dashboard-grid.editing .draggable-field {
   border: 1px blue dashed !important;
   box-shadow: 0 0 0 2px rgba(0,0,0,0.1) !important;
-  background-color: #fafafa !important;
+  /* No background overlay while editing dashboard layout */
 }
 #dashboard-grid .draggable-field input,
 #dashboard-grid .draggable-field select,


### PR DESCRIPTION
## Summary
- remove background overlay for widgets when editing dashboard layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68514d8ce3108333b9ff1b0b5a176a7d