### PR TITLE
Fix new record modal layout

### DIFF
--- a/templates/modals/new_record_modal.html
+++ b/templates/modals/new_record_modal.html
@@ -5,7 +5,7 @@
     <form id="new-record-form" method="post" class="form-layout">
       {% for field, meta in field_schema[table].items() %}
         {% if field != "id" and meta.type != "hidden" %}
-          <div>
+          <div class="form-group">
             <label class="form-label">{{ field }}</label>
             {% if meta.type == "textarea" %}
               <input type="hidden" name="{{ field }}">


### PR DESCRIPTION
## Summary
- wrap dynamic input fields in `new_record_modal.html` with `form-group`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68527fb0d42883338f620357fc423591