### PR TITLE
Add automation rule engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
     - [macros/fields.html](#macrosfieldshtml)
   - [Logging & Monitoring](#logging--monitoring)
   - [Import Workflow](#import-workflow)
+  - [Automation Rules](#automation-rules)
 
 ## Project Summary
 
@@ -200,6 +201,16 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 
 Large files are not streamed—they are fully loaded into memory during parsing, so extremely big uploads may exhaust memory.
 
+## Automation Rules
+
+Create automation rules under **Admin → Automation**. Rules can run daily or whenever a matching table is imported. Start the Huey worker with:
+
+```bash
+huey_consumer.py imports.tasks.huey
+```
+
+The worker also processes scheduled automation tasks defined in `automation/engine.py`.
+
 ## Application Architecture and Code Overview
 
 * **Routing & Views:** Defined in `main.py` using Flask decorators; routes handle list, detail, new record, and error pages. A context processor (`@app.context_processor`) injects the `field_schema`—the in-memory representation of all table fields, types, options, and layout—into all templates and front-end scripts for dynamic form generation and validation. Error handlers (e.g., `@app.errorhandler(404)`) and `abort()` calls manage invalid requests.
@@ -209,6 +220,7 @@ Large files are not streamed—they are fully loaded into memory during parsing,
 * **Database Layer:** Uses Python’s built-in `sqlite3` in `db/database.py` for connection management. Schema introspection and migrations occur in `db/schema.py`. CRUD operations reside in `db/records.py`; many-to-many relationship logic in `db/relationships.py`. Validation rules live in `db/validation.py`, and field schema editing utilities in `db/edit_fields.py`.
 
 * **Background Tasks:** Huey is initialized in `imports/tasks.py` and provides the `process_import` task used by the import workflow. Start a worker with `huey_consumer.py imports.tasks.huey`.
+* **Automation Rules:** Daily or import-triggered rules live in `automation/engine.py`. Start the same Huey worker to execute scheduled rules.
 
 * **Frontend Interaction:** Dynamic behaviors powered by JavaScript modules in `static/js/`:
 

--- a/automation/engine.py
+++ b/automation/engine.py
@@ -1,0 +1,66 @@
+import logging
+from db.database import get_connection
+from db.records import update_field_value
+from db.edit_history import append_edit_log
+from db.automation import get_rules, increment_run_count
+from imports.tasks import huey
+
+logger = logging.getLogger(__name__)
+
+
+def run_rule(rule_id: int) -> int:
+    """Execute a single automation rule. Returns number of records updated."""
+    rules = [r for r in get_rules() if r["id"] == rule_id]
+    if not rules:
+        logger.warning("Rule %s not found", rule_id)
+        return 0
+    rule = rules[0]
+    table = rule["table_name"]
+    condition_field = rule["condition_field"]
+    condition_value = rule["condition_value"]
+    operator = rule["condition_operator"]
+    action_field = rule["action_field"]
+    action_value = rule["action_value"]
+
+    sql_op = "=" if operator == "equals" else "LIKE"
+    param = condition_value if operator == "equals" else f"%{condition_value}%"
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            f"SELECT id, {action_field} FROM {table} WHERE {condition_field} {sql_op} ?",
+            (param,),
+        )
+        rows = cur.fetchall()
+    count = 0
+    for rec_id, old_val in rows:
+        if update_field_value(table, rec_id, action_field, action_value):
+            append_edit_log(
+                table,
+                rec_id,
+                action_field,
+                old_val,
+                action_value,
+                actor=f"rule:{rule_id}",
+            )
+            count += 1
+    if rows:
+        increment_run_count(rule_id)
+    return count
+
+
+@huey.task()
+def run_rule_task(rule_id: int) -> int:
+    return run_rule(rule_id)
+
+
+def run_import_rules(table_name: str) -> None:
+    for rule in get_rules(table_name):
+        if rule.get("run_on_import"):
+            run_rule(rule["id"])
+
+
+def trigger_scheduled_rules() -> None:
+    for rule in get_rules():
+        if rule.get("schedule") in {"daily", "always"}:
+            task = run_rule_task.s(rule["id"])
+            huey.enqueue(task)

--- a/db/automation.py
+++ b/db/automation.py
@@ -1,0 +1,100 @@
+import logging
+from db.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+def create_rule(
+    name: str,
+    table_name: str,
+    condition_field: str,
+    condition_operator: str,
+    condition_value: str,
+    action_field: str,
+    action_value: str,
+    run_on_import: bool = False,
+    schedule: str = "none",
+) -> int:
+    """Insert a new automation rule and return its id."""
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO automation_rules
+                (name, table_name, condition_field, condition_operator,
+                 condition_value, action_field, action_value,
+                 run_on_import, schedule)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                name,
+                table_name,
+                condition_field,
+                condition_operator,
+                condition_value,
+                action_field,
+                action_value,
+                int(run_on_import),
+                schedule,
+            ),
+        )
+        rule_id = cur.lastrowid
+        conn.commit()
+    return rule_id
+
+
+def update_rule(rule_id: int, **updates) -> bool:
+    """Update fields for an automation rule."""
+    if not updates:
+        return False
+    fields = ", ".join(f"{k}=?" for k in updates)
+    params = list(updates.values()) + [rule_id]
+    with get_connection() as conn:
+        conn.execute(
+            f"UPDATE automation_rules SET {fields} WHERE id = ?",
+            params,
+        )
+        conn.commit()
+    return True
+
+
+def delete_rule(rule_id: int) -> bool:
+    with get_connection() as conn:
+        conn.execute("DELETE FROM automation_rules WHERE id = ?", (rule_id,))
+        conn.commit()
+    return True
+
+
+def get_rules(table_name: str | None = None) -> list[dict]:
+    """Return automation rules optionally filtered by table."""
+    with get_connection() as conn:
+        cur = conn.cursor()
+        if table_name:
+            cur.execute(
+                "SELECT * FROM automation_rules WHERE table_name = ?",
+                (table_name,),
+            )
+        else:
+            cur.execute("SELECT * FROM automation_rules")
+        rows = cur.fetchall()
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, r)) for r in rows]
+
+
+def increment_run_count(rule_id: int) -> None:
+    with get_connection() as conn:
+        conn.execute(
+            "UPDATE automation_rules SET run_count = COALESCE(run_count,0)+1, "
+            "last_run = datetime('now') WHERE id = ?",
+            (rule_id,),
+        )
+        conn.commit()
+
+
+def reset_run_count(rule_id: int) -> None:
+    with get_connection() as conn:
+        conn.execute(
+            "UPDATE automation_rules SET run_count = 0 WHERE id = ?",
+            (rule_id,),
+        )
+        conn.commit()

