### PR TITLE
Move inline Tailwind classes to CSS

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -151,6 +151,26 @@ a:hover {
   color: #fff;
 }
 
+/* Sidebar navigation link */
+.sidebar-link {
+  padding: 0.5rem; /* p-2 */
+  color: #f3f4f6; /* text-gray-100 */
+  display: flex;
+  align-items: center;
+}
+.sidebar-link > * + * {
+  margin-left: 0.25rem; /* space-x-1 */
+}
+
+/* Sidebar collapse toggle */
+.sidebar-toggle {
+  padding: 0.5rem; /* p-2 */
+  font-size: 1.125rem; /* text-lg */
+  background-color: var(--color-primary);
+  color: #fff;
+  border-radius: 0.25rem;
+}
+
 .text-primary { color: var(--color-primary); }
 .text-secondary { color: var(--color-secondary); }
 .bg-primary-lightest { background-color: var(--color-primary-lightest); }

--- a/templates/admin/admin_automation.html
+++ b/templates/admin/admin_automation.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="text-3xl font-bold mb-4">Automation Rules</h1>
 <table id="rules-table" class="min-w-full text-sm divide-y mb-4"></table>
-<button id="new-rule" class="btn-primary px-3 py-1 rounded">New Rule</button>
+<button id="new-rule" class="btn-primary">New Rule</button>
 
 <div id="ruleModal" class="modal-container hidden" onclick="if(event.target.id === 'ruleModal') closeRuleModal()">
   <div class="modal-box w-96 max-w-full relative">

--- a/templates/admin/config_admin.html
+++ b/templates/admin/config_admin.html
@@ -71,7 +71,7 @@
                 {% else %}
                   <input type="text" name="value" value="{{ item.value }}" class="border border-gray-300 rounded px-2 py-1 text-sm flex-grow focus:ring-teal-600 focus:border-teal-600">
                 {% endif %}
-                <button type="submit" class="btn-primary px-3 py-1 rounded">Save</button>
+                <button type="submit" class="btn-primary">Save</button>
               </form>
             </td>
             <td class="px-2 py-1">{{ item.description }}</td>

--- a/templates/admin/database_admin.html
+++ b/templates/admin/database_admin.html
@@ -9,9 +9,9 @@
     <div id="db-path-display" class="px-2 py-1 text-sm font-mono rounded {{ 'text-green-600' if db_status == 'valid' else 'text-red-600' }}">{{ db_path }}</div>
     <form id="db-upload-form" class="flex items-center space-x-2" enctype="multipart/form-data">
       <input type="file" name="file" accept=".db" class="text-sm border border-gray-300 rounded" />
-      <button type="submit" class="btn-danger px-3 py-1 rounded">Change Database</button>
+      <button type="submit" class="btn-danger">Change Database</button>
     </form>
-    <button id="create-db-btn" type="button" class="btn-primary px-3 py-1 rounded" onclick="openCreateDbModal()">Create New DB</button>
+    <button id="create-db-btn" type="button" class="btn-primary" onclick="openCreateDbModal()">Create New DB</button>
   </div>
 </div>
 {% include "modals/create_db_modal.html" %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,13 +19,13 @@
   <div id="app-container" class="flex min-h-screen">
     <aside id="sidebar" class="fixed top-0 left-0 z-40 w-56 h-screen pt-4 bg-dark text-white hidden md:block flex flex-col flex-shrink-0">
       <div class="flex items-center justify-between px-2">
-        <a href="/" class="p-2 text-gray-100 flex items-center space-x-1" aria-label="Home">
+        <a href="/" class="sidebar-link" id="home-sidebar-link" aria-label="Home">
           <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M9.293 2.293a1 1 0 0 1 1.414 0l7 7A1 1 0 0 1 17 11h-1v6a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-6H3a1 1 0 0 1-.707-1.707l7-7Z" clip-rule="evenodd" />
           </svg>
           <span class="sidebar-label">Home</span>
         </a>
-        <button id="sidebarCollapse" class="p-2 text-lg bg-primary text-white rounded" aria-label="Toggle sidebar">&laquo;</button>
+        <button id="sidebarCollapse" class="sidebar-toggle" aria-label="Toggle sidebar">&laquo;</button>
       </div>
       <nav class="flex-1 overflow-y-auto px-3 space-y-2">
         {# Home link moved next to icon above #}
@@ -47,10 +47,10 @@
         </div>
         <div class="flex items-center space-x-2">
           {% if current_table in field_schema %}
-            <button type="button" onclick="openNewRecordModal()" class="btn-primary px-3 py-1 rounded">+ Add</button>
+            <button type="button" onclick="openNewRecordModal()" class="btn-primary">+ Add</button>
             {% if current_id %}
               <form method="post" action="/{{ current_table }}/{{ current_id }}/delete" onsubmit="return confirm('Are you sure?')">
-                <button type="submit" class="btn-danger px-3 py-1 rounded">Delete</button>
+                <button type="submit" class="btn-danger">Delete</button>
               </form>
             {% endif %}
           {% endif %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -3,15 +3,15 @@
 {% block title %}Dashboard{% endblock %}
 
 {% block nav_buttons %}
-<button id="dashboard_add" onclick="openDashboardModal()" class="btn-primary px-3 py-1 rounded">+ Add</button>
-<button id="dashboard_edit" class="btn-secondary px-3 py-1 rounded">Edit Layout</button>
-<button id="dashboard_save" class="btn-primary px-3 py-1 rounded hidden">Save Layout</button>
+<button id="dashboard_add" onclick="openDashboardModal()" class="btn-primary">+ Add</button>
+<button id="dashboard_edit" class="btn-secondary">Edit Layout</button>
+<button id="dashboard_save" class="btn-primary hidden">Save Layout</button>
 {% endblock %}
 
 {% block content %}
 <div class="flex items-center mb-4">
   <h1 class="text-3xl font-bold mr-4">Dashboard</h1>
-  <button id="dashboard_update" class="btn-primary px-3 py-1 rounded">Update</button>
+  <button id="dashboard_update" class="btn-primary">Update</button>
 </div>
 {% if not widgets %}
 <p class="text-gray-600">No widgets visible with current permissions please create new</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,11 +3,11 @@
 {% block title %}Home{% endblock %}
 
 {% block nav_buttons %}
-<a href="/import" class="btn-primary px-3 py-1 rounded">Import</a>
+<a href="/import" class="btn-primary">Import</a>
 {% endblock %}
 
 {% block header_actions %}
-<a href="/admin" class="btn-secondary px-3 py-1 rounded">Admin</a>
+<a href="/admin" class="btn-secondary">Admin</a>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- add sidebar-link and sidebar-toggle styles
- convert sidebar items to use new classes
- drop Tailwind padding and rounding from buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530528db688333943aa311aedc1ebe