### PR TITLE
Fix popover stacking order

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -228,6 +228,7 @@ a:hover {
   border-radius: 0.5rem; /* rounded */
   box-shadow: 0 4px 6px rgba(0,0,0,0.1); /* shadow-lg */
   padding: 0.5rem; /* p-2 */
+  z-index: 200; /* ensure popovers sit above other elements */
   max-width: 85vw;
   max-height: 85vh;
   overflow: auto;


### PR DESCRIPTION
## Summary
- raise `popover-dark` elements above the rest of the UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852916f17d08333952fa0d824fe1b5a