### PR TITLE
Add dropdown-btn utility class

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -119,6 +119,21 @@ a:hover {
 .btn-danger:hover {
   filter: brightness(90%);
 }
+/* Dropdown button */
+.dropdown-btn {
+  width: 100%;
+  padding: 0.5rem 0.75rem; /* py-2 px-3 */
+  border: 1px solid var(--color-primary-light);
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05); /* shadow-sm */
+  background-color: var(--bg-card);
+  color: var(--text-light);
+  text-align: left;
+}
+.dropdown-btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-secondary);
+}
 
 /* Card component */
 .card {

--- a/static/js/tag_selector.js
+++ b/static/js/tag_selector.js
@@ -12,7 +12,7 @@
       {% endfor %}
     </div>
 
-    <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
+    <button type="button" class="dropdown-btn" onclick="this.nextElementSibling.classList.toggle('hidden')">
       Choose Tags
     </button>
 

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -69,7 +69,7 @@
         {% endfor %}
       </div>
 
-      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
+      <button type="button" class="dropdown-btn" onclick="this.nextElementSibling.classList.toggle('hidden')">
         Choose Tags
       </button>
 
@@ -141,7 +141,7 @@
         {% endfor %}
       </div>
 
-      <button type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left focus:outline-none focus:ring-2 focus:ring-teal-600" onclick="this.nextElementSibling.classList.toggle('hidden')">
+      <button type="button" class="dropdown-btn" onclick="this.nextElementSibling.classList.toggle('hidden')">
         Choose Tags
       </button>
 

--- a/templates/modals/dashboard_modal.html
+++ b/templates/modals/dashboard_modal.html
@@ -33,7 +33,7 @@
 
         <div id="mathField1" class="flex items-start gap-2 mb-2 hidden">
           <div class="relative flex-grow">
-            <button id="mathSelect1Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
+            <button id="mathSelect1Toggle" type="button" class="dropdown-btn flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="mathSelect1Options" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
@@ -63,7 +63,7 @@
 
         <div id="mathField2" class="flex items-start gap-2 mb-2 hidden">
           <div class="relative flex-grow">
-            <button id="mathSelect2Toggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
+            <button id="mathSelect2Toggle" type="button" class="dropdown-btn flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="mathSelect2Options" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
@@ -80,7 +80,7 @@
           </div>
         </div>
 
-        <button id="columnSelectDashboardToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left focus:outline-none focus:ring-2 focus:ring-teal-600 hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>
+        <button id="columnSelectDashboardToggle" type="button" class="dropdown-btn hidden flex items-center justify-between"><span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span></button>
         <div id="columnSelectDashboardOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
         <div id="resultRow" class="mt-4 flex items-center justify-center gap-2 hidden">
           <input id="valueTitleInput" type="text" class="px-3 py-2 border rounded flex-grow" />
@@ -119,7 +119,7 @@
         </div>
         <div id="selectCountFieldContainer" class="mb-4 hidden">
           <div class="relative">
-            <button id="selectCountFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
+            <button id="selectCountFieldToggle" type="button" class="dropdown-btn flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="selectCountFieldOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
@@ -127,7 +127,7 @@
         </div>
         <div id="topNumericFieldContainer" class="mb-4 hidden">
           <div class="relative">
-            <button id="topNumericFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
+            <button id="topNumericFieldToggle" type="button" class="dropdown-btn flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="topNumericFieldOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
@@ -145,14 +145,14 @@
         </div>
         <div id="filteredRecordsContainer" class="mb-4 hidden">
           <div class="relative mb-2">
-            <button id="filteredTableToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
+            <button id="filteredTableToggle" type="button" class="dropdown-btn flex items-center justify-between">
               <span class="selected-label">Select Table</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="filteredTableOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
           </div>
           <input id="filteredSearchInput" type="text" placeholder="Search" class="w-full px-3 py-2 border rounded mb-2" />
           <div class="relative mb-2">
-            <button id="filteredSortToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
+            <button id="filteredSortToggle" type="button" class="dropdown-btn flex items-center justify-between">
               <span class="selected-label">Sort Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="filteredSortOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
@@ -185,7 +185,7 @@
         <div id="chartXFieldContainer" class="mb-4 hidden">
           <label id="chartXFieldLabel" class="block text-sm font-medium mb-1">X Field</label>
           <div class="relative">
-            <button id="chartXFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
+            <button id="chartXFieldToggle" type="button" class="dropdown-btn flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="chartXFieldOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>
@@ -204,7 +204,7 @@
         <div id="chartYFieldContainer" class="mb-4 hidden">
           <label class="block text-sm font-medium mb-1">Y Field</label>
           <div class="relative">
-            <button id="chartYFieldToggle" type="button" class="w-full px-3 py-2 border rounded shadow-sm bg-card text-light text-left flex items-center justify-between">
+            <button id="chartYFieldToggle" type="button" class="dropdown-btn flex items-center justify-between">
               <span class="selected-label">Select Field</span> <span class="arrow text-xl">▾</span>
             </button>
             <div id="chartYFieldOptions" class="absolute mt-1 w-full popover-dark hidden max-h-64 overflow-y-auto space-y-1"></div>


### PR DESCRIPTION
## Summary
- create `.dropdown-btn` utility class
- replace button classes in dashboard modal, tag selector, and field macros with `.dropdown-btn`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685316cce7d4833399df928db3bb5140