### PR TITLE
Fix dashboard chart widget overflow

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -85,6 +85,13 @@ a:hover {
   flex-direction: column;
 }
 
+/* Ensure Chart.js canvases fill their widget */
+.dashboard-widget canvas {
+  width: 100% !important;
+  height: 100% !important;
+  flex: 1 1 auto;
+}
+
 /* allow scroll area to use remaining height */
 .dashboard-widget > .overflow-auto {
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- constrain Chart.js canvases inside widgets so charts don't spill out of their grid cell

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856807424188333a81dd6ed12daa943