### PR TITLE
Refactor forms away from inline Tailwind

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -232,3 +232,54 @@ a:hover {
   max-height: 85vh;
   overflow: auto;
 }
+/* Form heading */
+.form-heading {
+  font-size: 1.5rem; /* text-2xl */
+  font-weight: 700;
+  margin-bottom: 1.5rem; /* mb-6 */
+}
+
+/* Vertical form layout */
+.form-layout > * + * {
+  margin-top: 1rem; /* space-y-4 */
+}
+
+.form-label {
+  display: block;
+  font-size: 0.875rem; /* text-sm */
+  font-weight: 500; /* font-medium */
+  text-transform: capitalize;
+  margin-bottom: 0.25rem; /* mb-1 */
+}
+
+.form-input {
+  width: 100%;
+  border: 1px solid var(--color-primary-light);
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem; /* py-1 px-2 */
+  font-size: 0.875rem; /* text-sm */
+}
+
+.modal-box {
+  background-color: #fff;
+  color: #000;
+  padding: 1.5rem; /* p-6 */
+  border-radius: 0.5rem; /* rounded-lg */
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1); /* shadow-lg */
+  width: 24rem; /* w-96 */
+  max-width: 100%;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.5rem; /* top-2 */
+  right: 0.5rem; /* right-2 */
+  font-size: 1.25rem; /* text-xl */
+  color: #4b5563; /* text-gray-600 */
+  cursor: pointer;
+}
+
+.modal-close:hover {
+  color: #1f2937; /* text-gray-800 */
+}

--- a/templates/modals/add_table_modal.html
+++ b/templates/modals/add_table_modal.html
@@ -1,19 +1,19 @@
 <div id="addTableModal" class="modal-container hidden" onclick="if(event.target.id === 'addTableModal') closeAddTableModal()">
-  <div class="bg-white text-black p-6 rounded-lg shadow-lg w-96 max-w-full relative">
-    <button type="button" onclick="closeAddTableModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
+  <div class="modal-box">
+    <button type="button" onclick="closeAddTableModal()" class="modal-close">&times;</button>
     <h3 class="text-lg font-bold mb-4">Add new base table</h3>
     <div id="tableError" class="text-red-600 hidden"></div>
-    <form onsubmit="submitNewTable(event)" class="space-y-4">
+    <form onsubmit="submitNewTable(event)" class="form-layout">
       <div>
-        <label for="tableName" class="block mb-1">Table Name</label>
-        <input id="tableName" type="text" class="w-full border rounded p-2" required />
+        <label for="tableName" class="form-label">Table Name</label>
+        <input id="tableName" type="text" class="form-input" required />
       </div>
       <div>
-        <label for="tableDescription" class="block mb-1">Description</label>
-        <textarea id="tableDescription" class="w-full border rounded p-2"></textarea>
+        <label for="tableDescription" class="form-label">Description</label>
+        <textarea id="tableDescription" class="form-input"></textarea>
       </div>
       <div class="flex justify-end">
-        <button type="submit" class="btn-primary px-4 py-2 rounded">Add</button>
+        <button type="submit" class="btn-primary">Add</button>
       </div>
     </form>
   </div>

--- a/templates/modals/bulk_edit_modal.html
+++ b/templates/modals/bulk_edit_modal.html
@@ -1,13 +1,13 @@
 <div id="bulkEditModal" class="modal-container hidden"
      onclick="if(event.target.id === 'bulkEditModal') closeBulkEditModal()">
-  <div class="bg-white text-black p-6 rounded-lg shadow-lg w-96 max-w-full relative">
-    <button type="button" onclick="closeBulkEditModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
+  <div class="modal-box">
+    <button type="button" onclick="closeBulkEditModal()" class="modal-close">&times;</button>
     <h3 class="text-lg font-bold">Bulk Edit {{ table }}</h3>
     <p id="bulk-edit-count" class="text-sm text-gray-600 mb-4"></p>
-    <form id="bulk-edit-form" class="space-y-4">
+    <form id="bulk-edit-form" class="form-layout">
       <div>
