### PR TITLE
Fix modal popover layering

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -378,7 +378,7 @@ a:hover {
   width: 24rem; /* w-96 */
   max-width: 100%;
   max-height: 85%;
-  overflow-y: auto;
+  overflow: visible;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- ensure modal popovers are not clipped behind the blurred overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68567cd4861883339d56e6a6d8010310