### PR TITLE
Fix date fields editing

### DIFF
--- a/templates/modals/bulk_edit_modal.html
+++ b/templates/modals/bulk_edit_modal.html
@@ -8,7 +8,7 @@
       <div class="modal-form-group form-group">
         <label for="bulk-field" class="form-label">Field</label>
         <select id="bulk-field" class="form-input">
-          {% for field, meta in field_schema[table].items() if not field.startswith('_') %}
+          {% for field, meta in field_schema[table].items() if not field.startswith('_') and field not in ['id', 'date_created', 'last_edited'] and meta.type != 'hidden' %}
             <option value="{{ field }}" data-type="{{ meta.type }}" data-options='{{ meta.options | tojson | e }}'>{{ field }}</option>
           {% endfor %}
         </select>

--- a/templates/modals/edit_fields_modal.html
+++ b/templates/modals/edit_fields_modal.html
@@ -66,7 +66,7 @@
           required>
           <option value="" disabled selected>Select field</option>
           {% for field, fmeta in field_schema[table].items() %}
-            {% if fmeta.type != "hidden" and field != "id" %}
+            {% if fmeta.type != "hidden" and field not in ['id', 'date_created', 'last_edited'] %}
               <option value="{{ field }}">{{ field }}</option>
             {% endif %}
           {% endfor %}

--- a/templates/modals/new_record_modal.html
+++ b/templates/modals/new_record_modal.html
@@ -4,7 +4,7 @@
     <h3 class="text-lg font-bold mb-4">Create New {{ table|capitalize }}</h3>
     <form id="new-record-form" method="post" action="{{ url_for('records.create_record_route', table=table) }}" class="form-layout">
       {% for field, meta in field_schema[table].items() %}
-        {% if field != "id" and meta.type != "hidden" %}
+        {% if field not in ["id", "date_created", "last_edited"] and meta.type != "hidden" %}
           <div class="form-group">
             <label class="form-label">{{ field }}</label>
             {% if meta.type == "textarea" %}


### PR DESCRIPTION
## Summary
- hide `date_created` and `last_edited` fields from user forms
- prevent bulk edit and removal of these auto fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e15cd8f08333a5796d8d5e45b84f