### PR TITLE
Replace gray backgrounds with accent colors

### DIFF
--- a/templates/_pagination.html
+++ b/templates/_pagination.html
@@ -2,13 +2,13 @@
   <div class="page-info">Page {{ page }} of {{ total_pages }}</div>
   <div class="space-x-1">
     {% if page > 1 %}
-      <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ page - 1 }}" class="px-2 py-1 bg-gray-200 rounded">Prev</a>
+      <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ page - 1 }}" class="px-2 py-1 bg-secondary-light rounded">Prev</a>
     {% endif %}
     {% for p in range(1, total_pages + 1) %}
       {% if p == page %}
         <span class="px-2 py-1 bg-teal-600 text-white rounded">{{ p }}</span>
       {% else %}
-        <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ p }}" class="px-2 py-1 bg-gray-200 rounded">{{ p }}</a>
+        <a href="?{{ base_qs }}{{ '&' if base_qs else '' }}page={{ p }}" class="px-2 py-1 bg-secondary-light rounded">{{ p }}</a>
       {% endif %}
     {% endfor %}
     {% if page < total_pages %}

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -42,7 +42,7 @@
       <button id="save-layout" class="btn-primary px-4 py-2 hidden rounded">
         Save Layout
       </button>
-      <button id="reset-layout" class="px-4 py-2 bg-gray-300 text-black rounded hidden">
+      <button id="reset-layout" class="px-4 py-2 bg-secondary-light text-black rounded hidden">
         Reset Layout
       </button>
       <button
@@ -53,7 +53,7 @@
         Edit Fields
       </button>
       <div id="special-visibility-wrapper" class="relative inline-block text-left hidden">
-        <button id="toggle-header-fields" type="button" class="inline-flex items-center px-2 py-1 bg-gray-200 rounded ml-2 space-x-1">
+        <button id="toggle-header-fields" type="button" class="inline-flex items-center px-2 py-1 bg-primary-light rounded ml-2 space-x-1">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
             <path d="M10 3a7 7 0 100 14 7 7 0 000-14zM2 10a8 8 0 1115.99.255L18 10h-2l-.002.255A8 8 0 012 10z" />
           </svg>
@@ -149,7 +149,7 @@
     <div class="flex items-center mb-2">
       <h2 class="text-xl font-semibold">Related Pages</h2>
       <div id="relation-visibility-wrapper" class="relative inline-block text-left ml-2 hidden">
-        <button id="toggle-relation-visibility" data-table="{{ table }}" type="button" class="inline-flex items-center px-2 py-1 bg-gray-200 rounded space-x-1">
+        <button id="toggle-relation-visibility" data-table="{{ table }}" type="button" class="inline-flex items-center px-2 py-1 bg-primary-light rounded space-x-1">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
             <path d="M10 12.5C11.3807 12.5 12.5 11.3807 12.5 10C12.5 8.61929 11.3807 7.5 10 7.5C8.61929 7.5 7.5 8.61929 7.5 10C7.5 11.3807 8.61929 12.5 10 12.5Z" />
             <path fill-rule="evenodd" clip-rule="evenodd" d="M0.664255 10.5904C0.517392 10.2087 0.517518 9.78563 0.66461 9.40408C2.10878 5.65788 5.7433 3 9.99859 3C14.256 3 17.892 5.66051 19.3347 9.40962C19.4816 9.79127 19.4814 10.2144 19.3344 10.5959C17.8902 14.3421 14.2557 17 10.0004 17C5.74298 17 2.10698 14.3395 0.664255 10.5904ZM14.0004 10C14.0004 12.2091 12.2095 14 10.0004 14C7.79123 14 6.00037 12.2091 6.00037 10C6.00037 7.79086 7.79123 6 10.0004 6C12.2095 6 14.0004 7.79086 14.0004 10Z" />

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -45,7 +45,7 @@
   </div>
   <!-- Visibility control -->
   <div class="relative inline-block text-left mb-4" id="column-visibility-wrapper">
-    <button id="toggle-columns" type="button" class="px-2 py-1 bg-gray-200 rounded">
+    <button id="toggle-columns" type="button" class="px-2 py-1 bg-primary-light rounded">
       Columns
     </button>
     <div id="column-dropdown" class="z-10 hidden mt-2 popover-dark space-y-1 w-48">
@@ -59,7 +59,7 @@
   </div>
   <!-- Filters control -->
   <div id="filters-visibility-wrapper" class="relative inline-block text-left mb-4">
-    <button type="button" id="toggle-filters" class="px-2 py-1 bg-gray-200 rounded">
+    <button type="button" id="toggle-filters" class="px-2 py-1 bg-primary-light rounded">
       Filters
     </button>
     <div id="filter-dropdown" class="z-10 hidden mt-2 popover-dark space-y-1 w-48">


### PR DESCRIPTION
## Summary
- use teal accent for pagination controls
- use purple accent for column and filter toggles in list view
- update detail view buttons with purple/teal theme

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852822738508333bf24f5b910b8416a