### PR TITLE
Add form-group classes to wizard templates

### DIFF
--- a/templates/wizard/wizard_database.html
+++ b/templates/wizard/wizard_database.html
@@ -3,11 +3,11 @@
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">Step 1: Choose or Create Database</h1>
 <form method="post" enctype="multipart/form-data" class="space-y-4">
-  <div>
+  <div class="form-group">
     <label class="block mb-1">Upload Database File</label>
     <input type="file" name="file" accept=".db" class="form-control">
   </div>
-  <div>
+  <div class="form-group">
     <label class="block mb-1">Or create new database</label>
     <input type="text" name="create_name" class="form-control" placeholder="name.db">
   </div>

--- a/templates/wizard/wizard_import.html
+++ b/templates/wizard/wizard_import.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">Step 4: Import CSV Data (optional)</h1>
 <form method="post" enctype="multipart/form-data" class="space-y-4">
-  <div>
+  <div class="form-group">
     <label class="block mb-1">Table</label>
     <select name="table" class="form-control">
       {% for t in base_tables %}
@@ -11,7 +11,7 @@
       {% endfor %}
     </select>
   </div>
-  <div>
+  <div class="form-group">
     <label class="block mb-1">CSV File</label>
     <input type="file" name="file" accept=".csv" class="form-control">
   </div>

--- a/templates/wizard/wizard_settings.html
+++ b/templates/wizard/wizard_settings.html
@@ -8,7 +8,7 @@
   {% set key = item.key %}
   {% set typ = item.type %}
   {% set default = item.value %}
-  <div class="setting-field" data-field="{{ key }}">
+  <div class="setting-field form-group" data-field="{{ key }}">
     <label class="block mb-1" for="{{ key }}">
       {{ item.labels or key.replace('_', ' ')|capitalize }}
       {% if item.required %}<span class="text-red-600">*</span>{% endif %}
@@ -40,7 +40,7 @@
   {% set key = item.key %}
   {% set typ = item.type %}
   {% set default = item.value %}
-  <div class="setting-field" data-field="{{ key }}">
+  <div class="setting-field form-group" data-field="{{ key }}">
     <label class="block mb-1" for="{{ key }}">
       {{ item.labels or key.replace('_', ' ')|capitalize }}
       {% if item.required %}<span class="text-red-600">*</span>{% endif %}

--- a/templates/wizard/wizard_table.html
+++ b/templates/wizard/wizard_table.html
@@ -3,15 +3,15 @@
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">Step 3: Create Base Table</h1>
 <form method="post" id="table-form" class="space-y-4">
-  <div>
+  <div class="form-group">
     <label class="block mb-1">Table Name</label>
     <input type="text" name="table_name" class="form-control w-full">
   </div>
-  <div>
+  <div class="form-group">
     <label class="block mb-1">Title Field</label>
     <input type="text" name="title_field" class="form-control w-full" required>
   </div>
-  <div>
+  <div class="form-group">
     <label class="block mb-1">Description</label>
     <input type="text" name="description" class="form-control w-full">
   </div>
@@ -30,21 +30,21 @@
   <div class="modal-box w-96 max-w-full relative">
     <button type="button" onclick="hideAddFieldModal()" class="modal-close">&times;</button>
     <form id="field-form" class="space-y-4">
-      <div>
+      <div class="form-group">
         <label class="block mb-2 text-sm font-medium">Field Name</label>
         <input name="field_name" type="text" class="form-control w-full" required>
       </div>
-      <div>
+      <div class="form-group">
         <label class="block mb-2 text-sm font-medium">Field Type</label>
         <select id="field_type" name="field_type" class="form-control block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200" required>
           <option disabled selected>Select type</option>
         </select>
       </div>
-      <div id="field-options-container" class="hidden">
+      <div id="field-options-container" class="form-group hidden">
         <label class="block mb-2 text-sm font-medium">Options (comma-separated)</label>
         <textarea name="field_options" rows="3" class="form-control w-full"></textarea>
       </div>
-      <div id="fk-select-container" class="hidden">
+      <div id="fk-select-container" class="form-group hidden">
         <label class="block mb-2 text-sm font-medium">Select linked field</label>
         <select name="foreign_key_target" class="form-control block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200">
           <option value="" disabled selected>Select field</option>


### PR DESCRIPTION
## Summary
- apply a shared `form-group` class to wrapper divs in wizard templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68527865819c8333b0c3353294b0fa6c