### PR TITLE
Fix click-to-edit behavior on detail view

### DIFF
--- a/static/js/click_to_edit.js
+++ b/static/js/click_to_edit.js
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   grid.addEventListener('click', async (e) => {
     if (grid.classList.contains('editing')) return;
-    const fieldEl = e.target.closest('.draggable-field');
+    const fieldEl = e.target.closest('.draggable-field[data-field]');
     if (!fieldEl) return;
     if (['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A'].includes(e.target.tagName)) {
       return;


### PR DESCRIPTION
## Summary
- fix click-to-edit targeting nested draggable fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68515728ad6483338be01a49e7539f6c