### PR TITLE
Fix file input styling in database admin

### DIFF
--- a/templates/admin/database_admin.html
+++ b/templates/admin/database_admin.html
@@ -8,7 +8,7 @@
   <div class="card p-4 space-y-4">
     <div id="db-path-display" class="px-2 py-1 text-sm font-mono rounded {{ 'text-green-600' if db_status == 'valid' else 'text-red-600' }}">{{ db_path }}</div>
     <form id="db-upload-form" class="flex items-center space-x-2" enctype="multipart/form-data">
-      <input type="file" name="file" accept=".db" class="text-sm border border-gray-300 rounded" />
+      <input type="file" name="file" accept=".db" class="form-control" />
       <button type="submit" class="btn-danger">Change Database</button>
     </form>
     <button id="create-db-btn" type="button" class="btn-primary" onclick="openCreateDbModal()">Create New DB</button>


### PR DESCRIPTION
## Summary
- style the database upload file input using `form-control` for dark mode consistency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d95c87f88333a795d57b71800e15