### PR TITLE
Fix chart sizing without resize observer

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -85,17 +85,6 @@ a:hover {
   flex-direction: column;
 }
 
-/* Ensure Chart.js canvases fill their widget */
-.dashboard-widget canvas {
-  width: 100% !important;
-  height: 100% !important;    /* keep canvas within widget bounds */
-  max-width: 100% !important; /* avoid any accidental overflow */
-  max-height: 100% !important;
-  box-sizing: border-box;     /* respect widget padding */
-  display: block;             /* remove inline baseline gap */
-  flex: 1 1 auto;             /* let flexbox handle remaining height */
-}
-
 /* allow scroll area to use remaining height */
 .dashboard-widget > .overflow-auto {
   flex: 1 1 auto;

--- a/static/js/dashboard_charts.js
+++ b/static/js/dashboard_charts.js
@@ -6,12 +6,20 @@ document.addEventListener('DOMContentLoaded', () => {
     '#7C3AED'  // purple
   ];
 
-  function attachResize(widget, chart) {
-    if (!chart) return;
-    const ro = new ResizeObserver(() => {
-      try { chart.resize(); } catch (e) { console.error('chart resize error', e); }
-    });
-    ro.observe(widget);
+
+  function setInitialCanvasSize(widget, canvas) {
+    const rect = widget.getBoundingClientRect();
+    const style = getComputedStyle(widget);
+    const paddingX = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+    const paddingY = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+    const title = widget.querySelector('.font-semibold');
+    const titleHeight = title ? title.offsetHeight : 0;
+    const width = rect.width - paddingX;
+    const height = rect.height - paddingY - titleHeight;
+    if (width > 0 && height > 0) {
+      canvas.width = width;
+      canvas.height = height;
+    }
   }
 
   async function refreshChartWidget(widget) {
@@ -29,6 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const hideLegend = widget._styling && widget._styling.hideLegend;
     const canvas = widget.querySelector('canvas') || document.createElement('canvas');
     if (!canvas.parentElement) widget.appendChild(canvas);
+    setInitialCanvasSize(widget, canvas);
     if (widget._chart) {
       try { widget._chart.destroy(); } catch (e) { console.error('chart destroy error', e); }
     }
@@ -53,7 +62,6 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error('[dashboard_charts] pie data fetch error', err);
       }
       widget._chart = chartInstance;
-      attachResize(widget, chartInstance);
       return;
     }
 
@@ -75,7 +83,6 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error('[dashboard_charts] bar data fetch error', err);
       }
       widget._chart = chartInstance;
-      attachResize(widget, chartInstance);
       return;
     }
 
@@ -96,7 +103,6 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error('[dashboard_charts] line data fetch error', err);
       }
       widget._chart = chartInstance;
-      attachResize(widget, chartInstance);
       return;
     }
 
@@ -132,7 +138,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
     widget._chart = chartInstance;
-    attachResize(widget, chartInstance);
   }
 
   const chartWidgets = document.querySelectorAll('[data-type="chart"]');


### PR DESCRIPTION
## Summary
- drop custom chart canvas resizing CSS
- compute the initial canvas dimensions when charts are created
- remove ResizeObserver logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685697673a7483339d6198dfb096e5d0