### PR TITLE
Refine dark mode styling

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -137,7 +137,7 @@ a:hover {
   border-radius: 0.25rem;
 }
 .nav-link:hover {
-  background-color: var(--color-secondary);
+  background-color: var(--color-primary);
   color: #fff;
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,7 +17,7 @@
     {% set current_id = segments[1] if segments|length > 1 else None %}
 
   <div id="app-container" class="flex min-h-screen">
-    <aside id="sidebar" class="fixed top-0 left-0 z-40 w-56 h-screen pt-4 bg-primary-dark text-white hidden md:block flex flex-col flex-shrink-0">
+    <aside id="sidebar" class="fixed top-0 left-0 z-40 w-56 h-screen pt-4 bg-dark text-white hidden md:block flex flex-col flex-shrink-0">
       <div class="flex items-center justify-between px-2">
         <a href="/" class="p-2 text-gray-100 flex items-center space-x-1" aria-label="Home">
           <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
@@ -30,15 +30,15 @@
       <nav class="flex-1 overflow-y-auto px-3 space-y-2">
         {# Home link moved next to icon above #}
         {% for nav in nav_cards if nav.table_name != 'dashboard' %}
-          <a href="/{{ nav.table_name }}" class="nav-link {{ 'bg-secondary text-white' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
+          <a href="/{{ nav.table_name }}" class="nav-link {{ 'bg-primary-dark text-white' if current_table == nav.table_name else '' }}">{{ nav.display_name }}</a>
         {% endfor %}
       </nav>
       <!-- Sidebar action buttons removed -->
       </aside>
-    <div id="sidebar-handle" class="hidden fixed top-0 left-0 h-screen w-3 bg-primary-dark text-white flex items-center justify-center cursor-pointer">&raquo;</div>
+    <div id="sidebar-handle" class="hidden fixed top-0 left-0 h-screen w-3 bg-dark text-white flex items-center justify-center cursor-pointer">&raquo;</div>
 
     <div id="content-wrapper" class="flex-1 flex flex-col md:ml-56">
-      <header id="page-header" class="bg-primary-dark text-white p-4 flex items-center justify-between fixed top-0 left-0 w-full z-40 shadow-md md:pl-56">
+      <header id="page-header" class="bg-dark text-white p-4 flex items-center justify-between fixed top-0 left-0 w-full z-40 shadow-md md:pl-56">
         <div class="flex items-center space-x-2">
           {% block nav_buttons %}{% endblock %}
         </div>


### PR DESCRIPTION
## Summary
- keep header and sidebar dark
- highlight sidebar links and nav hover with purple

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685155cae1348333a50135f6eb8dbd2d