### PR TITLE
Add color preset button styling

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -100,6 +100,16 @@ a:hover {
   display: inline-block;
 }
 
+/* Color preset button */
+.color-btn {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0.25rem;
+  border: 1px solid #d1d5db; /* tailwind gray-300 */
+  background-color: var(--btn-color);
+  display: inline-block;
+}
+
 .btn-primary { background-color: var(--color-primary); }
 .btn-secondary { background-color: var(--color-secondary); }
 .btn-danger { background-color: var(--color-danger); }

--- a/static/js/field_styling.js
+++ b/static/js/field_styling.js
@@ -89,9 +89,15 @@ document.addEventListener('DOMContentLoaded', () => {
     menu.dispatchEvent(new Event('change'));
   });
   const presetColors = ['#000000', '#ef4444', '#3b82f6', '#10b981', '#f59e0b', '#8b5cf6'];
-  presetsDiv.innerHTML = presetColors.map(c =>
-    `<button type="button" data-color="${c}" class="w-4 h-4 rounded border" style="background-color:${c}"></button>`
-  ).join('');
+  presetsDiv.innerHTML = '';
+  presetColors.forEach(c => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.dataset.color = c;
+    btn.className = 'color-btn';
+    btn.style.setProperty('--btn-color', c);
+    presetsDiv.appendChild(btn);
+  });
   presetsDiv.addEventListener('click', e => {
     if (e.target.dataset.color) {
       selectedColor = e.target.dataset.color;


### PR DESCRIPTION
## Summary
- make `.color-btn` class for color preset buttons and use CSS variable `--btn-color`
- generate color preset buttons dynamically in `field_styling.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a53fb178833387918ddb6911193c