### PR TITLE
Fix layout edit overlay

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -31,7 +31,7 @@ input[type=number] {
 #layout-grid.editing .draggable-field {
   border: 1px blue dashed !important;
   box-shadow: 0 0 0 2px rgba(0,0,0,0.1) !important;
-  background-color: #fafafa !important;
+  background-color: transparent !important;
 }
 
 


### PR DESCRIPTION
## Summary
- remove white overlay on fields while editing the detail view layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68515122e89c83338843fee6a6ece0f9