### PR TITLE
Remove unused imports and verify clean flake8

### DIFF
--- a/tests/test_relationship_visibility.py
+++ b/tests/test_relationship_visibility.py
@@ -1,4 +1,5 @@
-import os, sys, sqlite3, json
+import os
+import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from main import app
 from db.database import init_db_path

--- a/tests/test_wizard_routes.py
+++ b/tests/test_wizard_routes.py
@@ -1,4 +1,3 @@
-import pytest
 
 
 def test_wizard_start_without_progress_redirects_home(client):

--- a/views/admin/config.py
+++ b/views/admin/config.py
@@ -13,7 +13,7 @@ from flask import (
 from werkzeug.utils import secure_filename
 from logging_setup import configure_logging
 from db.config import get_config_rows, update_config
-from db.database import check_db_status, init_db_path
+from db.database import check_db_status
 from db.bootstrap import initialize_database, ensure_default_configs
 from db.schema import create_base_table
 from utils.field_registry import FIELD_TYPES


### PR DESCRIPTION
## Summary
- clean up stray imports from config view and tests
- run flake8 to ensure no unused imports remain

## Testing
- `flake8 --select=F401`

------
https://chatgpt.com/codex/tasks/task_e_68570f73ee7c833393e8fb0b9c94094a