### PR TITLE
Align dark mode components

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -261,8 +261,8 @@ a:hover {
 }
 
 .modal-box {
-  background-color: #fff;
-  color: #000;
+  background-color: var(--bg-card);
+  color: var(--text-light);
   padding: 1.5rem; /* p-6 */
   border-radius: 0.5rem; /* rounded-lg */
   box-shadow: 0 4px 6px rgba(0,0,0,0.1); /* shadow-lg */
@@ -276,10 +276,10 @@ a:hover {
   top: 0.5rem; /* top-2 */
   right: 0.5rem; /* right-2 */
   font-size: 1.25rem; /* text-xl */
-  color: #4b5563; /* text-gray-600 */
+  color: var(--text-light);
   cursor: pointer;
 }
 
 .modal-close:hover {
-  color: #1f2937; /* text-gray-800 */
+  color: var(--color-primary-light);
 }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -33,7 +33,7 @@
       'rowStart': row_start,
       'rowSpan': row_span
     } }) %}
-    <div id="widget-{{ widget.id }}" class="dashboard-widget draggable-field min-h-0 border p-2 rounded shadow bg-gray-50"
+    <div id="widget-{{ widget.id }}" class="dashboard-widget draggable-field min-h-0 border p-2 rounded shadow bg-card"
          data-widget="{{ widget.id }}"
          data-type="{{ widget.widget_type }}"
          {% if widget.widget_type in ['chart', 'value'] %}data-config='{{ widget.content }}'{% endif %}

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -106,7 +106,7 @@
           {% if styling.color %}{% set _ = style_parts.append('--field-color:' ~ styling.color) %}{% endif %}
           {% if styling.size %}{% set _ = style_parts.append('--field-size:' ~ styling.size ~ 'px') %}{% endif %}
           <div id="draggable-field-{{ field }}"
-               class="draggable-field border p-2 rounded shadow bg-gray-50{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }}"
+               class="draggable-field border p-2 rounded shadow bg-card text-light{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }}"
                data-field="{{ field }}"
                data-type="{{ field_schema[table][field].type }}"
                data-styling='{{ styling | tojson }}'

--- a/templates/import_view.html
+++ b/templates/import_view.html
@@ -41,7 +41,7 @@
         <h2 class="text-xl font-semibold mb-2">Available Fields for {{ file_name|default('Imported File') }}</h2>
         <div class="grid grid-cols-1 gap-2 text-sm text-gray-700" id="imported-fields-container">
             {% for header in parsed_headers %}
-            <div class="border px-3 py-2 rounded bg-gray-50" id="match-container-{{ header }}">
+            <div class="border px-3 py-2 rounded bg-card text-light" id="match-container-{{ header }}">
               <div class="flex justify-between items-center">
                 <strong>{{ header }}</strong>
                 <div id="select-wrapper-{{ header }}" class="ml-auto">
@@ -64,7 +64,7 @@
       <h2 class="text-xl font-semibold mb-2">Available Fields for '{{ selected_table }}'</h2>
       <div class="grid grid-cols-1 gap-2 text-sm text-gray-700" id="available-fields-list">
         {% for field, data in field_status.items() %}
-        <div class="border px-3 py-2 rounded bg-gray-50">
+        <div class="border px-3 py-2 rounded bg-card text-light">
             <strong>{{ field }}</strong> — {{ data.type }} — matched: {{ data.matched }}
         </div>
         {% endfor %}

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -69,7 +69,7 @@
         {% endfor %}
       </div>
 
-      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
+      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
         Choose Tags
       </button>
 
@@ -141,7 +141,7 @@
         {% endfor %}
       </div>
 
-      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
+      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
         Choose Tags
       </button>
 

