### PR TITLE
refactor: separate API routes

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,10 +74,12 @@ def wizard_redirect():
 from views.admin import admin_bp
 from views.records.record_views import records_bp
 from views.wizard import wizard_bp
+from views.api import api_bp
 
 app.register_blueprint(admin_bp)
 app.register_blueprint(records_bp)
 app.register_blueprint(wizard_bp)
+app.register_blueprint(api_bp)
 
 @app.context_processor
 def inject_field_schema():

--- a/views/admin/config.py
+++ b/views/admin/config.py
@@ -16,7 +16,6 @@ from db.config import get_config_rows, update_config
 from db.database import check_db_status, init_db_path
 from db.bootstrap import initialize_database, ensure_default_configs
 from db.schema import create_base_table
-from utils.field_registry import FIELD_TYPES
 from . import admin_bp, reload_app_state
 
 logger = logging.getLogger(__name__)
@@ -105,12 +104,6 @@ def update_database_file():
     if wants_json:
         return jsonify({'error': 'no_file'})
     return redirect(url_for('admin.database_page'))
-
-
-@admin_bp.route('/api/field-types')
-def api_field_types():
-    """Return list of available field types."""
-    return jsonify(list(FIELD_TYPES.keys()))
 
 
 @admin_bp.route('/add-table', methods=['POST'])

--- a/views/api.py
+++ b/views/api.py
@@ -1,0 +1,69 @@
+import logging
+from flask import Blueprint, request, jsonify, render_template
+from db.database import get_connection
+from db.schema import get_title_field
+from utils.field_registry import FIELD_TYPES
+from utils.records_helpers import build_list_context, require_base_table
+
+api_bp = Blueprint('api', __name__, url_prefix='/api')
+
+logger = logging.getLogger(__name__)
+
+@api_bp.route('/field-types')
+def api_field_types():
+    """Return list of available field types."""
+    return jsonify(list(FIELD_TYPES.keys()))
+
+
+@api_bp.route('/<table>/list')
+@require_base_table
+def api_list(table):
+    """Return id and label info for records in the table."""
+    search = request.args.get('search')
+    limit = request.args.get('limit', type=int)
+
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(f"PRAGMA table_info({table})")
+        cols = [r[1] for r in cur.fetchall()]
+        if not cols:
+            return jsonify([])
+        title_field = get_title_field(table)
+        if title_field:
+            label_field = title_field
+        elif table in cols:
+            label_field = table
+        elif len(cols) > 1:
+            label_field = cols[1]
+        else:
+            label_field = cols[0]
+
+        sql = f"SELECT id, {label_field} FROM {table}"
+        params = []
+        if search is not None:
+            sql += f" WHERE {label_field} LIKE ?"
+            params.append(f"%{search}%")
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        cur.execute(sql, params)
+        rows = cur.fetchall()
+
+    return jsonify([{'id': r[0], 'label': r[1]} for r in rows])
+
+
+@api_bp.route('/<table>/records')
+@require_base_table
+def api_records(table):
+    ctx = build_list_context(table)
+    rows = render_template('_record_rows.html', **ctx)
+    pager = render_template('_pagination.html', **ctx)
+    count = render_template('_record_count.html', **ctx)
+    filters = render_template('_filter_chips.html', **ctx)
+    ctx.update({
+        'rows_html': rows,
+        'pagination_html': pager,
+        'count_html': count,
+        'filters_html': filters,
+    })
+    return jsonify(ctx)

--- a/views/records/list_views.py
+++ b/views/records/list_views.py
@@ -3,8 +3,6 @@ import io
 import logging
 from flask import render_template, request, jsonify, Response
 
-from db.database import get_connection
-from db.schema import get_title_field
 from db.records import get_all_records
 
 from .record_views import records_bp
@@ -32,58 +30,6 @@ def list_view(table):
     return render_template('list_view.html', request=request, **ctx)
 
 
-@records_bp.route('/api/<table>/list')
-@require_base_table
-def api_list(table):
-    """Return id and label info for records in the table."""
-    search = request.args.get('search')
-    limit = request.args.get('limit', type=int)
-
-    with get_connection() as conn:
-        cur = conn.cursor()
-        cur.execute(f"PRAGMA table_info({table})")
-        cols = [r[1] for r in cur.fetchall()]
-        if not cols:
-            return jsonify([])
-        title_field = get_title_field(table)
-        if title_field:
-            label_field = title_field
-        elif table in cols:
-            label_field = table
-        elif len(cols) > 1:
-            label_field = cols[1]
-        else:
-            label_field = cols[0]
-
-        sql = f"SELECT id, {label_field} FROM {table}"
-        params = []
-        if search is not None:
-            sql += f" WHERE {label_field} LIKE ?"
-            params.append(f"%{search}%")
-        if limit is not None:
-            sql += " LIMIT ?"
-            params.append(limit)
-        cur.execute(sql, params)
-        rows = cur.fetchall()
-
-    return jsonify([{'id': r[0], 'label': r[1]} for r in rows])
-
-
-@records_bp.route('/api/<table>/records')
-@require_base_table
-def api_records(table):
-    ctx = build_list_context(table)
-    rows = render_template('_record_rows.html', **ctx)
-    pager = render_template('_pagination.html', **ctx)
-    count = render_template('_record_count.html', **ctx)
-    filters = render_template('_filter_chips.html', **ctx)
-    ctx.update({
-        'rows_html': rows,
-        'pagination_html': pager,
-        'count_html': count,
-        'filters_html': filters,
-    })
-    return jsonify(ctx)
 
 
 @records_bp.route('/<table>/export')


### PR DESCRIPTION
## Summary
- move general API endpoints into `views/api.py`
- register new blueprint in main app
- clean up admin config and list views

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856e5032b7883338f16027c4f464040