### PR TITLE
Fix modal close buttons

### DIFF
--- a/templates/admin/admin_automation.html
+++ b/templates/admin/admin_automation.html
@@ -7,7 +7,7 @@
 
 <div id="ruleModal" class="modal-container hidden" onclick="if(event.target.id === 'ruleModal') closeRuleModal()">
   <div class="modal-box w-96 max-w-full relative">
-    <button type="button" onclick="closeRuleModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
+    <button type="button" onclick="closeRuleModal()" class="modal-close">&times;</button>
     <h3 id="ruleModalTitle" class="text-lg font-bold mb-4">New Rule</h3>
     <form id="rule-form" class="space-y-4">
       <input type="hidden" id="rule-id">
@@ -63,7 +63,7 @@
 
 <div id="logsModal" class="modal-container hidden" onclick="if(event.target.id === 'logsModal') closeLogsModal()">
   <div class="modal-box w-fit max-w-full relative">
-    <button type="button" onclick="closeLogsModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
+    <button type="button" onclick="closeLogsModal()" class="modal-close">&times;</button>
     <h3 class="text-lg font-bold mb-4">Recent Logs</h3>
     <table id="logs-table" class="min-w-full text-sm divide-y mb-4"></table>
   </div>

--- a/templates/modals/dashboard_modal.html
+++ b/templates/modals/dashboard_modal.html
@@ -2,7 +2,7 @@
 <div id="dashboardModal" class="modal-container hidden"
      onclick="if(event.target.id === 'dashboardModal') closeDashboardModal()">
   <div class="modal-box w-fit min-w-[24rem] max-w-full relative">
-    <button onclick="closeDashboardModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
+    <button onclick="closeDashboardModal()" class="modal-close">&times;</button>
     <div class="mb-4 border-b border-gray-200">
       <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="dashboardTab" role="tablist">
         <li class="mr-2" role="presentation">

--- a/templates/modals/edit_fields_modal.html
+++ b/templates/modals/edit_fields_modal.html
@@ -1,7 +1,7 @@
 <div id="layoutModal" class="modal-container hidden"
      onclick="if(event.target.id === 'layoutModal') closeLayoutModal()">
   <div class="modal-box w-96 max-w-full relative">
-    <button type="button" onclick="closeLayoutModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
+    <button type="button" onclick="closeLayoutModal()" class="modal-close">&times;</button>
     <div class="mb-4 border-b border-gray-200">
       <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="editFieldsTabs" role="tablist">
         <li class="mr-2" role="presentation">

--- a/templates/modals/validation_modal.html
+++ b/templates/modals/validation_modal.html
@@ -1,6 +1,6 @@
 <div id="validationOverlay" class="modal-container hidden" onclick="if(event.target.id === 'validationOverlay') this.classList.add('hidden')">
   <div id="validation-popup" class="modal-box w-auto max-w-[70vw] max-h-[66vh] overflow-auto relative">
-    <button type="button" onclick="document.getElementById('validationOverlay').classList.add('hidden')" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
+    <button type="button" onclick="document.getElementById('validationOverlay').classList.add('hidden')" class="modal-close">&times;</button>
     <!-- Validation messages get injected here -->
   </div>
 </div>

--- a/templates/wizard/wizard_table.html
+++ b/templates/wizard/wizard_table.html
@@ -28,7 +28,7 @@
 <!-- Add Field Modal -->
 <div id="addFieldModal" class="modal-container hidden" onclick="if(event.target.id === 'addFieldModal') hideAddFieldModal()">
   <div class="modal-box w-96 max-w-full relative">
-    <button type="button" onclick="hideAddFieldModal()" class="absolute top-2 right-2 text-gray-600 hover:text-gray-800 text-xl">&times;</button>
+    <button type="button" onclick="hideAddFieldModal()" class="modal-close">&times;</button>
     <form id="field-form" class="space-y-4">
       <div>
         <label class="block mb-2 text-sm font-medium">Field Name</label>


### PR DESCRIPTION
## Summary
- ensure all modal close buttons use `.modal-close`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685275257af083338b3ae40f5316ac5b