### PR TITLE
Add form-group class in wizard table

### DIFF
--- a/templates/wizard/wizard_table.html
+++ b/templates/wizard/wizard_table.html
@@ -16,7 +16,7 @@
     <input type="text" name="description" class="form-control w-full">
   </div>
   <input type="hidden" name="fields_json" id="fields_json">
-  <div>
+  <div class="form-group">
     <h2 class="font-semibold mb-2">Fields</h2>
     <ul id="fields-list" class="mb-2 list-disc pl-5"></ul>
     <button type="button" onclick="showAddFieldModal()" class="btn-secondary px-2 py-1 rounded">Add Field</button>


### PR DESCRIPTION
## Summary
- tweak wizard table template to add `form-group` class to the Fields section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527fb51770833384e40bc09f6a9fbc