### PR TITLE
Add sidebar label class to home span

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -23,7 +23,7 @@
           <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M9.293 2.293a1 1 0 0 1 1.414 0l7 7A1 1 0 0 1 17 11h-1v6a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-6H3a1 1 0 0 1-.707-1.707l7-7Z" clip-rule="evenodd" />
           </svg>
-          <span>Home</span>
+          <span class="sidebar-label">Home</span>
         </a>
         <button id="sidebarCollapse" class="p-2 text-lg bg-primary text-white rounded" aria-label="Toggle sidebar">&laquo;</button>
       </div>


### PR DESCRIPTION
## Summary
- add a `sidebar-label` class to the "Home" label

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852785713f88333af7c0bc4b0154da3