### PR TITLE
Make wizard table field rows clickable

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -419,3 +419,13 @@ a:hover {
 .wizard-continue {
   display: inline-block;
 }
+
+/* Fields list rows used in the table wizard */
+.wizard-field-row {
+  cursor: pointer;
+  padding: 0.25rem 0.5rem; /* py-1 px-2 */
+  border-radius: 0.25rem;
+}
+.wizard-field-row:hover {
+  background-color: #374151; /* dark gray hover */
+}

--- a/static/js/wizard_table.js
+++ b/static/js/wizard_table.js
@@ -93,8 +93,9 @@ function updateFieldList(idx) {
   list.innerHTML = '';
   tables[idx].forEach((f, i) => {
     const li = document.createElement('li');
-    li.className = 'flex justify-between items-center';
+    li.className = 'flex justify-between items-center wizard-field-row';
     li.innerHTML = `<span>${f.name} (${f.type})</span>`;
+    li.onclick = () => showAddFieldModal(idx, i);
     const btnGroup = document.createElement('div');
     btnGroup.className = 'space-x-2';
 
@@ -102,14 +103,20 @@ function updateFieldList(idx) {
     editBtn.type = 'button';
     editBtn.textContent = 'Edit';
     editBtn.className = 'text-blue-600';
-    editBtn.onclick = () => showAddFieldModal(idx, i);
+    editBtn.onclick = (e) => {
+      e.stopPropagation();
+      showAddFieldModal(idx, i);
+    };
     btnGroup.appendChild(editBtn);
 
     const removeBtn = document.createElement('button');
     removeBtn.type = 'button';
     removeBtn.textContent = '×';
     removeBtn.className = 'text-red-600';
-    removeBtn.onclick = () => removeField(idx, i);
+    removeBtn.onclick = (e) => {
+      e.stopPropagation();
+      removeField(idx, i);
+    };
     btnGroup.appendChild(removeBtn);
 
     li.appendChild(btnGroup);


### PR DESCRIPTION
## Summary
- add `.wizard-field-row` styles
- make wizard table field rows clickable with a hover state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68550bea509083339377422ed60662f1