### PR TITLE
Add reusable filter-chip style

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -271,6 +271,20 @@ a:hover {
   padding: 0.5rem; /* p-2 */
 }
 
+/* Filter chip used for all query filter controls */
+.filter-chip {
+  display: flex;
+  align-items: center;
+  background-color: var(--bg-card);
+  color: var(--text-light);
+  border-radius: 9999px; /* rounded-full */
+  padding: 0.25rem 0.75rem; /* py-1 px-3 */
+  border: 1px solid var(--color-primary-light);
+}
+.filter-chip > * + * {
+  margin-left: 0.5rem; /* space-x-2 */
+}
+
 /* Reusable dark mode popover */
 .popover-dark {
   position: absolute;

--- a/templates/macros/filter_controls.html
+++ b/templates/macros/filter_controls.html
@@ -1,7 +1,7 @@
 {# templates/macros/filter_controls.html #}
 
 {%- macro text_filter(field, value, operator) -%}
-  <div class="filter-chip flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light">
+  <div class="filter-chip">
     <select
       name="{{ field }}_op"
       class="operator-select appearance-none text-xs rounded-full border-0 bg-transparent text-center text-teal-600 cursor-pointer w-auto"
@@ -26,7 +26,7 @@
 {%- endmacro -%}
 
 {%- macro select_filter(field, value, options) -%}
-  <div class="filter-chip flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light">
+  <div class="filter-chip">
     <select
       name="{{ field }}"
       class="bg-transparent text-sm rounded px-1 py-0.5"
@@ -44,7 +44,7 @@
 
 {%- macro multi_select_popover(field, selected, options, mode) -%}
     {% set actual = selected | reject('equalto', '') | list %}
-<div class="relative filter-chip flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light">
+<div class="relative filter-chip">
   <button
     type="button"
     class="multi-select-chip bg-transparent text-sm focus:outline-none"
@@ -81,7 +81,7 @@
 
 {%- macro select_multi_filter(field, selected, options) -%}
   {% set actual = selected | reject('equalto', '') | list %}
-  <div class="filter-chip select-multi-filter flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light" data-field="{{ field }}">
+  <div class="filter-chip select-multi-filter" data-field="{{ field }}">
     <span class="text-xs border border-gray-400 rounded px-1 mr-1">{{ field | replace('_',' ') | capitalize }}</span>
     <div class="flex flex-col max-h-32 overflow-y-auto">
       {% for opt in options %}
@@ -96,7 +96,7 @@
 {%- endmacro -%}
 
 {% macro boolean_filter(field, value) %}
-  <div class="filter-chip flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light">
+  <div class="filter-chip">
     <select
       name="{{ field }}"
       class="bg-transparent text-sm rounded px-1 py-0.5"
@@ -111,7 +111,7 @@
 {% endmacro %}
 
 {%- macro number_filter(field, min_val, max_val) -%}
-  <div class="filter-chip flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light">
+  <div class="filter-chip">
     <span class="text-xs border border-gray-400 rounded px-1 mr-1">
       {{ field | replace('_',' ') | capitalize }}
     </span>
@@ -134,7 +134,7 @@
 {%- endmacro -%}
 
 {%- macro date_filter(field, start_val, end_val) -%}
-  <div class="filter-chip flex items-center space-x-2 bg-card text-light rounded-full px-3 py-1 border border-primary-light">
+  <div class="filter-chip">
     <span class="text-xs border border-gray-400 rounded px-1 mr-1">
       {{ field | replace('_',' ') | capitalize }}
     </span>


### PR DESCRIPTION
## Summary
- add `.filter-chip` style for consistent filter appearance
- update filter macros to use the new class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e9b4c34c833384e01a3b1563b209