### PR TITLE
Remove z-index classes from popovers

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -229,7 +229,7 @@ a:hover {
   border-radius: 0.5rem; /* rounded */
   box-shadow: 0 4px 6px rgba(0,0,0,0.1); /* shadow-lg */
   padding: 0.5rem; /* p-2 */
-  z-index: 200; /* ensure popovers sit above other elements */
+  z-index: 200 !important; /* ensure popovers sit above other elements */
   max-width: 85vw;
   max-height: 85vh;
   overflow: auto;

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -62,7 +62,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
           </svg>
         </button>
-        <div id="header-field-popover" class="popover-dark absolute right-0 z-20 hidden mt-2 space-y-1 w-48">
+        <div id="header-field-popover" class="popover-dark absolute right-0 hidden mt-2 space-y-1 w-48">
           <label class="flex items-center space-x-2">
             <input type="checkbox" class="header-field-toggle" value="title" checked>
             <span class="text-sm">Title</span>
@@ -158,7 +158,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
           </svg>
         </button>
-        <div id="relation-visibility-popover" class="popover-dark absolute right-0 z-20 hidden mt-2 space-y-2 w-64">
+        <div id="relation-visibility-popover" class="popover-dark absolute right-0 hidden mt-2 space-y-2 w-64">
           <div class="font-semibold text-sm border-b pb-1 mb-1">Relations Visibility</div>
           {% for sec, grp, vis in related %}
             <div class="space-y-1">

--- a/templates/list_view.html
+++ b/templates/list_view.html
@@ -48,7 +48,7 @@
     <button id="toggle-columns" type="button" class="px-2 py-1 bg-primary-light rounded">
       Columns
     </button>
-    <div id="column-dropdown" class="popover-dark absolute right-0 z-20 hidden mt-2 space-y-1 w-48">
+    <div id="column-dropdown" class="popover-dark absolute right-0 hidden mt-2 space-y-1 w-48">
       {% for field in fields if not field.startswith('_') and field != 'edit_log' %}
         <label class="flex items-center space-x-2">
           <input type="checkbox" class="column-toggle" value="{{ field }}" checked>
@@ -62,7 +62,7 @@
     <button type="button" id="toggle-filters" class="px-2 py-1 bg-primary-light rounded">
       Filters
     </button>
-    <div id="filter-dropdown" class="popover-dark absolute right-0 z-20 hidden mt-2 space-y-1 w-48">
+    <div id="filter-dropdown" class="popover-dark absolute right-0 hidden mt-2 space-y-1 w-48">
     </div>
   </div>
   

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -73,7 +73,7 @@
         Choose Tags
       </button>
 
-      <div class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1" data-options>
+      <div class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1" data-options>
         <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)))">
 
         {% for option in field_schema[table][field].options %}
@@ -145,7 +145,7 @@
         Choose Tags
       </button>
 
-      <div class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1" data-options>
+      <div class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1" data-options>
         <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)))">
 
         {% for option in field_schema[table][field].options %}

--- a/templates/macros/filter_controls.html
+++ b/templates/macros/filter_controls.html
@@ -55,7 +55,7 @@
   </button>
 
   <div
-  class="multi-select-popover popover-dark absolute z-20 mt-1 hidden overflow-scroll"
+  class="multi-select-popover popover-dark absolute mt-1 hidden overflow-scroll"
   data-field="{{ field }}">
     <div class="text-right mb-1 text-xs">
       <label class="mr-1">Mode:</label>

--- a/templates/modals/dashboard_modal.html
+++ b/templates/modals/dashboard_modal.html
@@ -36,7 +36,7 @@
             <button id="mathSelect1Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="mathSelect1Options" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
+            <div id="mathSelect1Options" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
           </div>
           <div id="aggToggle1" class="flex">
             <label class="cursor-pointer">
@@ -66,7 +66,7 @@
             <button id="mathSelect2Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="mathSelect2Options" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
+            <div id="mathSelect2Options" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
           </div>
           <div id="aggToggle2" class="flex">
             <label class="cursor-pointer">
@@ -81,7 +81,7 @@
         </div>
 
         <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left focus:outline-none focus:ring-2 focus:ring-teal-600 hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>
-        <div id="columnSelectDashboardOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
+        <div id="columnSelectDashboardOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
         <div id="resultRow" class="mt-4 flex items-center justify-center gap-2 hidden">
           <input id="valueTitleInput" type="text" class="px-3 py-2 border rounded flex-grow" />
           <div id="valueResult" class="font-semibold"></div>
@@ -122,7 +122,7 @@
             <button id="selectCountFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="selectCountFieldOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
+            <div id="selectCountFieldOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
           </div>
         </div>
         <div id="topNumericFieldContainer" class="mb-4 hidden">
@@ -130,7 +130,7 @@
             <button id="topNumericFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="topNumericFieldOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
+            <div id="topNumericFieldOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
           </div>
         </div>
         <div id="topNumericDirection" class="flex gap-2 mb-4 hidden">
@@ -148,14 +148,14 @@
             <button id="filteredTableToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Table</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="filteredTableOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
+            <div id="filteredTableOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
           </div>
           <input id="filteredSearchInput" type="text" placeholder="Search" class="w-full px-3 py-2 border rounded mb-2" />
           <div class="relative mb-2">
             <button id="filteredSortToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Sort Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="filteredSortOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
+            <div id="filteredSortOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
           </div>
           <input id="filteredLimitInput" type="number" value="10" min="1" class="w-full px-3 py-2 border rounded" />
         </div>
@@ -188,7 +188,7 @@
             <button id="chartXFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="chartXFieldOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
+            <div id="chartXFieldOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
           </div>
         </div>
         <div id="chartOrientContainer" class="flex mb-4 hidden">
@@ -207,7 +207,7 @@
             <button id="chartYFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
-            <div id="chartYFieldOptions" class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
+            <div id="chartYFieldOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
           </div>
         </div>
         <div id="chartAggContainer" class="flex mb-4 hidden">


### PR DESCRIPTION
## Summary
- clean up z-index utility classes on popover containers
- keep `.popover-dark` at `z-index: 200` with `!important`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852f9769e2c8333b4aefebb51cab87e