### PR TITLE
Add form-select class and refactor templates

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -293,6 +293,27 @@ a:hover {
   color: var(--text-light);
 }
 
+/* Select element styling mirroring Tailwind utility classes */
+.form-select {
+  display: block;
+  width: 100%;
+  padding-top: 0.625rem;  /* py-2.5 */
+  padding-bottom: 0.625rem;
+  padding-left: 0;        /* px-0 */
+  padding-right: 0;
+  font-size: 0.875rem;    /* text-sm */
+  color: #6b7280;         /* text-gray-500 */
+  background-color: transparent;
+  border: 0;
+  border-bottom: 2px solid #e5e7eb; /* border-b-2 border-gray-200 */
+  appearance: none;
+}
+.form-select:focus {
+  outline: none;          /* focus:outline-none */
+  box-shadow: none;       /* focus:ring-0 */
+  border-color: #e5e7eb;  /* focus:border-gray-200 */
+}
+
 .modal-box {
   background-color: var(--bg-card);
   color: var(--text-light);

--- a/templates/import_view.html
+++ b/templates/import_view.html
@@ -9,7 +9,7 @@
     <div class="flex items-center space-x-4">
       <form method="GET" action="/import" class="flex items-center space-x-2">
         <label for="table" class="font-medium mr-2">Select Base Table</label>
-        <select name="table" id="table" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200" onchange="this.form.submit()">
+        <select name="table" id="table" class="form-select" onchange="this.form.submit()">
             <option value="" disabled {% if not selected_table %}selected{% endif %}>Choose a table</option>
             {% for table in schema.keys() %}
                 <option value="{{ table }}" {% if selected_table == table %}selected{% endif %}>{{ table|capitalize }}</option>
@@ -45,7 +45,7 @@
               <div class="flex justify-between items-center">
                 <strong>{{ header }}</strong>
                 <div id="select-wrapper-{{ header }}" class="ml-auto">
-                  <select name="match_{{ header }}" data-header="{{ header }}" data-table="{{ selected_table }}" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200">
+                  <select name="match_{{ header }}" data-header="{{ header }}" data-table="{{ selected_table }}" class="form-select">
                     <option value="">Unmatched</option>
                     {% for field, data in field_status.items() %}
                       {% if not data.matched %}
@@ -74,7 +74,7 @@
   </div>
   {% endif %}
   <template id="dropdown-template">
-    <select name="match___HEADER__" data-header="__HEADER__" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200" data-table="{{ selected_table }}">
+    <select name="match___HEADER__" data-header="__HEADER__" class="form-select" data-table="{{ selected_table }}">
       <option value="">Unmatched</option>
       {% for field, data in field_status.items() %}
         {% if not data.matched %}

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -40,7 +40,7 @@
     <form method="POST" action="{{ url_for(update_endpoint, table=table, record_id=record_id) }}" class="inline">
       <input type="hidden" name="field" value="{{ field }}">
       <select name="new_value"
-              class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200"
+              class="form-select"
               onchange="submitFieldAjax(this.form)">
         {% for option in field_schema[table][field].options %}
           <option value="{{ option }}" {% if option == value %}selected{% endif %}>{{ option }}</option>

--- a/templates/modals/dashboard_modal.html
+++ b/templates/modals/dashboard_modal.html
@@ -175,7 +175,7 @@
       <form id="chartWidgetForm" class="relative w-full" onsubmit="event.preventDefault();">
         <div class="mb-4">
           <label for="chartTypeSelect" class="block text-sm font-medium mb-1">Chart Type</label>
-          <select id="chartTypeSelect" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light">
+          <select id="chartTypeSelect" class="form-select form-control">
             <option value="" selected disabled>Select Chart Type</option>
             <option value="bar">Bar</option>
             <option value="line">Line</option>

--- a/templates/modals/edit_fields_modal.html
+++ b/templates/modals/edit_fields_modal.html
@@ -25,7 +25,7 @@
         <label class="block mb-2 text-sm font-medium">Field Name</label>
         <input name="field_name" type="text" class="w-full border px-3 py-2 rounded mb-4" required>
         <label class="block mb-2 text-sm font-medium">Field Type</label>
-        <select id="field_type" name="field_type" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200">
+        <select id="field_type" name="field_type" class="form-select">
           <option disabled selected>Select type</option>
         </select>
         <div id="field-options-container" class="hidden mb-4">
@@ -34,7 +34,7 @@
         </div>
         <div id="fk-select-container" class="hidden mb-4">
           <label class="block mb-2 text-sm font-medium">Select linked field</label>
-          <select name="foreign_key_target" class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200">
+          <select name="foreign_key_target" class="form-select">
             <option value="" disabled selected>Select field</option>
             {% for source_table, fields in field_schema.items() %}
               {% for field, meta in fields.items() %}
@@ -61,7 +61,7 @@
         <select
           id="field-to-remove"
           name="field_name"
-          class="block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200 mt-1"
+          class="form-select mt-1"
           onchange="fetchRemoveCount(this.value)"
           required>
           <option value="" disabled selected>Select field</option>

--- a/templates/wizard/wizard_table.html
+++ b/templates/wizard/wizard_table.html
@@ -38,7 +38,7 @@
       </div>
       <div class="form-group">
         <label class="block mb-2 text-sm font-medium">Field Type</label>
-        <select id="field_type" name="field_type" class="form-control block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200" required>
+        <select id="field_type" name="field_type" class="form-control form-select" required>
           <option disabled selected>Select type</option>
         </select>
       </div>
@@ -48,7 +48,7 @@
       </div>
       <div id="fk-select-container" class="form-group hidden">
         <label class="block mb-2 text-sm font-medium">Select linked field</label>
-        <select name="foreign_key_target" class="form-control block py-2.5 px-0 w-full text-sm text-gray-500 bg-transparent border-0 border-b-2 border-gray-200 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200">
+        <select name="foreign_key_target" class="form-control form-select">
           <option value="" disabled selected>Select field</option>
           {% for source_table, fields in field_schema.items() %}
             {% for field, meta in fields.items() %}


### PR DESCRIPTION
## Summary
- add `.form-select` to `styles.css` for consistent select styling
- refactor select elements in templates to use the new class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853141bb6b883338442615d1695281e