### PR TITLE
Add form-control utility

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -200,3 +200,12 @@ a:hover {
 .border-primary { border-color: var(--color-primary); }
 .border-primary-dark { border-color: var(--color-primary-dark); }
 .border-primary-light { border-color: var(--color-primary-light); }
+
+/* Reusable form control styling */
+.form-control {
+  background-color: var(--bg-card);
+  color: var(--text-light);
+  border: 1px solid var(--color-primary-light);
+  padding: 0.25rem 0.5rem; /* py-1 px-2 */
+  border-radius: 0.25rem;  /* rounded */
+}

--- a/templates/wizard/wizard_database.html
+++ b/templates/wizard/wizard_database.html
@@ -5,11 +5,11 @@
 <form method="post" enctype="multipart/form-data" class="space-y-4">
   <div>
     <label class="block mb-1">Upload Database File</label>
-    <input type="file" name="file" accept=".db" class="border rounded px-2 py-1">
+    <input type="file" name="file" accept=".db" class="form-control">
   </div>
   <div>
     <label class="block mb-1">Or create new database</label>
-    <input type="text" name="create_name" class="border rounded px-2 py-1" placeholder="name.db">
+    <input type="text" name="create_name" class="form-control" placeholder="name.db">
   </div>
   <button type="submit" class="btn-primary px-4 py-2 rounded">Continue</button>
 </form>

--- a/templates/wizard/wizard_import.html
+++ b/templates/wizard/wizard_import.html
@@ -5,7 +5,7 @@
 <form method="post" enctype="multipart/form-data" class="space-y-4">
   <div>
     <label class="block mb-1">Table</label>
-    <select name="table" class="border rounded px-2 py-1">
+    <select name="table" class="form-control">
       {% for t in base_tables %}
       <option value="{{ t }}">{{ t }}</option>
       {% endfor %}
@@ -13,7 +13,7 @@
   </div>
   <div>
     <label class="block mb-1">CSV File</label>
-    <input type="file" name="file" accept=".csv" class="border rounded px-2 py-1">
+    <input type="file" name="file" accept=".csv" class="form-control">
   </div>
   <button type="submit" class="btn-primary px-4 py-2 rounded">Import</button>
   <a href="{{ url_for('wizard.table_step') }}" class="ml-4 text-teal-600 underline">Back</a>

--- a/templates/wizard/wizard_settings.html
+++ b/templates/wizard/wizard_settings.html
@@ -14,20 +14,20 @@
       {% if item.required %}<span class="text-red-600">*</span>{% endif %}
     </label>
     {% if item.options %}
-      <select name="{{ key }}" id="{{ key }}" class="border rounded px-2 py-1">
+      <select name="{{ key }}" id="{{ key }}" class="form-control">
         {% for opt in item.options %}
         <option value="{{ opt }}" {% if (config.get(key) or default) == opt %}selected{% endif %}>{{ opt }}</option>
         {% endfor %}
       </select>
     {% elif typ in ('integer', 'number') %}
-      <input type="number" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full" {% if item.required %}required{% endif %}>
+      <input type="number" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="form-control w-full" {% if item.required %}required{% endif %}>
     {% elif typ == 'boolean' %}
       <input type="checkbox" name="{{ key }}" id="{{ key }}" value="1" {% if config.get(key, default) in ('1', 1, True, 'true') %}checked{% endif %}>
       <input type="hidden" name="{{ key }}" value="0">
     {% elif typ == 'date' %}
-      <input type="date" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full" {% if item.required %}required{% endif %}>
+      <input type="date" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="form-control w-full" {% if item.required %}required{% endif %}>
     {% else %}
-      <input type="text" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full" {% if item.required %}required{% endif %}>
+      <input type="text" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="form-control w-full" {% if item.required %}required{% endif %}>
     {% endif %}
     {% if errors and errors.get(key) %}
       <p class="text-red-600 text-sm">This field is required.</p>
@@ -46,20 +46,20 @@
       {% if item.required %}<span class="text-red-600">*</span>{% endif %}
     </label>
     {% if item.options %}
-      <select name="{{ key }}" id="{{ key }}" class="border rounded px-2 py-1">
+      <select name="{{ key }}" id="{{ key }}" class="form-control">
         {% for opt in item.options %}
         <option value="{{ opt }}" {% if (config.get(key) or default) == opt %}selected{% endif %}>{{ opt }}</option>
         {% endfor %}
       </select>
     {% elif typ in ('integer', 'number') %}
-      <input type="number" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full" {% if item.required %}required{% endif %}>
+      <input type="number" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="form-control w-full" {% if item.required %}required{% endif %}>
     {% elif typ == 'boolean' %}
       <input type="checkbox" name="{{ key }}" id="{{ key }}" value="1" {% if config.get(key, default) in ('1', 1, True, 'true') %}checked{% endif %}>
       <input type="hidden" name="{{ key }}" value="0">
     {% elif typ == 'date' %}
-      <input type="date" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full" {% if item.required %}required{% endif %}>
+      <input type="date" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="form-control w-full" {% if item.required %}required{% endif %}>
     {% else %}
-      <input type="text" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="border rounded px-2 py-1 w-full" {% if item.required %}required{% endif %}>
+      <input type="text" name="{{ key }}" id="{{ key }}" value="{{ config.get(key, default) }}" class="form-control w-full" {% if item.required %}required{% endif %}>
     {% endif %}
     {% if errors and errors.get(key) %}
       <p class="text-red-600 text-sm">This field is required.</p>

--- a/templates/wizard/wizard_table.html
+++ b/templates/wizard/wizard_table.html
@@ -5,15 +5,15 @@
 <form method="post" id="table-form" class="space-y-4">
   <div>
     <label class="block mb-1">Table Name</label>
-    <input type="text" name="table_name" class="border rounded px-2 py-1 w-full">
+    <input type="text" name="table_name" class="form-control w-full">
   </div>
   <div>
     <label class="block mb-1">Title Field</label>
-    <input type="text" name="title_field" class="border rounded px-2 py-1 w-full" required>
+    <input type="text" name="title_field" class="form-control w-full" required>
   </div>
   <div>
     <label class="block mb-1">Description</label>
-    <input type="text" name="description" class="border rounded px-2 py-1 w-full">
+    <input type="text" name="description" class="form-control w-full">
   </div>
   <input type="hidden" name="fields_json" id="fields_json">
   <div>
@@ -32,7 +32,7 @@
     <form id="field-form" class="space-y-4">
       <div>
         <label class="block mb-2 text-sm font-medium">Field Name</label>
-        <input name="field_name" type="text" class="w-full border px-3 py-2 rounded" required>
+        <input name="field_name" type="text" class="form-control w-full" required>
       </div>
       <div>
         <label class="block mb-2 text-sm font-medium">Field Type</label>
@@ -42,7 +42,7 @@
       </div>
       <div id="field-options-container" class="hidden">
         <label class="block mb-2 text-sm font-medium">Options (comma-separated)</label>
-        <textarea name="field_options" rows="3" class="w-full border px-3 py-2 rounded"></textarea>
+        <textarea name="field_options" rows="3" class="form-control w-full"></textarea>
       </div>
       <div id="fk-select-container" class="hidden">
         <label class="block mb-2 text-sm font-medium">Select linked field</label>


### PR DESCRIPTION
## Summary
- add a `.form-control` style for consistent input visuals
- update wizard templates to use the new class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68519bdeb7b08333b5687920a832fcd2