### PR TITLE
Remove Tailwind CDN and use custom styles

### DIFF
--- a/db/automation.py
+++ b/db/automation.py
@@ -1,4 +1,6 @@
 import logging
+import sqlite3
+import time
 from db.database import get_connection
 
 logger = logging.getLogger(__name__)
@@ -82,13 +84,22 @@ def get_rules(table_name: str | None = None) -> list[dict]:
 
 
 def increment_run_count(rule_id: int) -> None:
-    with get_connection() as conn:
-        conn.execute(
-            "UPDATE automation_rules SET run_count = COALESCE(run_count,0)+1, "
-            "last_run = datetime('now') WHERE id = ?",
-            (rule_id,),
-        )
-        conn.commit()
+    """Increment the run counter for a rule, retrying if the database is locked."""
+    for _ in range(5):
+        try:
+            with get_connection() as conn:
+                conn.execute(
+                    "UPDATE automation_rules SET run_count = COALESCE(run_count,0)+1, "
+                    "last_run = datetime('now') WHERE id = ?",
+                    (rule_id,),
+                )
+                conn.commit()
+            return
+        except sqlite3.OperationalError as exc:
+            if 'locked' in str(exc).lower():
+                time.sleep(0.1)
+                continue
+            raise
 
 
 def reset_run_count(rule_id: int) -> None:

--- a/db/records.py
+++ b/db/records.py
@@ -195,6 +195,14 @@ def create_record(table, form_data):
 
             cursor.execute(sql, params)
             record_id = cursor.lastrowid
+            # Some tables define an `id` column without autoincrement. If the
+            # insert omitted an id value, populate it with the rowid so future
+            # queries can reference the record.
+            if "id" in cols and "id" not in field_names:
+                cursor.execute(
+                    f"UPDATE {table} SET id = ? WHERE rowid = ?",
+                    (record_id, record_id),
+                )
             conn.commit()
             return record_id
         except Exception as e:

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -229,3 +229,64 @@ a:hover {
   box-shadow: 0 4px 6px rgba(0,0,0,0.1); /* shadow-lg */
   padding: 0.5rem; /* p-2 */
 }
+/* Layout classes converted from Tailwind */
+.flex { display: flex; }
+.flex-col { flex-direction: column; }
+.flex-1 { flex: 1 1 auto; }
+.items-center { align-items: center; }
+.justify-between { justify-content: space-between; }
+.justify-center { justify-content: center; }
+.space-x-1 > * + * { margin-left: 0.25rem; }
+.space-x-2 > * + * { margin-left: 0.5rem; }
+.space-y-2 > * + * { margin-top: 0.5rem; }
+.hidden { display: none; }
+.block { display: block; }
+.min-h-screen { min-height: 100vh; }
+.fixed { position: fixed; }
+.top-0 { top: 0; }
+.left-0 { left: 0; }
+.z-40 { z-index: 40; }
+.w-56 { width: 14rem; }
+.w-6 { width: 1.5rem; }
+.w-3 { width: 0.75rem; }
+.h-6 { height: 1.5rem; }
+.h-screen { height: 100vh; }
+.pt-4 { padding-top: 1rem; }
+.p-2 { padding: 0.5rem; }
+.p-4 { padding: 1rem; }
+.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.mt-16 { margin-top: 4rem; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-10 { margin-bottom: 2.5rem; }
+.text-lg { font-size: 1.125rem; }
+.text-2xl { font-size: 1.5rem; }
+.text-4xl { font-size: 2.25rem; }
+.text-5xl { font-size: 3rem; line-height: 1; }
+.font-bold { font-weight: bold; }
+.text-center { text-align: center; }
+.text-white { color: #ffffff; }
+.text-gray-100 { color: #f3f4f6; }
+.cursor-pointer { cursor: pointer; }
+.rounded { border-radius: 0.25rem; }
+.shadow-md { box-shadow: 0 4px 6px rgba(0,0,0,0.1); }
+.gap-6 { gap: 1.5rem; }
+.max-w-5xl { max-width: 64rem; }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.grid { display: grid; }
+.grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+@media (min-width: 640px) { .sm\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (min-width: 1024px) { .lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+@media (min-width: 768px) {
+  .md\:block { display: block; }
+  .md\:ml-56 { margin-left: 14rem; }
+  .md\:pl-56 { padding-left: 14rem; }
+}
+/* Home page styles */
+.index-heading { text-align: center; margin-bottom: 2.5rem; font-size: 2.25rem; font-weight: bold; }
+.card-grid { display: grid; grid-template-columns: repeat(1, minmax(0, 1fr)); gap: 1.5rem; max-width: 64rem; margin-left: auto; margin-right: auto; }
+@media (min-width: 640px) { .card-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (min-width: 1024px) { .card-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+.icon-card { display: flex; align-items: center; justify-content: center; }
+.icon-plus { color: #0d9488; font-size: 3rem; font-weight: bold; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=IBM+Plex+Sans:wght@400;500;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/overrides.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,8 +11,8 @@
 {% endblock %}
 
 {% block content %}
-<h1 class="text-4xl font-bold text-center mb-10">{{ heading }}</h1>
-<div id="card-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
+<h1 class="index-heading">{{ heading }}</h1>
+<div id="card-grid" class="card-grid">
   <a href="/dashboard" class="card-link">
     <h2 class="text-2xl font-bold mb-2">Dashboard</h2>
     <p class="text-light">View overall summary and stats</p>
@@ -24,8 +24,8 @@
     <p class="text-light">{{ card.description }}</p>
   </a>
   {% endfor %}
-  <a href="#" onclick="openAddTableModal()" class="card-link flex items-center justify-center">
-    <span class="text-teal-600 text-5xl font-bold">+</span>
+  <a href="#" onclick="openAddTableModal()" class="card-link icon-card">
+    <span class="icon-plus">+</span>
   </a>
 </div>
 


### PR DESCRIPTION
## Summary
- drop Tailwind CDN in `base.html`
- implement minimal utility styles in `styles.css`
- redesign home page to use new CSS classes
- make `create_record` populate `id` when tables don't autoincrement
- harden automation run count updates against locked database

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851ad07f1fc83338c199f33f1d48c0f