### PR TITLE
Consolidate grid layout classes

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -242,6 +242,14 @@ input[type=number] {
   z-index: 100;
 }
 
+/* Standard grid layout used in detail and dashboard pages */
+.layout-grid {
+  display: grid;
+  grid-template-columns: repeat(20, 1fr);
+  grid-auto-rows: 1em;
+  position: relative;
+}
+
 /* Utility button and component styles */
 .btn-primary {
   background-color: var(--color-primary);

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -18,8 +18,7 @@
 {% endif %}
 
 <div id="dashboard-grid"
-     class="relative w-full grid"
-     style="grid-template-columns: repeat(20, 1fr); grid-auto-rows: 1em;">
+     class="layout-grid relative w-full">
   {% set default_width = { 'value': 4, 'table': 10, 'chart': 10 } %}
   {% set default_height = { 'value': 3, 'table': 8,  'chart': 12 } %}
   {% set widget_layout = {} %}

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -85,13 +85,9 @@
 
     <!-- Layout container with computed initial height -->
     <div id="layout-grid"
-         class="relative w-full grid"
+         class="layout-grid relative w-full"
          data-table="{{ table }}"
-         data-record-id="{{ record.id }}"
-         style="
-           grid-template-columns: repeat(20, 1fr);
-           grid-auto-rows: 1em;
-         ">
+         data-record-id="{{ record.id }}">
 
       {% for field, value in record.items() %}
         {% if field_schema[table][field].type not in ['hidden', 'title'] and field not in ['date_added', 'date_created', 'last_updated', 'last_edited'] %}


### PR DESCRIPTION
## Summary
- remove duplicate `.dashboard-grid` style
- apply `.layout-grid` to both detail and dashboard grid containers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851a1fa92b883338e3dc962301dbe78