--- a/templates/macros/filter_controls.html
+++ b/templates/macros/filter_controls.html
@@ -1,7 +1,7 @@
 {# templates/macros/filter_controls.html #}
 
 {%- macro text_filter(field, value, operator) -%}
-  <div class="filter-chip flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1 border border-gray-300">
+  <div class="filter-chip flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light">
     <select
       name="{{ field }}_op"
       class="operator-select appearance-none text-xs rounded-full border-0 bg-transparent text-center text-teal-600 cursor-pointer w-auto"
@@ -26,7 +26,7 @@
 {%- endmacro -%}
 
 {%- macro select_filter(field, value, options) -%}
-  <div class="filter-chip flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1 border border-gray-300">
+  <div class="filter-chip flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light">
     <select
       name="{{ field }}"
       class="bg-transparent text-sm rounded px-1 py-0.5"
@@ -44,7 +44,7 @@
 
 {%- macro multi_select_popover(field, selected, options, mode) -%}
     {% set actual = selected | reject('equalto', '') | list %}
-<div class="relative filter-chip flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1 border border-gray-300">
+<div class="relative filter-chip flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light">
   <button
     type="button"
     class="multi-select-chip bg-transparent text-sm focus:outline-none"
@@ -81,7 +81,7 @@
 
 {%- macro select_multi_filter(field, selected, options) -%}
   {% set actual = selected | reject('equalto', '') | list %}
-  <div class="filter-chip select-multi-filter flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1 border border-gray-300" data-field="{{ field }}">
+  <div class="filter-chip select-multi-filter flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light" data-field="{{ field }}">
     <span class="text-xs border border-gray-400 rounded px-1 mr-1">{{ field | replace('_',' ') | capitalize }}</span>
     <div class="flex flex-col max-h-32 overflow-y-auto">
       {% for opt in options %}
@@ -96,7 +96,7 @@
 {%- endmacro -%}
 
 {% macro boolean_filter(field, value) %}
-  <div class="filter-chip flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1 border border-gray-300">
+  <div class="filter-chip flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light">
     <select
       name="{{ field }}"
       class="bg-transparent text-sm rounded px-1 py-0.5"
@@ -111,7 +111,7 @@
 {% endmacro %}
 
 {%- macro number_filter(field, min_val, max_val) -%}
-  <div class="filter-chip flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1 border border-gray-400">
+  <div class="filter-chip flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light">
     <span class="text-xs border border-gray-400 rounded px-1 mr-1">
       {{ field | replace('_',' ') | capitalize }}
     </span>
@@ -134,7 +134,7 @@
 {%- endmacro -%}
 
 {%- macro date_filter(field, start_val, end_val) -%}
-  <div class="filter-chip flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1 border border-gray-400">
+  <div class="filter-chip flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light">
     <span class="text-xs border border-gray-400 rounded px-1 mr-1">
       {{ field | replace('_',' ') | capitalize }}
     </span>

--- a/templates/modals/dashboard_modal.html
+++ b/templates/modals/dashboard_modal.html
@@ -33,7 +33,7 @@
 
         <div id="mathField1" class="flex items-start gap-2 mb-2 hidden">
           <div class="relative flex-grow">
-            <button id="mathSelect1Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
+            <button id="mathSelect1Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="mathSelect1Options" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
@@ -63,7 +63,7 @@
 
         <div id="mathField2" class="flex items-start gap-2 mb-2 hidden">
           <div class="relative flex-grow">
-            <button id="mathSelect2Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
+            <button id="mathSelect2Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="mathSelect2Options" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
@@ -80,7 +80,7 @@
           </div>
         </div>
 
-        <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left focus:outline-none focus:ring-2 focus:ring-teal-600 hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>
+        <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left focus:outline-none focus:ring-2 focus:ring-teal-600 hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>
         <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
         <div id="resultRow" class="mt-4 flex items-center justify-center gap-2 hidden">
           <input id="valueTitleInput" type="text" class="px-3 py-2 border rounded flex-grow" />
@@ -119,7 +119,7 @@
         </div>
         <div id="selectCountFieldContainer" class="mb-4 hidden">
           <div class="relative">
-            <button id="selectCountFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
+            <button id="selectCountFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="selectCountFieldOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
@@ -127,7 +127,7 @@
         </div>
         <div id="topNumericFieldContainer" class="mb-4 hidden">
           <div class="relative">
-            <button id="topNumericFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
+            <button id="topNumericFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="topNumericFieldOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
@@ -145,14 +145,14 @@
         </div>
         <div id="filteredRecordsContainer" class="mb-4 hidden">
           <div class="relative mb-2">
-            <button id="filteredTableToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
+            <button id="filteredTableToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Table</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="filteredTableOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
           </div>
           <input id="filteredSearchInput" type="text" placeholder="Search" class="w-full px-3 py-2 border rounded mb-2" />
           <div class="relative mb-2">
-            <button id="filteredSortToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
+            <button id="filteredSortToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Sort Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="filteredSortOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
@@ -175,7 +175,7 @@
       <form id="chartWidgetForm" class="relative w-full" onsubmit="event.preventDefault();">
         <div class="mb-4">
           <label for="chartTypeSelect" class="block text-sm font-medium mb-1">Chart Type</label>
-          <select id="chartTypeSelect" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black">
+          <select id="chartTypeSelect" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light">
             <option value="" selected disabled>Select Chart Type</option>
             <option value="bar">Bar</option>
             <option value="line">Line</option>
@@ -185,7 +185,7 @@
         <div id="chartXFieldContainer" class="mb-4 hidden">
           <label id="chartXFieldLabel" class="block text-sm font-medium mb-1">X Field</label>
           <div class="relative">
-            <button id="chartXFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
+            <button id="chartXFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="chartXFieldOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
@@ -204,7 +204,7 @@
         <div id="chartYFieldContainer" class="mb-4 hidden">
           <label class="block text-sm font-medium mb-1">Y Field</label>
           <div class="relative">
-            <button id="chartYFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-black text-left flex items-center justify-between">
+            <button id="chartYFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="chartYFieldOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>

--- a/templates/wizard/wizard_table.html
+++ b/templates/wizard/wizard_table.html
@@ -19,7 +19,7 @@
   <div>
     <h2 class="font-semibold mb-2">Fields</h2>
     <ul id="fields-list" class="mb-2 list-disc pl-5"></ul>
-    <button type="button" onclick="showAddFieldModal()" class="bg-gray-200 px-2 py-1 rounded">Add Field</button>
+    <button type="button" onclick="showAddFieldModal()" class="btn-secondary px-2 py-1 rounded">Add Field</button>
   </div>
   <button type="submit" class="btn-primary px-4 py-2 rounded">Continue</button>
   <a href="{{ url_for('wizard.settings_step') }}" class="ml-4 text-primary underline">Back</a>


### PR DESCRIPTION
## Summary
- set modal boxes to dark theme
- darken filter chips
- update multi-select buttons for dark mode
- use dark backgrounds for dashboard widgets and import view
- style detail view cards and wizard button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526cb22c6c83338238c146733f2453