### PR TITLE
Add chart legend toggle for dashboard widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
   accepts optional `search` and `limit` query parameters to filter results.
 * **CSV Import Workflow:** Upload a CSV on `/import`, map fields, then start a background job via `/import-start` and poll `/import-status` for progress.
 
+### Dashboard Customization
+
+Chart widgets include a **Hide Legend** option in the styling menu. Right‑click a chart while editing the dashboard and toggle this checkbox to remove the legend. The preference is saved to the widget's styling JSON and respected when charts render.
+
 ## Project Structure
 
 ```text

--- a/static/js/dashboard_charts.js
+++ b/static/js/dashboard_charts.js
@@ -18,6 +18,18 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
+    let styling = {};
+    if (widget._styling) {
+      styling = widget._styling;
+    } else if (widget.dataset.styling) {
+      try {
+        styling = JSON.parse(widget.dataset.styling);
+      } catch (e) {
+        styling = {};
+      }
+    }
+    const legendDisplay = !styling.hideLegend;
+
     const { chart_type: type = 'bar', x_field, y_field, aggregation, field, orientation } = cfg;
     const canvas = widget.querySelector('canvas') || document.createElement('canvas');
     if (!canvas.parentElement) widget.appendChild(canvas);
@@ -34,7 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
         new Chart(canvas, {
           type: 'pie',
           data: { labels, datasets: [{ data: values, backgroundColor: colors }] },
-          options: { responsive: true, maintainAspectRatio: false }
+          options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: legendDisplay } } }
         });
       } catch (err) {
         console.error('[dashboard_charts] pie data fetch error', err);
@@ -53,7 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
         new Chart(canvas, {
           type: 'bar',
           data: { labels, datasets: [{ data: values, backgroundColor: colors }] },
-          options: { responsive: true, maintainAspectRatio: false, indexAxis: orientation === 'y' ? 'y' : 'x', plugins: { legend: { display: false } } }
+          options: { responsive: true, maintainAspectRatio: false, indexAxis: orientation === 'y' ? 'y' : 'x', plugins: { legend: { display: legendDisplay } } }
         });
       } catch (err) {
         console.error('[dashboard_charts] bar data fetch error', err);
@@ -71,7 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
         new Chart(canvas, {
           type: 'line',
           data: { labels, datasets: [{ data: values, borderColor: FLOWBITE_COLORS[0], backgroundColor: 'rgba(13,148,136,0.2)', fill: false }] },
-          options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } } }
+          options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: legendDisplay } } }
         });
       } catch (err) {
         console.error('[dashboard_charts] line data fetch error', err);
@@ -107,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
       options: {
         responsive: true,
         maintainAspectRatio: false,
-        plugins: { legend: { display: false } }
+        plugins: { legend: { display: legendDisplay } }
       }
     });
   });

--- a/static/js/field_styling.js
+++ b/static/js/field_styling.js
@@ -49,6 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
     <label class="flex items-center space-x-2"><input type="checkbox" data-opt="bold"> <span>Bold</span></label>
     <label class="flex items-center space-x-2"><input type="checkbox" data-opt="italic"> <span>Italic</span></label>
     <label class="flex items-center space-x-2"><input type="checkbox" data-opt="underline"> <span>Underline</span></label>
+    <label class="flex items-center space-x-2"><input type="checkbox" data-opt="hide-legend"> <span>Hide legend</span></label>
     <label class="flex items-center space-x-1">
       <span class="whitespace-nowrap mr-1">Size</span>
       <button type="button" data-size-act="dec" class="px-1 border rounded">-</button>
@@ -64,6 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const presetsDiv = menu.querySelector('#color-presets');
   const sizeInput = menu.querySelector('[data-opt="size"]');
   const sizeDisplay = menu.querySelector('[data-opt="size-display"]');
+  const hideLegendCheckbox = menu.querySelector('[data-opt="hide-legend"]');
   const SIZE_MIN = 10;
   const SIZE_MAX = 48;
   const SIZE_STEP = 1;
@@ -120,6 +122,14 @@ document.addEventListener('DOMContentLoaded', () => {
     menu.querySelector('[data-opt="bold"]').checked = !!styling.bold;
     menu.querySelector('[data-opt="italic"]').checked = !!styling.italic;
     menu.querySelector('[data-opt="underline"]').checked = !!styling.underline;
+    if (hideLegendCheckbox) {
+      hideLegendCheckbox.checked = !!styling.hideLegend;
+      if (isDashboard && fieldEl.dataset.type === 'chart') {
+        hideLegendCheckbox.parentElement.classList.remove('hidden');
+      } else {
+        hideLegendCheckbox.parentElement.classList.add('hidden');
+      }
+    }
     sizeInput.value = styling.size || '';
     updateSizeDisplay(sizeInput.value);
     selectedColor = styling.color || '#000000';
@@ -156,6 +166,9 @@ document.addEventListener('DOMContentLoaded', () => {
       color: selectedColor,
       size: parseInt(sizeInput.value, 10) || null
     });
+    if (isDashboard && hideLegendCheckbox) {
+      styling.hideLegend = hideLegendCheckbox.checked;
+    }
     currentEl._styling = styling;
     applyStyling(currentEl, styling);
 

--- a/tests/test_admin_dashboard_views.py
+++ b/tests/test_admin_dashboard_views.py
@@ -137,6 +137,20 @@ def test_dashboard_update_style_success(client):
     update_widget_styling(widget['id'], original)
 
 
+def test_dashboard_update_style_hide_legend(client):
+    widget = get_dashboard_widgets()[0]
+    original = json.loads(widget.get('styling') or '{}')
+    resp = client.post(
+        '/dashboard/style',
+        json={'widget_id': widget['id'], 'styling': {'hideLegend': True}},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()['success']
+    updated = next(w for w in get_dashboard_widgets() if w['id'] == widget['id'])
+    assert json.loads(updated['styling']) == {'hideLegend': True}
+    update_widget_styling(widget['id'], original)
+
+
 def test_dashboard_update_style_invalid_data(client):
     resp = client.post('/dashboard/style', json={'widget_id': None, 'styling': 'x'})
     assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- allow hiding chart legends via field styling context menu
- persist `hideLegend` styling flag for widgets
- make charts respect the flag when rendering
- document the option in the README
- test `/dashboard/style` accepts the new flag

## Testing
- `pytest -q`
- `pytest tests/test_admin_dashboard_views.py::test_dashboard_update_style_hide_legend -q`

------
https://chatgpt.com/codex/tasks/task_e_68565ef1f8a48333ad7d88b9e889c1a1