### PR TITLE
Update create DB modal input wrapper class

### DIFF
--- a/templates/modals/create_db_modal.html
+++ b/templates/modals/create_db_modal.html
@@ -4,7 +4,7 @@
     <h3 class="text-lg font-bold mb-4">Create New Database</h3>
     <div id="create-db-error" class="text-red-600 hidden mb-2"></div>
     <form id="create-db-form" onsubmit="submitCreateDb(event)" class="form-layout">
-      <div class="modal-form-group">
+      <div class="modal-form-group db-name-group">
         <label for="create-db-name" class="form-label">Filename (.db)</label>
         <input id="create-db-name" type="text" class="form-input" required>
       </div>


### PR DESCRIPTION
## Summary
- add a descriptive CSS class `db-name-group` to the create DB modal input wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527fb43a288333be9c85965865fc41