### PR TITLE
Enhance purple theme shades

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,9 +1,11 @@
 :root {
   --font-sans: 'Inter', 'IBM Plex Sans', sans-serif;
   --font-mono: 'JetBrains Mono', 'Menlo', monospace;
+  --color-primary-dark: #5B21B6; /* darker purple */
   --color-primary: #7C3AED; /* purple */
+  --color-primary-light: #E9D5FF; /* light purple */
+  --color-primary-lightest: #F5F3FF;
   --color-secondary: #0D9488; /* teal */
-  --color-primary-light: #E9D5FF;
   --color-secondary-light: #99F6E4;
   --color-danger: #dc2626;
   --bg-dark: #111827;
@@ -141,10 +143,11 @@ a:hover {
 
 .text-primary { color: var(--color-primary); }
 .text-secondary { color: var(--color-secondary); }
+.bg-primary-lightest { background-color: var(--color-primary-lightest); }
 .bg-primary-light { background-color: var(--color-primary-light); }
 .bg-secondary-light { background-color: var(--color-secondary-light); }
-
 .bg-primary { background-color: var(--color-primary); }
+.bg-primary-dark { background-color: var(--color-primary-dark); }
 .bg-secondary { background-color: var(--color-secondary); }
 .bg-dark { background-color: var(--bg-dark); }
 .bg-card { background-color: var(--bg-card); }
@@ -194,3 +197,6 @@ a:hover {
 .bg-teal-100 { background-color: var(--color-primary-light); }
 .border-teal-600, .border-purple-600 { border-color: var(--color-primary); }
 .border-teal-200 { border-color: var(--color-primary-light); }
+.border-primary { border-color: var(--color-primary); }
+.border-primary-dark { border-color: var(--color-primary-dark); }
+.border-primary-light { border-color: var(--color-primary-light); }

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,7 +17,7 @@
     {% set current_id = segments[1] if segments|length > 1 else None %}
 
   <div id="app-container" class="flex min-h-screen">
-    <aside id="sidebar" class="fixed top-0 left-0 z-40 w-56 h-screen pt-4 bg-primary text-white hidden md:block flex flex-col flex-shrink-0">
+    <aside id="sidebar" class="fixed top-0 left-0 z-40 w-56 h-screen pt-4 bg-primary-dark text-white hidden md:block flex flex-col flex-shrink-0">
       <div class="flex items-center justify-between px-2">
         <a href="/" class="p-2 text-gray-100 flex items-center space-x-1" aria-label="Home">
           <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
@@ -35,10 +35,10 @@
       </nav>
       <!-- Sidebar action buttons removed -->
       </aside>
-    <div id="sidebar-handle" class="hidden fixed top-0 left-0 h-screen w-3 bg-primary text-white flex items-center justify-center cursor-pointer">&raquo;</div>
+    <div id="sidebar-handle" class="hidden fixed top-0 left-0 h-screen w-3 bg-primary-dark text-white flex items-center justify-center cursor-pointer">&raquo;</div>
 
     <div id="content-wrapper" class="flex-1 flex flex-col md:ml-56">
-      <header id="page-header" class="bg-primary text-white p-4 flex items-center justify-between fixed top-0 left-0 w-full z-40 shadow-md md:pl-56">
+      <header id="page-header" class="bg-primary-dark text-white p-4 flex items-center justify-between fixed top-0 left-0 w-full z-40 shadow-md md:pl-56">
         <div class="flex items-center space-x-2">
           {% block nav_buttons %}{% endblock %}
         </div>

--- a/templates/modals/dashboard_modal.html
+++ b/templates/modals/dashboard_modal.html
@@ -94,25 +94,25 @@
         <div id="tableTypeSelect" class="flex gap-2 mb-4">
           <label class="flex-1 cursor-pointer">
             <input type="radio" name="tableType" value="base-count" class="sr-only peer" checked>
-            <div class="p-2 border rounded text-center peer-checked:bg-purple-500 peer-checked:text-white">
+            <div class="p-2 border rounded text-center peer-checked:bg-primary-dark peer-checked:text-white">
               Base Count
             </div>
           </label>
           <label class="flex-1 cursor-pointer">
             <input type="radio" name="tableType" value="select-count" class="sr-only peer">
-            <div class="p-2 border rounded text-center peer-checked:bg-purple-500 peer-checked:text-white">
+            <div class="p-2 border rounded text-center peer-checked:bg-primary-dark peer-checked:text-white">
               Select Value Counts
             </div>
           </label>
           <label class="flex-1 cursor-pointer">
             <input type="radio" name="tableType" value="top-numeric" class="sr-only peer">
-            <div class="p-2 border rounded text-center peer-checked:bg-purple-500 peer-checked:text-white">
+            <div class="p-2 border rounded text-center peer-checked:bg-primary-dark peer-checked:text-white">
               Top/Bottom Numeric
             </div>
           </label>
           <label class="flex-1 cursor-pointer">
             <input type="radio" name="tableType" value="filtered-records" class="sr-only peer">
-            <div class="p-2 border rounded text-center peer-checked:bg-purple-500 peer-checked:text-white">
+            <div class="p-2 border rounded text-center peer-checked:bg-primary-dark peer-checked:text-white">
               Filtered Records
             </div>
           </label>
@@ -136,11 +136,11 @@
         <div id="topNumericDirection" class="flex gap-2 mb-4 hidden">
           <label class="cursor-pointer">
             <input type="radio" name="topDirection" value="desc" class="sr-only peer" checked>
-            <div class="p-1 border rounded-l text-center peer-checked:bg-purple-500 peer-checked:text-white">Top</div>
+            <div class="p-1 border rounded-l text-center peer-checked:bg-primary-dark peer-checked:text-white">Top</div>
           </label>
           <label class="cursor-pointer">
             <input type="radio" name="topDirection" value="asc" class="sr-only peer">
-            <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-purple-500 peer-checked:text-white">Bottom</div>
+            <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-primary-dark peer-checked:text-white">Bottom</div>
           </label>
         </div>
         <div id="filteredRecordsContainer" class="mb-4 hidden">

--- a/templates/modals/edit_fields_modal.html
+++ b/templates/modals/edit_fields_modal.html
@@ -5,7 +5,7 @@
     <div class="mb-4 border-b border-gray-200">
       <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="editFieldsTabs" role="tablist">
         <li class="mr-2" role="presentation">
-          <button id="tab-add" type="button" role="tab" aria-controls="pane-add" aria-selected="true" class="inline-block p-2 rounded-t-lg border-b-2 text-purple-600 border-purple-600">
+          <button id="tab-add" type="button" role="tab" aria-controls="pane-add" aria-selected="true" class="inline-block p-2 rounded-t-lg border-b-2 text-primary border-primary-dark">
             Add Field
           </button>
         </li>


### PR DESCRIPTION
## Summary
- add purple shade variables in CSS
- tweak navigation bar and dashboard modals to use darker purple
- style edit fields modal tab with theme classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68515188c94083339a546de996dd55b8