### PR TITLE
Add hide-legend dashboard styling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Top/Bottom Numeric:** Table widget listing records with the highest or lowest values for a numeric field.
 * **Filtered Records Widget:** Table widget showing records from any table matching a search filter, with optional sort and limit.
 * **Dashboard Grid Editing:** Widgets can be dragged, resized, and saved using `/dashboard/layout`.
+* **Widget Styling:** Right-click a widget to adjust text styles. Chart widgets include a "Hide Legend" toggle.
 * **Numerical Summaries:** `/<table>/sum-field` returns the sum for numeric columns, used by dashboard charts.
 * **List API:** `/api/<table>/list` provides ID and label data for dropdowns. It
   accepts optional `search` and `limit` query parameters to filter results.

--- a/static/js/dashboard_charts.js
+++ b/static/js/dashboard_charts.js
@@ -45,6 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
           data: { labels, datasets: [{ data: values, backgroundColor: colors }] },
           options: { responsive: true, maintainAspectRatio: false }
         });
+        widget._chart = chartInstance;
       } catch (err) {
         console.error('[dashboard_charts] pie data fetch error', err);
       }
@@ -65,6 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
           data: { labels, datasets: [{ data: values, backgroundColor: colors }] },
           options: { responsive: true, maintainAspectRatio: false, indexAxis: orientation === 'y' ? 'y' : 'x', plugins: { legend: { display: false } } }
         });
+        widget._chart = chartInstance;
       } catch (err) {
         console.error('[dashboard_charts] bar data fetch error', err);
       }
@@ -84,6 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
           data: { labels, datasets: [{ data: values, borderColor: FLOWBITE_COLORS[0], backgroundColor: 'rgba(13,148,136,0.2)', fill: false }] },
           options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } } }
         });
+        widget._chart = chartInstance;
       } catch (err) {
         console.error('[dashboard_charts] line data fetch error', err);
       }
@@ -122,6 +125,7 @@ document.addEventListener('DOMContentLoaded', () => {
         plugins: { legend: { display: false } }
       }
     });
+    widget._chart = chartInstance;
     attachResize(widget, chartInstance);
   });
 });

--- a/static/js/field_styling.js
+++ b/static/js/field_styling.js
@@ -14,6 +14,12 @@ function applyStyling(el, styling) {
   } else {
     el.style.removeProperty('--field-size');
   }
+  if (el.dataset.type === 'chart' && el._chart) {
+    el._chart.options.plugins = el._chart.options.plugins || {};
+    el._chart.options.plugins.legend = el._chart.options.plugins.legend || {};
+    el._chart.options.plugins.legend.display = !styling.hideLegend;
+    try { el._chart.update(); } catch (e) { console.error('chart update error', e); }
+  }
   const label = el.querySelector('div.text-sm.font-bold.capitalize.mb-1');
   if (label) label.classList.remove('hidden');
 }
@@ -49,6 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
     <label class="flex items-center space-x-2"><input type="checkbox" data-opt="bold"> <span>Bold</span></label>
     <label class="flex items-center space-x-2"><input type="checkbox" data-opt="italic"> <span>Italic</span></label>
     <label class="flex items-center space-x-2"><input type="checkbox" data-opt="underline"> <span>Underline</span></label>
+    <label class="flex items-center space-x-2 chart-only hidden"><input type="checkbox" data-opt="hide-legend"> <span>Hide Legend</span></label>
     <label class="flex items-center space-x-1">
       <span class="whitespace-nowrap mr-1">Size</span>
       <button type="button" data-size-act="dec" class="px-1 border rounded">-</button>
@@ -64,6 +71,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const presetsDiv = menu.querySelector('#color-presets');
   const sizeInput = menu.querySelector('[data-opt="size"]');
   const sizeDisplay = menu.querySelector('[data-opt="size-display"]');
+  const hideLegendLabel = menu.querySelector('.chart-only');
+  const hideLegendCb = menu.querySelector('[data-opt="hide-legend"]');
   const SIZE_MIN = 10;
   const SIZE_MAX = 48;
   const SIZE_STEP = 1;
@@ -117,6 +126,12 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     currentEl = fieldEl;
     const styling = fieldEl._styling || {};
+    if (fieldEl.dataset.type === 'chart') {
+      hideLegendLabel.classList.remove('hidden');
+      hideLegendCb.checked = !!styling.hideLegend;
+    } else {
+      hideLegendLabel.classList.add('hidden');
+    }
     menu.querySelector('[data-opt="bold"]').checked = !!styling.bold;
     menu.querySelector('[data-opt="italic"]').checked = !!styling.italic;
     menu.querySelector('[data-opt="underline"]').checked = !!styling.underline;
@@ -154,7 +169,8 @@ document.addEventListener('DOMContentLoaded', () => {
       italic: menu.querySelector('[data-opt="italic"]').checked,
       underline: menu.querySelector('[data-opt="underline"]').checked,
       color: selectedColor,
-      size: parseInt(sizeInput.value, 10) || null
+      size: parseInt(sizeInput.value, 10) || null,
+      hideLegend: hideLegendCb.checked
     });
     currentEl._styling = styling;
     applyStyling(currentEl, styling);

--- a/tests/test_admin_dashboard_views.py
+++ b/tests/test_admin_dashboard_views.py
@@ -137,6 +137,20 @@ def test_dashboard_update_style_success(client):
     update_widget_styling(widget['id'], original)
 
 
+def test_dashboard_update_style_hide_legend(client):
+    widget = get_dashboard_widgets()[0]
+    original = json.loads(widget.get('styling') or '{}')
+    resp = client.post(
+        '/dashboard/style',
+        json={'widget_id': widget['id'], 'styling': {'hideLegend': True}},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()['success']
+    updated = next(w for w in get_dashboard_widgets() if w['id'] == widget['id'])
+    assert json.loads(updated['styling']) == {'hideLegend': True}
+    update_widget_styling(widget['id'], original)
+
+
 def test_dashboard_update_style_invalid_data(client):
     resp = client.post('/dashboard/style', json={'widget_id': None, 'styling': 'x'})
     assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- allow toggling chart legends via right-click style menu
- expose chart instance for later manipulation
- document the new widget styling feature
- test dashboard style endpoint with hideLegend option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68568d560a2883338336f52276fc3cb3