### PR TITLE
Ensure darkmode for field context menu

### DIFF
--- a/static/js/field_styling.js
+++ b/static/js/field_styling.js
@@ -43,7 +43,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const menu = document.createElement('div');
   menu.id = 'field-style-menu';
   window.fieldStyleMenu = menu;
-  menu.className = 'absolute bg-white border rounded shadow p-2 space-y-1 hidden z-50 text-sm';
+  // Use the reusable dark mode popover styling
+  menu.className = 'absolute popover-dark space-y-1 hidden text-sm';
   menu.innerHTML = `
     <label class="flex items-center space-x-2"><input type="checkbox" data-opt="bold"> <span>Bold</span></label>
     <label class="flex items-center space-x-2"><input type="checkbox" data-opt="italic"> <span>Italic</span></label>


### PR DESCRIPTION
## Summary
- keep the field right‑click menu in dark mode using the shared `popover-dark` style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68558b682b708333b71342c41ab9a095