### PR TITLE
Add automation rule engine

### DIFF
--- a/automation/engine.py
+++ b/automation/engine.py
@@ -1,0 +1,58 @@
+import logging
+from huey import crontab
+from imports.tasks import huey
+from db.automation import get_rules, increment_run_count
+from db.records import get_all_records, get_record_by_id, update_field_value
+from db.schema import get_field_schema
+from utils.record_ops import _normalize_value
+from db.edit_history import append_edit_log
+
+logger = logging.getLogger(__name__)
+
+@huey.task()
+def run_rule(rule_id: int) -> dict | None:
+    rules = get_rules(rule_id=rule_id)
+    if not rules:
+        logger.warning("run_rule: rule %s not found", rule_id)
+        return None
+    rule = rules[0]
+    table = rule["table_name"]
+    cond_field = rule["condition_field"]
+    cond_value = rule.get("condition_value")
+    op = rule.get("condition_operator", "equals")
+    act_field = rule["action_field"]
+    act_value = rule.get("action_value")
+    records = get_all_records(table, filters={cond_field: cond_value}, ops={cond_field: op})
+    ids = [r.get("id") for r in records if r.get("id") is not None]
+    schema = get_field_schema().get(table, {})
+    fmeta = schema.get(act_field, {})
+    norm_val = _normalize_value(fmeta.get("type", "text"), act_value)
+    for rid in ids:
+        prev = get_record_by_id(table, rid)
+        old = prev.get(act_field) if prev else None
+        if update_field_value(table, rid, act_field, norm_val):
+            append_edit_log(
+                table,
+                rid,
+                act_field,
+                old,
+                norm_val,
+                actor=f"rule:{rule_id}",
+            )
+    increment_run_count(rule_id)
+    return {"updated": len(ids)}
+
+
+@huey.periodic_task(crontab(minute="*/10"))
+def run_always_rules() -> None:
+    for rule in get_rules():
+        if rule.get("schedule") == "always":
+            run_rule(rule["id"])  # type: ignore[arg-type]
+
+
+@huey.periodic_task(crontab(hour=0, minute=0))
+def run_daily_rules() -> None:
+    for rule in get_rules():
+        if rule.get("schedule") == "daily":
+            run_rule(rule["id"])  # type: ignore[arg-type]
+

--- a/db/automation.py
+++ b/db/automation.py
@@ -1,0 +1,143 @@
+import datetime
+import logging
+from typing import Any, Dict, List, Optional
+from db.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+CREATE_SQL = """
+CREATE TABLE IF NOT EXISTS automation_rules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    table_name TEXT NOT NULL,
+    condition_field TEXT NOT NULL,
+    condition_operator TEXT NOT NULL,
+    condition_value TEXT,
+    action_field TEXT NOT NULL,
+    action_value TEXT,
+    run_on_import BOOLEAN NOT NULL DEFAULT 0,
+    schedule TEXT NOT NULL DEFAULT 'none',
+    last_run TEXT,
+    run_count INTEGER NOT NULL DEFAULT 0
+)
+"""
+
+
+def _ensure_table() -> None:
+    with get_connection() as conn:
+        conn.execute(CREATE_SQL)
+        conn.commit()
+
+
+def create_rule(rule: Dict[str, Any]) -> Optional[int]:
+    """Insert a new automation rule and return its id."""
+    _ensure_table()
+    fields = [
+        "name",
+        "table_name",
+        "condition_field",
+        "condition_operator",
+        "condition_value",
+        "action_field",
+        "action_value",
+        "run_on_import",
+        "schedule",
+    ]
+    values = [rule.get(f) for f in fields]
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO automation_rules
+            (name, table_name, condition_field, condition_operator,
+             condition_value, action_field, action_value, run_on_import, schedule)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            values,
+        )
+        conn.commit()
+        return cur.lastrowid
+
+
+def update_rule(rule_id: int, **fields: Any) -> int:
+    """Update an existing rule. Returns rows affected."""
+    _ensure_table()
+    if not fields:
+        return 0
+    sets = ", ".join(f"{k} = ?" for k in fields)
+    params = list(fields.values()) + [rule_id]
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(f"UPDATE automation_rules SET {sets} WHERE id = ?", params)
+        conn.commit()
+        return cur.rowcount
+
+
+def delete_rule(rule_id: int) -> int:
+    _ensure_table()
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute("DELETE FROM automation_rules WHERE id = ?", (rule_id,))
+        conn.commit()
+        return cur.rowcount
+
+
+def get_rules(table_name: str | None = None, rule_id: int | None = None) -> List[Dict[str, Any]]:
+    _ensure_table()
+    query = (
+        "SELECT id, name, table_name, condition_field, condition_operator,"
+        " condition_value, action_field, action_value, run_on_import, schedule,"
+        " last_run, run_count FROM automation_rules"
+    )
+    params: List[Any] = []
+    clauses = []
+    if table_name:
+        clauses.append("table_name = ?")
+        params.append(table_name)
+    if rule_id:
+        clauses.append("id = ?")
+        params.append(rule_id)
+    if clauses:
+        query += " WHERE " + " AND ".join(clauses)
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(query, params)
+        rows = cur.fetchall()
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, r)) for r in rows]
+
+
+def increment_run_count(rule_id: int) -> None:
+    _ensure_table()
+    ts = datetime.datetime.utcnow().isoformat(timespec="seconds")
+    with get_connection() as conn:
+        conn.execute(
+            "UPDATE automation_rules SET run_count = COALESCE(run_count,0)+1, last_run=? WHERE id=?",
+            (ts, rule_id),
+        )
+        conn.commit()
+
+
+def reset_run_count(rule_id: int | None = None) -> None:
+    _ensure_table()
+    with get_connection() as conn:
+        if rule_id is None:
+            conn.execute("UPDATE automation_rules SET run_count = 0")
+        else:
+            conn.execute("UPDATE automation_rules SET run_count = 0 WHERE id = ?", (rule_id,))
+        conn.commit()
+
+
+def get_rule_logs(rule_id: int, limit: int = 20) -> List[Dict[str, Any]]:
+    actor = f"rule:{rule_id}"
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT id, table_name, record_id, field_name, old_value, new_value, timestamp "
+            "FROM edit_history WHERE actor = ? ORDER BY id DESC LIMIT ?",
+            (actor, limit),
+        )
+        rows = cur.fetchall()
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, r)) for r in rows]
+

