### PR TITLE
Fix create-record form action

### DIFF
--- a/templates/modals/new_record_modal.html
+++ b/templates/modals/new_record_modal.html
@@ -2,7 +2,7 @@
   <div class="modal-box">
     <button type="button" onclick="closeNewRecordModal()" class="modal-close">&times;</button>
     <h3 class="text-lg font-bold mb-4">Create New {{ table|capitalize }}</h3>
-    <form id="new-record-form" method="post" class="form-layout">
+    <form id="new-record-form" method="post" action="{{ url_for('records.create_record_route', table=table) }}" class="form-layout">
       {% for field, meta in field_schema[table].items() %}
         {% if field != "id" and meta.type != "hidden" %}
           <div class="form-group">


### PR DESCRIPTION
## Summary
- point the new record modal form to the create endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e036c53c8333b428631f0c2b462c