### PR TITLE
Use stylesheet for dark popover styling

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -209,3 +209,13 @@ a:hover {
   padding: 0.25rem 0.5rem; /* py-1 px-2 */
   border-radius: 0.25rem;  /* rounded */
 }
+
+/* Reusable dark mode popover */
+.popover-dark {
+  background-color: var(--bg-card);
+  color: var(--text-light);
+  border: 1px solid var(--color-primary-light);
+  border-radius: 0.5rem; /* rounded */
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1); /* shadow-lg */
+  padding: 0.5rem; /* p-2 */
+}

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -62,7 +62,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
           </svg>
         </button>
-        <div id="header-field-popover" class="absolute right-0 z-20 hidden mt-2 bg-card border rounded shadow-lg p-2 space-y-1 w-48 text-light">
+        <div id="header-field-popover" class="popover-dark absolute right-0 z-20 hidden mt-2 space-y-1 w-48">
           <label class="flex items-center space-x-2">
             <input type="checkbox" class="header-field-toggle" value="title" checked>
             <span class="text-sm">Title</span>
@@ -162,7 +162,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
           </svg>
         </button>
-        <div id="relation-visibility-popover" class="absolute right-0 z-20 hidden mt-2 bg-card border rounded shadow-lg p-2 space-y-2 w-64 text-light">
+        <div id="relation-visibility-popover" class="popover-dark absolute right-0 z-20 hidden mt-2 space-y-2 w-64">
           <div class="font-semibold text-sm border-b pb-1 mb-1">Relations Visibility</div>
           {% for sec, grp, vis in related %}
             <div class="space-y-1">

--- a/templates/macros/filter_controls.html
+++ b/templates/macros/filter_controls.html
@@ -55,7 +55,7 @@
   </button>
 
   <div
-  class="multi-select-popover absolute z-20 mt-1 bg-white text-black border rounded shadow p-2 hidden overflow-scroll "
+  class="multi-select-popover popover-dark absolute z-20 mt-1 hidden overflow-scroll"
   data-field="{{ field }}">
     <div class="text-right mb-1 text-xs">
       <label class="mr-1">Mode:</label>


### PR DESCRIPTION
## Summary
- centralize popover styling with new `.popover-dark` class
- apply the new popover class in the templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a2637004833387b90c0a33cd7be8