--- a/imports/tasks.py
+++ b/imports/tasks.py
@@ -61,6 +61,9 @@ def _run_import(job_id, table, rows):
                     job_id, imported_rows=idx, errors=json.dumps(errors)
                 )
         _update_import_status(job_id, status="complete")
+        # trigger automation rules that run on import
+        from automation import engine as automation_engine
+        automation_engine.run_import_rules(table)
         logger.info(
             "Import job %s for table %s complete: %s rows imported, %s errors",
             job_id,

--- a/static/js/automation.js
+++ b/static/js/automation.js
@@ -1,0 +1,17 @@
+async function fetchRules() {
+  const resp = await fetch('/admin/api/automation/rules');
+  const rules = await resp.json();
+  const table = document.getElementById('rules-table');
+  table.innerHTML = '<tr><th>ID</th><th>Name</th><th>Table</th><th>Runs</th><th></th></tr>' +
+    rules.map(r => `<tr><td>${r.id}</td><td>${r.name}</td><td>${r.table_name}</td><td>${r.run_count || 0}</td><td><button data-id="${r.id}" class="run">Run</button></td></tr>`).join('');
+}
+
+document.addEventListener('click', async e => {
+  if (e.target.classList.contains('run')) {
+    const id = e.target.getAttribute('data-id');
+    await fetch(`/admin/api/automation/rules/${id}/run`, {method:'POST'});
+    fetchRules();
+  }
+});
+
+document.addEventListener('DOMContentLoaded', fetchRules);

--- a/templates/admin/admin_automation.html
+++ b/templates/admin/admin_automation.html
@@ -1,8 +1,11 @@
 {% extends "base.html" %}
-
 {% block title %}Automation{% endblock %}
-
+{% block scripts %}
+<script type="module" src="{{ url_for('static', filename='js/automation.js') }}"></script>
+{% endblock %}
 {% block content %}
-<h1 class="text-3xl font-bold mb-4">Automation</h1>
-<p class="text-gray-600">This page is under construction.</p>
+<h1 class="text-3xl font-bold mb-4">Automation Rules</h1>
+<table id="rules-table" class="min-w-full text-sm"></table>
+<button id="new-rule" class="btn">New Rule</button>
+<div id="rule-form" class="hidden"></div>
 {% endblock %}

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import sqlite3
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from main import app
+from imports import tasks as import_tasks
+from db.automation import create_rule, get_rules, reset_run_count
+from db.records import delete_record
+from automation import engine
+
+app.testing = True
+client = app.test_client()
+DB_PATH = 'data/crossbook.db'
+
+
+def test_rule_runs_on_import():
+    import_tasks.huey.immediate = True
+    engine.huey.immediate = True
+    rule_id = create_rule(
+        'AutoDesc',
+        'character',
+        'character',
+        'equals',
+        'AutoTest',
+        'description',
+        'RULED',
+        True,
+        'none',
+    )
+    from db.records import create_record
+    rec_id = create_record('character', {'character': 'AutoTest', 'description': 'orig'})
+    engine.run_import_rules('character')
+    with sqlite3.connect(DB_PATH) as conn:
+        row = conn.execute("SELECT description FROM character WHERE id=?", (rec_id,)).fetchone()
+        assert row is not None
+        desc = row[0]
+    assert desc == 'RULED'
+    delete_record('character', rec_id)
+    reset_run_count(rule_id)
+
+def test_run_count_reset():
+    engine.huey.immediate = True
+    rule_id = create_rule(
+        'CountRule',
+        'character',
+        'character',
+        'equals',
+        'Ajihad',
+        'description',
+        'X',
+        False,
+        'none',
+    )
+    engine.run_rule(rule_id)
+    rules = [r for r in get_rules() if r['id'] == rule_id]
+    assert rules[0]['run_count'] >= 1
+    reset_run_count(rule_id)
+    rules = [r for r in get_rules() if r['id'] == rule_id]
+    assert rules[0]['run_count'] == 0

--- a/views/admin/__init__.py
+++ b/views/admin/__init__.py
@@ -39,6 +39,7 @@ def admin_html_redirect():
 from . import dashboard  # noqa: F401  # register routes
 from . import config  # noqa: F401  # register routes
 from . import imports  # noqa: F401  # register routes
+from . import automation  # noqa: F401  # register routes
 
 __all__ = [
     'admin_bp',

--- a/views/admin/automation.py
+++ b/views/admin/automation.py
@@ -1,0 +1,87 @@
+import logging
+from flask import request, jsonify
+from db.automation import (
+    create_rule,
+    update_rule,
+    delete_rule,
+    get_rules,
+    reset_run_count,
+)
+from automation.engine import run_rule
+from db.database import get_connection
+from db.edit_history import get_edit_entry, revert_edit
+from . import admin_bp
+
+logger = logging.getLogger(__name__)
+
+
+@admin_bp.route('/admin/api/automation/rules')
+def list_rules():
+    return jsonify(get_rules())
+
+
+@admin_bp.route('/admin/api/automation/rules', methods=['POST'])
+def create_rule_route():
+    data = request.get_json(silent=True) or {}
+    rule_id = create_rule(
+        data.get('name', ''),
+        data.get('table_name', ''),
+        data.get('condition_field', ''),
+        data.get('condition_operator', 'equals'),
+        data.get('condition_value', ''),
+        data.get('action_field', ''),
+        data.get('action_value', ''),
+        bool(data.get('run_on_import')),
+        data.get('schedule', 'none'),
+    )
+    return jsonify({'id': rule_id})
+
+
+@admin_bp.route('/admin/api/automation/rules/<int:rule_id>', methods=['POST'])
+def update_rule_route(rule_id):
+    data = request.get_json(silent=True) or {}
+    update_rule(rule_id, **data)
+    return jsonify({'success': True})
+
+
+@admin_bp.route('/admin/api/automation/rules/<int:rule_id>/delete', methods=['POST'])
+def delete_rule_route(rule_id):
+    delete_rule(rule_id)
+    return jsonify({'success': True})
+
+
+@admin_bp.route('/admin/api/automation/rules/<int:rule_id>/run', methods=['POST'])
+def run_rule_route(rule_id):
+    count = run_rule(rule_id)
+    return jsonify({'updated': count})
+
+
+@admin_bp.route('/admin/api/automation/rules/<int:rule_id>/reset', methods=['POST'])
+def reset_rule_route(rule_id):
+    reset_run_count(rule_id)
+    return jsonify({'success': True})
+
+
+@admin_bp.route('/admin/api/automation/rules/<int:rule_id>/logs')
+def rule_logs(rule_id):
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT id, table_name, record_id, timestamp, field_name, old_value, new_value, actor "
+            "FROM edit_history WHERE actor = ? ORDER BY id DESC LIMIT 20",
+            (f'rule:{rule_id}',),
+        )
+        rows = cur.fetchall()
+        cols = [d[0] for d in cur.description]
+        return jsonify([dict(zip(cols, r)) for r in rows])
+
+
+@admin_bp.route('/admin/api/automation/rollback', methods=['POST'])
+def rollback_entry():
+    data = request.get_json(silent=True) or {}
+    entry_id = int(data.get('entry_id', 0))
+    entry = get_edit_entry(entry_id)
+    if not entry:
+        return jsonify({'error': 'not_found'}), 404
+    revert_edit(entry)
+    return jsonify({'success': True})


### PR DESCRIPTION
## Summary
- add simple automation rule storage and engine
- hook into imports after job completion
- expose admin API endpoints and placeholder JS/HTML
- document running automation rules
- include basic automation tests

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError database is locked)*

------
https://chatgpt.com/codex/tasks/task_e_6851a1d768848333b73fb46bdf0ab3ee