### PR TITLE
Add dashboard widget deletion

### DIFF
--- a/db/dashboard.py
+++ b/db/dashboard.py
@@ -150,6 +150,22 @@ def update_widget_styling(widget_id: int, styling: dict) -> bool:
             return False
 
 
+def delete_widget(widget_id: int) -> bool:
+    """Remove a dashboard widget by ID."""
+    with get_connection() as conn:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "DELETE FROM dashboard_widget WHERE id = ?",
+                (widget_id,),
+            )
+            conn.commit()
+            return cur.rowcount > 0
+        except Exception as exc:
+            logger.warning("[delete_widget] SQL error: %s", exc)
+            return False
+
+
 def get_base_table_counts() -> list[dict]:
     """Return record counts for each base table."""
     base_tables = current_app.config.get("BASE_TABLES", [])

--- a/static/js/dashboard_grid.js
+++ b/static/js/dashboard_grid.js
@@ -11,6 +11,9 @@ const defaultWidgetHeight = {
 };
 
 const widgetLayout = window.WIDGET_LAYOUT || {};
+window.removeDashboardWidget = function(id) {
+  delete widgetLayout[id];
+};
 
 function enterEditMode() {
   const grid = document.getElementById('dashboard-grid');

--- a/static/js/field_styling.js
+++ b/static/js/field_styling.js
@@ -63,6 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
       <input type="hidden" data-opt="size" value="">
     </label>
     <div id="color-presets" class="flex space-x-1 mt-1"></div>
+    ${isDashboard ? '<button type="button" id="widget-delete-btn" class="btn-danger w-full">Remove Widget</button>' : ''}
   `;
   document.body.appendChild(menu);
 
@@ -75,6 +76,25 @@ document.addEventListener('DOMContentLoaded', () => {
   const SIZE_MIN = 10;
   const SIZE_MAX = 48;
   const SIZE_STEP = 1;
+
+  const deleteBtn = menu.querySelector('#widget-delete-btn');
+  if (deleteBtn) {
+    deleteBtn.addEventListener('click', () => {
+      if (!currentEl) return;
+      const wid = currentEl.dataset.widget;
+      if (!wid) return;
+      fetch(`/dashboard/widget/${wid}/delete`, { method: 'POST' })
+        .then(res => res.json())
+        .then(data => {
+          if (data.success) {
+            if (window.removeDashboardWidget) window.removeDashboardWidget(wid);
+            currentEl.remove();
+            menu.classList.add('hidden');
+          }
+        })
+        .catch(err => console.error('Dashboard widget delete failed', err));
+    });
+  }
 
   function updateSizeDisplay(val) {
     sizeDisplay.textContent = val || '';

--- a/tests/test_admin_dashboard_views.py
+++ b/tests/test_admin_dashboard_views.py
@@ -196,3 +196,22 @@ def test_dashboard_filtered_records_invalid_table(client):
     resp = client.get('/dashboard/filtered-records', query_string={'table': 'bad'})
     assert resp.status_code == 400
     assert resp.get_json() == []
+
+
+def test_dashboard_delete_widget(client):
+    data = {
+        'title': 'Delete Me',
+        'widget_type': 'value',
+        'content': '1',
+        'col_start': 1,
+        'col_span': 1,
+        'row_span': 1,
+    }
+    resp = client.post('/dashboard/widget', json=data)
+    assert resp.status_code == 200
+    wid = resp.get_json()['id']
+    del_resp = client.post(f'/dashboard/widget/{wid}/delete')
+    assert del_resp.status_code == 200
+    assert del_resp.get_json()['success']
+    widgets = get_dashboard_widgets()
+    assert all(w['id'] != wid for w in widgets)

--- a/views/admin/dashboard.py
+++ b/views/admin/dashboard.py
@@ -6,6 +6,7 @@ from db.dashboard import (
     create_widget,
     update_widget_layout,
     update_widget_styling,
+    delete_widget,
     get_base_table_counts,
     get_top_numeric_values,
     get_filtered_records,
@@ -104,6 +105,15 @@ def dashboard_update_style():
         return jsonify({'error': 'Invalid data'}), 400
     success = update_widget_styling(widget_id, styling)
     return jsonify({'success': bool(success)})
+
+
+@admin_bp.route('/dashboard/widget/<int:widget_id>/delete', methods=['POST'])
+def dashboard_delete_widget(widget_id):
+    """Delete a dashboard widget."""
+    success = delete_widget(widget_id)
+    if not success:
+        return jsonify({'error': 'Failed to delete widget'}), 500
+    return jsonify({'success': True})
 
 
 @admin_bp.route('/dashboard/base-count')


### PR DESCRIPTION
## Summary
- allow removing dashboard widgets from the UI
- delete widgets with a new API
- remove widget layout entry when deleted
- test widget deletion endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856bd1fce3083338c8bff8e953a2547