### PR TITLE
Add input-sm style and simplify inline field inputs

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -262,6 +262,14 @@ a:hover {
   border-radius: 0.25rem;  /* rounded */
 }
 
+/* Small input used for inline editing */
+.input-sm {
+  border: 1px solid var(--color-primary-light);
+  padding: 0.125rem 0.25rem; /* py-0.5 px-1 */
+  font-size: 0.875rem; /* text-sm */
+  border-radius: 0.25rem; /* rounded */
+}
+
 /* Selected tags container */
 .tag-container {
   background-color: var(--bg-card);

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -13,7 +13,7 @@
   {% if request.args.get('edit') == field %}
     {{ inline_input(field, update_endpoint, table, record_id,
         '<input type="text" name="new_value" value="' ~ value ~
-        '" class="border px-1 py-0.5 text-sm rounded" onchange="submitFieldAjax(this.form)">\n<span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
+        '" class="input-sm" onchange="submitFieldAjax(this.form)">\n<span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
   {% else %}
     <span class="ml-1" data-field="{{ field }}">{{ value }}</span>
   {% endif %}
@@ -109,7 +109,7 @@
   {% if request.args.get('edit') == field %}
     {{ inline_input(field, update_endpoint, table, record_id,
         '<input type="number" name="new_value" value="' ~ value ~
-        '" class="appearance-none border px-1 py-0.5 text-sm rounded"  onchange="submitFieldAjax(this.form)"><span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
+        '" class="input-sm" onchange="submitFieldAjax(this.form)"><span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
   {% else %}
     <span class="ml-1" data-field="{{ field }}">{{ value }}</span>
   {% endif %}
@@ -119,7 +119,7 @@
   {% if request.args.get('edit') == field %}
     {{ inline_input(field, update_endpoint, table, record_id,
         '<input type="date" name="new_value" value="' ~ value ~
-        '" class="border px-1 py-0.5 text-sm rounded" onchange="submitFieldAjax(this.form)"><span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
+        '" class="input-sm" onchange="submitFieldAjax(this.form)"><span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
   {% else %}
     <span class="ml-1" data-field="{{ field }}">{{ value }}</span>
   {% endif %}
@@ -193,7 +193,7 @@
   {% if request.args.get('edit') == field %}
     {{ inline_input(field, update_endpoint, table, record_id,
           '<input type="url" name="new_value" value="' ~ value ~
-          '" class="border px-1 py-0.5 text-sm rounded" onchange="submitFieldAjax(this.form)">\n<span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
+          '" class="input-sm" onchange="submitFieldAjax(this.form)">\n<span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>' ) }}
   {% else %}
     <a href="{{ value }}" target="_blank" rel="noopener">{{ value }}</a>
   {% endif %}


### PR DESCRIPTION
## Summary
- add `.input-sm` helper class for inline inputs
- use `input-sm` across field rendering macros

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853efb5516c8333abe484302c05de98