--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -196,6 +196,25 @@ def _create_core_tables(cur: sqlite3.Cursor) -> None:
         """
     )
 
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS automation_rules (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            table_name TEXT NOT NULL,
+            condition_field TEXT NOT NULL,
+            condition_operator TEXT NOT NULL,
+            condition_value TEXT,
+            action_field TEXT NOT NULL,
+            action_value TEXT,
+            run_on_import BOOLEAN NOT NULL DEFAULT 0,
+            schedule TEXT NOT NULL DEFAULT 'none',
+            last_run TEXT,
+            run_count INTEGER NOT NULL DEFAULT 0
+        )
+        """
+    )
+
     # Generic relationships table for many-to-many links
     cur.execute(
         """

--- a/imports/tasks.py
+++ b/imports/tasks.py
@@ -68,6 +68,14 @@ def _run_import(job_id, table, rows):
             len(rows) - len(errors),
             len(errors),
         )
+
+        from db.automation import get_rules
+        from automation.engine import run_rule
+
+        for rule in get_rules(table_name=table):
+            if rule.get("run_on_import"):
+                run_rule(rule["id"])  # type: ignore[arg-type]
+
         return {"job_id": job_id, "imported": len(rows) - len(errors), "errors": errors}
     except Exception:
         logger.exception("Import job %s for table %s failed", job_id, table)

--- a/static/js/automation.js
+++ b/static/js/automation.js
@@ -1,0 +1,49 @@
+async function loadRules() {
+  const resp = await fetch('/admin/automation/rules');
+  const rules = await resp.json();
+  const tbody = document.querySelector('#automation-table tbody');
+  tbody.innerHTML = '';
+  rules.forEach(r => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${r.name}</td><td>${r.table_name}</td>` +
+      `<td>${r.condition_field} ${r.condition_operator} ${r.condition_value}</td>` +
+      `<td>${r.action_field} = ${r.action_value}</td>` +
+      `<td>${r.schedule}</td><td>${r.run_count}</td>` +
+      `<td><button data-run="${r.id}">Run</button> <button data-reset="${r.id}">Reset</button> <button data-logs="${r.id}">Logs</button></td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadRules();
+  document.body.addEventListener('click', async evt => {
+    if (evt.target.dataset.run) {
+      await fetch(`/admin/automation/trigger/${evt.target.dataset.run}`, {method:'POST'});
+      loadRules();
+    } else if (evt.target.dataset.reset) {
+      await fetch(`/admin/automation/reset/${evt.target.dataset.reset}`, {method:'POST'});
+      loadRules();
+    } else if (evt.target.dataset.logs) {
+      const resp = await fetch(`/admin/automation/logs/${evt.target.dataset.logs}`);
+      const logs = await resp.json();
+      alert(JSON.stringify(logs));
+    }
+  });
+  const modal = document.getElementById('rule-modal');
+  const form = document.getElementById('rule-form');
+  document.getElementById('new-rule-btn').addEventListener('click', () => {
+    form.reset();
+    modal.classList.remove('hidden');
+  });
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(form).entries());
+    data.run_on_import = form.querySelector('input[name="run_on_import"]').checked ? 1 : 0;
+    const id = data.id;
+    delete data.id;
+    const url = id ? `/admin/automation/rule/${id}` : '/admin/automation/rule';
+    await fetch(url, {method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify(data)});
+    modal.classList.add('hidden');
+    loadRules();
+  });
+});

--- a/templates/admin/admin_automation.html
+++ b/templates/admin/admin_automation.html
@@ -1,8 +1,36 @@
 {% extends "base.html" %}
-
 {% block title %}Automation{% endblock %}
-
 {% block content %}
-<h1 class="text-3xl font-bold mb-4">Automation</h1>
-<p class="text-gray-600">This page is under construction.</p>
+<h1 class="text-3xl font-bold mb-4">Automation Rules</h1>
+<table id="automation-table" class="table-auto w-full mb-4 border">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Table</th>
+      <th>Condition</th>
+      <th>Action</th>
+      <th>Schedule</th>
+      <th>Runs</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<button id="new-rule-btn" class="bg-blue-500 text-white px-2 py-1">New Rule</button>
+<div id="rule-modal" class="hidden fixed inset-0 bg-gray-500 bg-opacity-50 flex items-center justify-center">
+  <form id="rule-form" class="bg-white p-4 space-y-2">
+    <input type="hidden" name="id" />
+    <label>Name <input name="name" class="border"/></label>
+    <label>Table <input name="table_name" class="border"/></label>
+    <label>Condition Field <input name="condition_field" class="border"/></label>
+    <label>Operator <input name="condition_operator" class="border"/></label>
+    <label>Value <input name="condition_value" class="border"/></label>
+    <label>Action Field <input name="action_field" class="border"/></label>
+    <label>Action Value <input name="action_value" class="border"/></label>
+    <label>Run on Import <input type="checkbox" name="run_on_import" value="1"/></label>
+    <label>Schedule <select name="schedule" class="border"><option value="none">none</option><option value="daily">daily</option><option value="always">always</option></select></label>
+    <button type="submit" class="bg-green-600 text-white px-2 py-1">Save</button>
+  </form>
+</div>
+<script src="/static/js/automation.js"></script>
 {% endblock %}

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import sqlite3
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from db.database import init_db_path
+from db.records import get_record_by_id, create_record
+from db.automation import (
+    create_rule,
+    get_rules,
+    reset_run_count,
+    get_rule_logs,
+)
+from automation.engine import run_rule, run_daily_rules
+from imports import tasks as import_tasks
+
+DB_PATH = 'data/crossbook.db'
+init_db_path(DB_PATH)
+
+
+def test_rule_creation_and_reset():
+    rule_id = create_rule({
+        'name': 'test',
+        'table_name': 'location',
+        'condition_field': 'location',
+        'condition_operator': 'equals',
+        'condition_value': 'XPlace',
+        'action_field': 'description',
+        'action_value': 'AUTO',
+        'run_on_import': 1,
+        'schedule': 'none',
+    })
+    rules = get_rules(rule_id=rule_id)
+    assert rules and rules[0]['name'] == 'test'
+    reset_run_count(rule_id)
+    assert get_rules(rule_id=rule_id)[0]['run_count'] == 0
+
+
+def test_rule_executes_on_import():
+    import_tasks.huey.immediate = True
+    rule_id = create_rule({
+        'name': 'import_rule',
+        'table_name': 'location',
+        'condition_field': 'location',
+        'condition_operator': 'equals',
+        'condition_value': 'ImportPlace',
+        'action_field': 'description',
+        'action_value': 'IMPORTED',
+        'run_on_import': 1,
+        'schedule': 'none',
+    })
+    import_tasks.import_rows('location', [{'location': 'ImportPlace', 'description': ''}])
+    with sqlite3.connect(DB_PATH) as conn:
+        status = conn.execute("SELECT description FROM location WHERE location='ImportPlace'").fetchone()[0]
+    assert status == 'IMPORTED'
+    assert get_rules(rule_id=rule_id)[0]['run_count'] == 1
+
+
+def test_daily_schedule_and_rollback():
+    import_tasks.huey.immediate = True
+    rule_id = create_rule({
+        'name': 'daily_rule',
+        'table_name': 'location',
+        'condition_field': 'location',
+        'condition_operator': 'equals',
+        'condition_value': 'DailyPlace',
+        'action_field': 'description',
+        'action_value': 'DAILY',
+        'run_on_import': 0,
+        'schedule': 'daily',
+    })
+    rec_id = create_record('location', {'location': 'DailyPlace'})
+    run_daily_rules()
+    assert get_record_by_id('location', rec_id)['description'] == 'DAILY'
+    logs = get_rule_logs(rule_id, limit=1)
+    assert logs
+    from db.edit_history import revert_edit
+    assert revert_edit(logs[0])
+    assert get_record_by_id('location', rec_id)['description'] != 'DAILY'
+    reset_run_count(rule_id)
+

--- a/views/admin/__init__.py
+++ b/views/admin/__init__.py
@@ -39,6 +39,7 @@ def admin_html_redirect():
 from . import dashboard  # noqa: F401  # register routes
 from . import config  # noqa: F401  # register routes
 from . import imports  # noqa: F401  # register routes
+from . import automation  # noqa: F401  # register routes
 
 __all__ = [
     'admin_bp',

--- a/views/admin/automation.py
+++ b/views/admin/automation.py
@@ -1,0 +1,80 @@
+import logging
+from flask import render_template, jsonify, request
+from . import admin_bp
+from db.automation import (
+    create_rule,
+    update_rule,
+    delete_rule,
+    get_rules,
+    reset_run_count,
+    get_rule_logs,
+)
+from db.edit_history import get_edit_entry, revert_edit
+from automation.engine import run_rule
+
+logger = logging.getLogger(__name__)
+
+
+@admin_bp.route("/admin/automation")
+def automation_page():
+    return render_template("admin/admin_automation.html")
+
+
+@admin_bp.route("/admin/automation/rules")
+def automation_list():
+    table = request.args.get("table")
+    rules = get_rules(table_name=table)
+    return jsonify(rules)
+
+
+@admin_bp.route("/admin/automation/rule", methods=["POST"])
+def automation_create():
+    data = request.get_json(silent=True) or {}
+    rid = create_rule(data)
+    return jsonify({"id": rid})
+
+
+@admin_bp.route("/admin/automation/rule/<int:rule_id>", methods=["POST"])
+def automation_update(rule_id):
+    data = request.get_json(silent=True) or {}
+    update_rule(rule_id, **data)
+    return jsonify({"success": True})
+
+
+@admin_bp.route("/admin/automation/rule/<int:rule_id>", methods=["DELETE"])
+def automation_delete(rule_id):
+    delete_rule(rule_id)
+    return jsonify({"success": True})
+
+
+@admin_bp.route("/admin/automation/trigger/<int:rule_id>", methods=["POST"])
+def automation_trigger(rule_id):
+    run_rule(rule_id)
+    return jsonify({"success": True})
+
+
+@admin_bp.route("/admin/automation/reset/<int:rule_id>", methods=["POST"])
+def automation_reset(rule_id):
+    reset_run_count(rule_id)
+    return jsonify({"success": True})
+
+
+@admin_bp.route("/admin/automation/logs/<int:rule_id>")
+def automation_logs(rule_id):
+    try:
+        limit = int(request.args.get("limit", 20))
+    except (TypeError, ValueError):
+        limit = 20
+    return jsonify(get_rule_logs(rule_id, limit=limit))
+
+
+@admin_bp.route("/admin/automation/rollback", methods=["POST"])
+def automation_rollback():
+    data = request.get_json(silent=True) or {}
+    edit_id = data.get("edit_id")
+    entry = get_edit_entry(edit_id)
+    if not entry:
+        return jsonify({"error": "not_found"}), 404
+    success = revert_edit(entry)
+    return jsonify({"success": bool(success)})
+


### PR DESCRIPTION
## Summary
- implement automation rules table and CRUD helpers
- create task engine for running rules
- trigger automation rules after imports
- expose admin views and UI for rule management
- document automation rules and worker
- test automation rule creation, import execution, scheduling and rollback
- remove unnecessary `automation/__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685192f3faf48333b611358c9dad659a