### PR TITLE
Fix Chart.js canvas overflow

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -88,8 +88,12 @@ a:hover {
 /* Ensure Chart.js canvases fill their widget */
 .dashboard-widget canvas {
   width: 100% !important;
-  height: 100% !important; /* keep canvas within widget bounds */
-  flex: 1 1 auto;          /* let flexbox handle remaining height */
+  height: 100% !important;    /* keep canvas within widget bounds */
+  max-width: 100% !important; /* avoid any accidental overflow */
+  max-height: 100% !important;
+  box-sizing: border-box;     /* respect widget padding */
+  display: block;             /* remove inline baseline gap */
+  flex: 1 1 auto;             /* let flexbox handle remaining height */
 }
 
 /* allow scroll area to use remaining height */


### PR DESCRIPTION
## Summary
- avoid chart canvas overflow from widget container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68568e341df483339294aee835578846