### PR TITLE
Fix automation rule form styling

### DIFF
--- a/templates/admin/admin_automation.html
+++ b/templates/admin/admin_automation.html
@@ -13,38 +13,38 @@
       <input type="hidden" id="rule-id">
       <div class="form-group">
         <label for="rule-name" class="block mb-1">Name</label>
-        <input id="rule-name" type="text" class="w-full border rounded p-2">
+        <input id="rule-name" type="text" class="form-input">
       </div>
       <div class="form-group">
         <label for="rule-table" class="block mb-1">Table</label>
-        <input id="rule-table" type="text" class="w-full border rounded p-2">
+        <input id="rule-table" type="text" class="form-input">
       </div>
       <div class="form-group">
         <label for="rule-cond-field" class="block mb-1">Condition Field</label>
-        <input id="rule-cond-field" type="text" class="w-full border rounded p-2">
+        <input id="rule-cond-field" type="text" class="form-input">
       </div>
       <div class="form-group">
         <label for="rule-cond-op" class="block mb-1">Condition Operator</label>
-        <select id="rule-cond-op" class="w-full border rounded p-2">
+        <select id="rule-cond-op" class="form-input">
           <option value="equals">equals</option>
           <option value="contains">contains</option>
         </select>
       </div>
       <div class="form-group">
         <label for="rule-cond-value" class="block mb-1">Condition Value</label>
-        <input id="rule-cond-value" type="text" class="w-full border rounded p-2">
+        <input id="rule-cond-value" type="text" class="form-input">
       </div>
       <div class="form-group">
         <label for="rule-action-field" class="block mb-1">Action Field</label>
-        <input id="rule-action-field" type="text" class="w-full border rounded p-2">
+        <input id="rule-action-field" type="text" class="form-input">
       </div>
       <div class="form-group">
         <label for="rule-action-value" class="block mb-1">Action Value</label>
-        <input id="rule-action-value" type="text" class="w-full border rounded p-2">
+        <input id="rule-action-value" type="text" class="form-input">
       </div>
       <div class="form-group">
         <label for="rule-schedule" class="block mb-1">Schedule</label>
-        <select id="rule-schedule" class="w-full border rounded p-2">
+        <select id="rule-schedule" class="form-input">
           <option value="none">none</option>
           <option value="daily">daily</option>
           <option value="always">always</option>


### PR DESCRIPTION
## Summary
- use `form-input` darkmode styles in `admin_automation.html`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853c387d6948333bb2e285f2361638c