### PR TITLE
Fix dashboard search input styling

### DIFF
--- a/static/js/dashboard_modal/value.js
+++ b/static/js/dashboard_modal/value.js
@@ -244,7 +244,7 @@ export function populateFieldDropdown(dropdown, restrictNumeric, allowedTypes, c
   const search = document.createElement('input');
   search.type = 'text';
   search.placeholder = 'Search...';
-  search.className = 'w-full px-2 py-1 border rounded text-sm mb-2';
+  search.className = 'form-input w-full px-2 py-1 border rounded text-sm mb-2';
   search.addEventListener('input', function() {
     const v = this.value.toLowerCase();
     [...dropdown.querySelectorAll('label')].forEach(l => l.classList.toggle('hidden', !l.textContent.toLowerCase().includes(v)));


### PR DESCRIPTION
## Summary
- ensure dashboard modal search input uses `form-input` for dark mode support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d9604a1083338c1940e5c57b8811