### PR TITLE
Add custom IDs for detail view elements

### DIFF
--- a/static/js/edit_fields.js
+++ b/static/js/edit_fields.js
@@ -1,7 +1,7 @@
 document.addEventListener("DOMContentLoaded", () => {
     const fieldTypeSelect = document.getElementById("field_type");
-    const optionsContainer = document.getElementById("field-options-container");
-    const fkSelectContainer = document.getElementById("fk-select-container");
+    const optionsContainer = document.getElementById("field_options_container");
+    const fkSelectContainer = document.getElementById("fk_select_container");
 
     if (!fieldTypeSelect) return;
 
@@ -73,7 +73,7 @@ function toggleRemoveButton() {
 }
 
 function updateRemoveInfo(count) {
-  const removeInfoDiv = document.getElementById("remove-info");
+  const removeInfoDiv = document.getElementById("remove_info_section");
   const removeCountP = document.getElementById("remove-count");
   const checkboxLabel = document.getElementById("checkbox-label");
   const confirmCheckbox = document.getElementById("confirm-delete-checkbox");

--- a/static/js/new_record_modal.js
+++ b/static/js/new_record_modal.js
@@ -7,12 +7,12 @@ const escHandler = (e) => {
 
 export function openNewRecordModal() {
   recordTrigger = document.activeElement;
-  document.getElementById('newRecordModal').classList.remove('hidden');
+  document.getElementById('new_record_modal').classList.remove('hidden');
   document.addEventListener('keydown', escHandler);
 }
 
 export function closeNewRecordModal() {
-  document.getElementById('newRecordModal').classList.add('hidden');
+  document.getElementById('new_record_modal').classList.add('hidden');
   document.removeEventListener('keydown', escHandler);
   if (recordTrigger) {
     recordTrigger.focus();

--- a/static/js/relationship_dropdown.js
+++ b/static/js/relationship_dropdown.js
@@ -1,5 +1,5 @@
 export function toggleAddRelation(tableA, idA, tableB) {
-  const container = document.getElementById(`add-rel-${tableB}`);
+  const container = document.getElementById(`add_relation_form-${tableB}`);
   if (!container) return;
   container.classList.toggle('hidden');
   const select = container.querySelector('select');

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -7,10 +7,10 @@
 {# Define the percentage snap constant (# of % per grid column) #}
 {% set PCT_SNAP = 5 %}
 
-<div class="max-w-6xl mx-auto card p-6 flex space-x-6">
+<div id="detail_view_container" class="max-w-6xl mx-auto card p-6 flex space-x-6">
 
   <!-- Left: Main Details -->
-  <div class="flex-1">
+  <div id="primary_fields" class="flex-1">
     {% if title_field %}
     {% set display_value = record.get(title_field) or "Untitled" %}
     {% else %}
@@ -146,7 +146,7 @@
 
   <!-- Right: Related Content -->
   <div id="related-pages" class="w-full md:w-1/3 lg:w-1/4 xl:w-64 border-l-2 border-teal-200 pl-6 flex-shrink-0">
-    <div class="flex items-center mb-2">
+    <div id="header_container" class="flex items-center mb-2">
       <h2 class="text-xl font-semibold">Related Pages</h2>
       <div id="relation-visibility-wrapper" class="relative inline-block text-left ml-2 hidden">
         <button id="toggle-relation-visibility" data-table="{{ table }}" type="button" class="dropdown-btn inline-flex items-center space-x-1">
@@ -159,9 +159,9 @@
           </svg>
         </button>
         <div id="relation-visibility-popover" class="popover-dark absolute right-0 hidden mt-2 space-y-2 w-64">
-          <div class="font-semibold text-sm border-b pb-1 mb-1">Relations Visibility</div>
+          <div id="relation_visibility_title" class="font-semibold text-sm border-b pb-1 mb-1">Relations Visibility</div>
           {% for sec, grp, vis in related %}
-            <div class="space-y-1">
+            <div id="relation_visibility_container-{{ sec }}" class="space-y-1">
               <label class="flex items-center space-x-2">
                 <input type="checkbox" class="relation-visible" value="{{ sec }}">
                 <span class="text-sm">Toggle Show: {{ grp.label }}</span>
@@ -180,7 +180,7 @@
         {% set has_items = group['items']|length > 0 %}
         {% set hide = vis.hidden and (vis.force or not has_items) %}
         <li class="related-group{% if hide %} hidden{% endif %}" data-section="{{ section }}" data-has-items="{{ 1 if has_items else 0 }}">
-          <div class="flex items-center justify-between">
+          <div id="relation_section_header-{{ section }}" class="flex items-center justify-between">
             <strong>{{ group.label }}:</strong>
             <button
               onclick="toggleAddRelation('{{ table }}', {{ record.id }}, '{{ section }}')"
@@ -191,7 +191,7 @@
           </div>
           {% if group['items'] %}
             {% for item in group['items'] %}
-                <div class="flex justify-between items-center">
+                <div id="relation_item_row-{{ item.id }}" class="flex justify-between items-center">
                   <a href="/{{ section }}/{{ item.id }}" class="underline">
                     {% if section == 'content' %}{{ item.id }}{% else %}{{ item.name }}{% endif %}
                   </a>
@@ -207,10 +207,10 @@
           {% else %}
             <span class="text-gray-400 relation-hint">None</span>
           {% endif %}
-          <div id="add-rel-{{ section }}" class="mt-2 hidden">
+          <div id="add_relation_form-{{ section }}" class="mt-2 hidden">
             <input type="text" placeholder="Search..." class="form-input mb-1" oninput="searchRelation('{{ section }}', this)">
             <select id="rel-options-{{ section }}" class="form-select mb-1"></select>
-            <div class="flex space-x-1 items-center mb-1 text-xs">
+            <div id="relation_direction_controls-{{ section }}" class="flex space-x-1 items-center mb-1 text-xs">
               <label class="flex items-center space-x-1">
                 <input type="radio" name="rel-dir-{{ section }}" value="one" class="rel-dir" checked>
                 <span class="relation-arrow">-&gt;</span>
@@ -259,10 +259,10 @@
 
 <script type="module">
   window.openLayoutModal = function () {
-    document.getElementById("layoutModal").classList.remove("hidden");
+    document.getElementById("edit_fields_modal").classList.remove("hidden");
   };
   window.closeLayoutModal = function () {
-    document.getElementById("layoutModal").classList.add("hidden");
+    document.getElementById("edit_fields_modal").classList.add("hidden");
   };
 </script>
 <script type="module" src="{{ url_for('static', filename='js/field_ajax.js') }}"></script>

--- a/templates/modals/edit_fields_modal.html
+++ b/templates/modals/edit_fields_modal.html
@@ -1,24 +1,24 @@
-<div id="layoutModal" class="modal-container hidden"
-     onclick="if(event.target.id === 'layoutModal') closeLayoutModal()">
+<div id="edit_fields_modal" class="modal-container hidden"
+     onclick="if(event.target.id === 'edit_fields_modal') closeLayoutModal()">
   <div class="modal-box w-96 max-w-full relative">
     <button type="button" onclick="closeLayoutModal()" class="modal-close">&times;</button>
     <div class="mb-4 border-b border-gray-200">
       <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="editFieldsTabs" role="tablist">
         <li class="mr-2" role="presentation">
-          <button id="tab-add" type="button" role="tab" aria-controls="pane-add" aria-selected="true" class="inline-block p-2 rounded-t-lg border-b-2 text-primary border-primary-dark">
+          <button id="tab-add" type="button" role="tab" aria-controls="add_field_pane" aria-selected="true" class="inline-block p-2 rounded-t-lg border-b-2 text-primary border-primary-dark">
             Add Field
           </button>
         </li>
         <li role="presentation">
-          <button id="tab-remove" type="button" role="tab" aria-controls="pane-remove" aria-selected="false" class="inline-block p-2 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300">
+          <button id="tab-remove" type="button" role="tab" aria-controls="remove_field_pane" aria-selected="false" class="inline-block p-2 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300">
             Remove Field
           </button>
         </li>
       </ul>
     </div>
-    <div id="editFieldsContent">
+    <div id="edit_fields_content">
     <!-- Add Field Pane -->
-    <div id="pane-add" role="tabpanel" aria-labelledby="tab-add">
+    <div id="add_field_pane" role="tabpanel" aria-labelledby="tab-add">
       <h3 class="text-lg font-bold mb-4">Add Field to {{table}}</h3>
       <form method="POST" id="add-field-form" action="/{{ table }}/{{ record.id }}/add-field">
         <input type="hidden" name="record_id" value="{{ record.id }}">
@@ -28,11 +28,11 @@
         <select id="field_type" name="field_type" class="form-select">
           <option disabled selected>Select type</option>
         </select>
-        <div id="field-options-container" class="hidden mb-4">
+        <div id="field_options_container" class="hidden mb-4">
           <label class="block mb-2 text-sm font-medium">Options (comma-separated)</label>
           <textarea name="field_options" rows="3" class="form-input"></textarea>
         </div>
-        <div id="fk-select-container" class="hidden mb-4">
+        <div id="fk_select_container" class="hidden mb-4">
           <label class="block mb-2 text-sm font-medium">Select linked field</label>
           <select name="foreign_key_target" class="form-select">
             <option value="" disabled selected>Select field</option>
@@ -54,7 +54,7 @@
     </div>
 
     <!-- Remove Field Pane -->
-    <div id="pane-remove" class="hidden">
+    <div id="remove_field_pane" class="hidden">
       <h3 class="text-lg font-bold mb-4">Remove Field from {{table}}</h3>
       <form id="remove-field-form" method="POST" action="/{{table}}/{{record.id}}/remove-field">
         <label for="field-to-remove" class="block text-sm font-medium">Select Field to Remove</label>
@@ -72,7 +72,7 @@
           {% endfor %}
         </select>
 
-        <div id="remove-info" class="mt-4 hidden">
+        <div id="remove_info_section" class="mt-4 hidden">
           <p id="remove-count" class="text-sm text-red-600"></p>
           <label class="inline-flex items-center mt-2">
             <input 

--- a/templates/modals/new_record_modal.html
+++ b/templates/modals/new_record_modal.html
@@ -1,11 +1,11 @@
-<div id="newRecordModal" class="modal-container hidden" onclick="if(event.target.id === 'newRecordModal') closeNewRecordModal()">
+<div id="new_record_modal" class="modal-container hidden" onclick="if(event.target.id === 'new_record_modal') closeNewRecordModal()">
   <div class="modal-box">
     <button type="button" onclick="closeNewRecordModal()" class="modal-close">&times;</button>
     <h3 class="text-lg font-bold mb-4">Create New {{ table|capitalize }}</h3>
     <form id="new-record-form" method="post" action="{{ url_for('records.create_record_route', table=table) }}" class="form-layout">
       {% for field, meta in field_schema[table].items() %}
         {% if field not in ["id", "date_created", "last_edited"] and meta.type != "hidden" %}
-          <div class="form-group">
+          <div id="form_group-{{ loop.index }}" class="form-group">
             <label class="form-label">{{ field }}</label>
             {% if meta.type == "textarea" %}
               <input type="hidden" name="{{ field }}">


### PR DESCRIPTION
## Summary
- add `detail_view_container`, `primary_fields`, and other IDs to `detail_view.html`
- rename IDs in Edit Fields modal and New Record modal
- update scripts to reference the new IDs
- adjust relationship dropdown handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685683405e608333a366638aa8295bad