### PR TITLE
Add card-title style and clean admin markup

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -219,6 +219,13 @@ a:hover {
   background-color: #374151;
 }
 
+/* Card titles used on the home and admin pages */
+.card-title {
+  font-size: 1.5rem; /* text-2xl */
+  font-weight: 700;  /* font-bold */
+  margin-bottom: 0.5rem; /* mb-2 */
+}
+
 .modal-container {
   position: fixed;
   inset: 0;

--- a/templates/admin/admin.html
+++ b/templates/admin/admin.html
@@ -6,19 +6,19 @@
 <h1 class="text-3xl font-bold mb-6">Admin</h1>
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
   <a href="/admin/config" class="card-link">
-    <h2 class="text-2xl font-bold mb-2">Configuration</h2>
+    <h2 class="card-title">Configuration</h2>
     <p class="admin-cards">Manage application settings</p>
   </a>
   <a href="/admin/database" class="card-link">
-    <h2 class="text-2xl font-bold mb-2">Database</h2>
+    <h2 class="card-title">Database</h2>
     <p class="admin-cards">Manage database file</p>
   </a>
   <a href="/admin/users" class="card-link">
-    <h2 class="text-2xl font-bold mb-2">User Management</h2>
+    <h2 class="card-title">User Management</h2>
     <p class="admin-cards">Coming soon</p>
   </a>
   <a href="/admin/automation" class="card-link">
-    <h2 class="text-2xl font-bold mb-2">Automation</h2>
+    <h2 class="card-title">Automation</h2>
     <p class="admin-cards">Coming soon</p>
   </a>
 </div>


### PR DESCRIPTION
## Summary
- simplify `<h2>` markup on admin page
- introduce reusable `.card-title` CSS class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68533c8e87688333ae74518871e06da1