### PR TITLE
Add API blueprint and base tables endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Numerical Summaries:** `/<table>/sum-field` returns the sum for numeric columns, used by dashboard charts.
 * **List API:** `/api/<table>/list` provides ID and label data for dropdowns. It
   accepts optional `search` and `limit` query parameters to filter results.
+* **Base Tables API:** `/api/base-tables` returns the rows from `config_base_tables` for navigation metadata.
 * **CSV Import Workflow:** Upload a CSV on `/import`, map fields, then start a background job via `/import-start` and poll `/import-status` for progress.
 
 ## Project Structure
@@ -315,6 +316,7 @@ The following functions encapsulate the application logic:
 | `manage_relationship()`                       | **Route:** POST `/relationship` – AJAX endpoint for adding or removing a relationship between two records. It expects a JSON payload with `table_a`, `id_a`, `table_b`, `id_b`, and an `action` ("add" or "remove"). Depending on the action, it inserts or deletes a row in the `relationships` table using `INSERT OR IGNORE` for adds. On success, the endpoint returns JSON `{"success": True}`. Missing fields or invalid actions yield a 400 error and database errors return status 500. *(This function uses its own sqlite3 connection for simplicity.)* |
 | `dashboard()` | **Route:** GET `/dashboard` – Displays the dashboard page with draggable widgets.
 | `api_list(table)` | **Route:** GET `/api/<table>/list` – Returns JSON with `id` and `label` values for dropdowns. Supports optional `search` and `limit` query params. |
+| `api_base_tables()` | **Route:** GET `/api/base-tables` – Returns the contents of the `config_base_tables` table for navigation metadata. |
 
 | `add_field_route(table, record_id)` | **Route:** POST `/<table>/<int:record_id>/add-field` – Adds a new column to the table and updates the field schema. |
 | `remove_field_route(table, record_id)` | **Route:** POST `/<table>/<int:record_id>/remove-field` – Removes a column from the table and refreshes the schema. |

--- a/main.py
+++ b/main.py
@@ -74,10 +74,12 @@ def wizard_redirect():
 from views.admin import admin_bp
 from views.records.record_views import records_bp
 from views.wizard import wizard_bp
+from views.api import api_bp
 
 app.register_blueprint(admin_bp)
 app.register_blueprint(records_bp)
 app.register_blueprint(wizard_bp)
+app.register_blueprint(api_bp)
 
 @app.context_processor
 def inject_field_schema():

--- a/tests/test_api_base_tables.py
+++ b/tests/test_api_base_tables.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from main import app
+from db.database import init_db_path
+
+init_db_path('data/crossbook.db')
+app.testing = True
+client = app.test_client()
+
+
+def test_api_base_tables():
+    resp = client.get('/api/base-tables')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert any(row['table_name'] == 'content' for row in data)
+

--- a/views/api/__init__.py
+++ b/views/api/__init__.py
@@ -1,0 +1,15 @@
+import logging
+from flask import Blueprint, jsonify
+from db.database import get_connection
+from db.schema import load_card_info
+
+api_bp = Blueprint('api', __name__)
+
+logger = logging.getLogger(__name__)
+
+@api_bp.route('/api/base-tables')
+def api_base_tables():
+    """Return configured base tables with display info."""
+    with get_connection() as conn:
+        data = load_card_info(conn)
+    return jsonify(data)


### PR DESCRIPTION
## Summary
- provide `/api/base-tables` endpoint returning `config_base_tables`
- register new `api` blueprint in `main.py`
- document new endpoint
- test API returns expected data

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fbe7412083339b99006af755d642