### PR TITLE
Update modal form groups

### DIFF
--- a/templates/modals/add_table_modal.html
+++ b/templates/modals/add_table_modal.html
@@ -4,11 +4,11 @@
     <h3 class="text-lg font-bold mb-4">Add new base table</h3>
     <div id="tableError" class="text-red-600 hidden"></div>
     <form onsubmit="submitNewTable(event)" class="form-layout">
-      <div class="modal-form-group">
+      <div class="modal-form-group form-group">
         <label for="tableName" class="form-label">Table Name</label>
         <input id="tableName" type="text" class="form-input" required />
       </div>
-      <div class="modal-form-group">
+      <div class="modal-form-group form-group">
         <label for="tableDescription" class="form-label">Description</label>
         <textarea id="tableDescription" class="form-input"></textarea>
       </div>


### PR DESCRIPTION
## Summary
- add missing Bootstrap form-group class in Add Table modal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68527fb24a58833380c581f58b4d5f2c