### PR TITLE
Fix form input colors for dark mode

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -258,6 +258,8 @@ a:hover {
   border-radius: 0.25rem;
   padding: 0.25rem 0.5rem; /* py-1 px-2 */
   font-size: 0.875rem; /* text-sm */
+  background-color: var(--bg-card);
+  color: var(--text-light);
 }
 
 .modal-box {


### PR DESCRIPTION
## Summary
- ensure `.form-input` uses dark background and light text so inputs are readable in dark mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68528669b1488333b93822ba46a1d15f