### PR TITLE
Fix dark mode container styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ The worker also processes scheduled automation tasks defined in `automation/engi
 
 * **Static Assets & Styling:** Tailwind is loaded via CDN in `templates/base.html`. Global rules live in `static/css/styles.css`, while `static/css/overrides.css` contains Tailwind tweaks used by the layout editors. Update these files to change colors, spacing or other visual details. Any custom IDs or extra class names used in the templates are defined in these stylesheets so all styling remains centralized.
 * **`.popover-dark` utility:** Defined in `static/css/styles.css`, this dark themed dropdown container sets `z-index: 200` so popovers stay above the sidebar. It is used for column and filter dropdowns in `list_view.html`, the header and relation popovers in `detail_view.html`, and within `macros/filter_controls.html`, `macros/fields.html` and dashboard modals.
+* **`.tag-container` utility:** Provides dark mode styling for selected tag lists. Applied in multi-select and foreign key fields via `macros/fields.html` and the `tag_selector.js` macro.
 
 * **Templating & Macros:** Jinja2 templates in `templates/` include the core pages (`base.html`, `index.html`, `list_view.html`, `detail_view.html`, `new_record.html`, `dashboard.html`) plus admin and import views. Partial templates like `modals/edit_fields_modal.html` and `modals/bulk_edit_modal.html` are used for modals. Reusable macros live in `templates/macros/fields.html` and `filter_controls.html`.
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -240,6 +240,15 @@ a:hover {
   border-radius: 0.25rem;  /* rounded */
 }
 
+/* Selected tags container */
+.tag-container {
+  background-color: var(--bg-card);
+  color: var(--text-light);
+  border: 1px solid var(--color-primary-light);
+  border-radius: 0.5rem; /* rounded */
+  padding: 0.5rem; /* p-2 */
+}
+
 /* Reusable dark mode popover */
 .popover-dark {
   position: absolute;

--- a/static/js/tag_selector.js
+++ b/static/js/tag_selector.js
@@ -3,7 +3,7 @@
     <input type="hidden" name="field" value="{{ field }}">
     {% set selected_options = (value or '').split(', ') %}
 
-    <div class="flex flex-wrap gap-1 mb-2">
+    <div class="flex flex-wrap gap-1 mb-2 tag-container">
       {% for tag in selected_options if tag %}
         <span class="inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full">
           {{ tag }}
@@ -12,11 +12,11 @@
       {% endfor %}
     </div>
 
-    <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-white text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
+    <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
       Choose Tags
     </button>
 
-    <div class="absolute z-10 mt-1 w-full bg-white border rounded shadow hidden max-h-64 overflow-y-auto p-2 space-y-1" data-options>
+    <div class="absolute z-10 mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1" data-options>
       <input type="text" placeholder="Search..." class="w-full px-2 py-1 border rounded text-sm mb-2" oninput="const v=this.value.toLowerCase();[...this.parentElement.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)))">
       {% for option in get_field_options(table, field) %}
         <label class="flex items-center space-x-2">

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -60,7 +60,7 @@
       {% set selected_options = (value or '').split(',') %}
       {% set selected_options = selected_options | map('trim') | reject('equalto', '') | list %}
 
-      <div class="flex flex-wrap gap-1 mb-2">
+      <div class="flex flex-wrap gap-1 mb-2 tag-container">
         {% for tag in selected_options if tag %}
           <span class="inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full">
             {{ tag }}
@@ -94,7 +94,7 @@
   {% else %}
     {% set selected_options = (value or '').split(',') %}
     {% set selected_options = selected_options | map('trim') | reject('equalto', '') | list %}
-    <div class="flex flex-wrap gap-1" data-field="{{ field }}">
+    <div class="flex flex-wrap gap-1 tag-container" data-field="{{ field }}">
       {% for tag in selected_options if tag %}
         <span class="inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full">{{ tag }}</span>
       {% endfor %}
@@ -132,7 +132,7 @@
       {% set selected_options = (value or '').split(',') %}
       {% set selected_options = selected_options | map('trim') | reject('equalto', '') | list %}
 
-      <div class="flex flex-wrap gap-1 mb-2">
+      <div class="flex flex-wrap gap-1 mb-2 tag-container">
         {% for tag in selected_options if tag %}
           <span class="inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full">
             {{ tag }}
@@ -166,7 +166,7 @@
   {% else %}
     {% set selected_options = (value or '').split(',') %}
     {% set selected_options = selected_options | map('trim') | reject('equalto', '') | list %}
-    <div class="flex flex-wrap gap-1" data-field="{{ field }}">
+    <div class="flex flex-wrap gap-1 tag-container" data-field="{{ field }}">
       {% for tag in selected_options if tag %}
         <span class="inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full">{{ tag }}</span>
       {% endfor %}


### PR DESCRIPTION
## Summary
- add `.tag-container` CSS class for dark mode tag lists
- use the new class in field macros and tag selector
- document the new utility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68530e3db1c483338107f78c04df2ba7