-        <label for="bulk-field" class="block text-sm font-medium text-gray-700 mb-1">Field</label>
-        <select id="bulk-field" class="w-full border px-2 py-1 rounded">
+        <label for="bulk-field" class="form-label">Field</label>
+        <select id="bulk-field" class="form-input">
           {% for field, meta in field_schema[table].items() if not field.startswith('_') %}
             <option value="{{ field }}" data-type="{{ meta.type }}" data-options='{{ meta.options | tojson | e }}'>{{ field }}</option>
           {% endfor %}
@@ -16,7 +16,7 @@
       <div id="bulk-input-container"></div>
       <div id="bulk-edit-status" class="text-sm hidden"></div>
       <div class="text-right">
-        <button type="submit" class="btn-primary px-3 py-1 rounded">Submit</button>
+        <button type="submit" class="btn-primary">Submit</button>
       </div>
     </form>
   </div>

--- a/templates/modals/create_db_modal.html
+++ b/templates/modals/create_db_modal.html
@@ -1,15 +1,15 @@
 <div id="createDbModal" class="modal-container hidden" onclick="if(event.target.id === 'createDbModal') closeCreateDbModal()">
-  <div class="bg-white text-black p-6 rounded-lg shadow-lg w-96 max-w-full relative">
-    <button type="button" onclick="closeCreateDbModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
+  <div class="modal-box">
+    <button type="button" onclick="closeCreateDbModal()" class="modal-close">&times;</button>
     <h3 class="text-lg font-bold mb-4">Create New Database</h3>
     <div id="create-db-error" class="text-red-600 hidden mb-2"></div>
-    <form id="create-db-form" onsubmit="submitCreateDb(event)" class="space-y-4">
+    <form id="create-db-form" onsubmit="submitCreateDb(event)" class="form-layout">
       <div>
-        <label for="create-db-name" class="block mb-1">Filename (.db)</label>
-        <input id="create-db-name" type="text" class="w-full border rounded p-2" required>
+        <label for="create-db-name" class="form-label">Filename (.db)</label>
+        <input id="create-db-name" type="text" class="form-input" required>
       </div>
       <div class="flex justify-end">
-        <button type="submit" class="btn-primary px-4 py-2 rounded">Create</button>
+        <button type="submit" class="btn-primary">Create</button>
       </div>
     </form>
   </div>

--- a/templates/new_record.html
+++ b/templates/new_record.html
@@ -2,30 +2,30 @@
 {% block title %}New {{ table|capitalize }}{% endblock %}
 
 {% block content %}
-<h1 class="text-2xl font-bold mb-6">Create New {{ table|capitalize }}</h1>
+<h1 class="form-heading">Create New {{ table|capitalize }}</h1>
 
-<form id="new-record-form" method="post" class="space-y-4">
+<form id="new-record-form" method="post" class="form-layout">
   {% for field, ftype in fields.items() %}
     {% if field != "id" and ftype != "hidden" %}
       <div>
-        <label class="block text-sm font-medium capitalize mb-1">{{ field }}</label>
+        <label class="form-label">{{ field }}</label>
         {% if ftype == "textarea" %}
           <input type="hidden" name="{{ field }}">
           <div class="quill-editor" data-quill></div>
         {% elif ftype == "boolean" %}
           <input type="checkbox" name="{{ field }}" value="1">
         {% elif ftype == "number" %}
-          <input type="number" name="{{ field }}" class="w-full border rounded px-2 py-1 text-sm">
+          <input type="number" name="{{ field }}" class="form-input">
         {% elif ftype == "date" %}
-          <input type="date" name="{{ field }}" class="w-full border rounded px-2 py-1 text-sm">
+          <input type="date" name="{{ field }}" class="form-input">
         {% else %}
-          <input type="text" name="{{ field }}" class="w-full border rounded px-2 py-1 text-sm">
+          <input type="text" name="{{ field }}" class="form-input">
         {% endif %}
       </div>
     {% endif %}
   {% endfor %}
 
-  <button type="submit" class="btn-primary px-4 py-2 rounded">Create</button>
+  <button type="submit" class="btn-primary">Create</button>
 </form>
 <script type="module" src="{{ url_for('static', filename='js/editor.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add reusable form and modal classes in `styles.css`
- replace inline Tailwind classes in `new_record.html`
- use new classes for modal templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685269b2b0808333bb7813ece40eacc0