### PR TITLE
Refactor modal scripts with helper

### DIFF
--- a/static/js/add_table.js
+++ b/static/js/add_table.js
@@ -1,23 +1,11 @@
-let addTableTrigger = null;
-let escHandler = (e) => {
-  if (e.key === 'Escape') {
-    closeAddTableModal();
-  }
-};
+import { openModal, closeModal } from './modal_helper.js';
 
 export function openAddTableModal() {
-  addTableTrigger = document.activeElement;
-  document.getElementById('addTableModal').classList.remove('hidden');
-  document.addEventListener('keydown', escHandler);
+  openModal('addTableModal');
 }
 
 export function closeAddTableModal() {
-  document.getElementById('addTableModal').classList.add('hidden');
-  document.removeEventListener('keydown', escHandler);
-  if (addTableTrigger) {
-    addTableTrigger.focus();
-    addTableTrigger = null;
-  }
+  closeModal('addTableModal');
   const err = document.getElementById('tableError');
   if (err) {
     err.textContent = '';

--- a/static/js/bulk_edit_modal.js
+++ b/static/js/bulk_edit_modal.js
@@ -1,24 +1,12 @@
-let bulkTrigger = null;
-let escHandler = (e) => {
-  if (e.key === 'Escape') {
-    closeBulkEditModal();
-  }
-};
+import { openModal, closeModal } from './modal_helper.js';
 
 export function openBulkEditModal() {
   updateSelectedCount();
-  bulkTrigger = document.activeElement;
-  document.getElementById('bulkEditModal').classList.remove('hidden');
-  document.addEventListener('keydown', escHandler);
+  openModal('bulkEditModal');
 }
 
 export function closeBulkEditModal() {
-  document.getElementById('bulkEditModal').classList.add('hidden');
-  document.removeEventListener('keydown', escHandler);
-  if (bulkTrigger) {
-    bulkTrigger.focus();
-    bulkTrigger = null;
-  }
+  closeModal('bulkEditModal');
 }
 
 let tableName;

--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -1,28 +1,15 @@
 import { initValueWidgets, createValueWidget, updateColumnOptions } from './dashboard_modal/value.js';
 import { initTableWidgets, createTableWidget, updateTablePreview } from './dashboard_modal/table.js';
 import { initChartWidgets, createChartWidget, updateChartUI } from './dashboard_modal/chart.js';
-
-let dashboardTrigger = null;
-const escHandler = (e) => {
-  if (e.key === 'Escape') {
-    closeDashboardModal();
-  }
-};
+import { openModal, closeModal } from './modal_helper.js';
 
 export function openDashboardModal() {
-  dashboardTrigger = document.activeElement;
-  document.getElementById('dashboardModal').classList.remove('hidden');
-  document.addEventListener('keydown', escHandler);
+  openModal('dashboardModal');
   setActiveTab('value');
 }
 
 export function closeDashboardModal() {
-  document.getElementById('dashboardModal').classList.add('hidden');
-  document.removeEventListener('keydown', escHandler);
-  if (dashboardTrigger) {
-    dashboardTrigger.focus();
-    dashboardTrigger = null;
-  }
+  closeModal('dashboardModal');
 }
 
 let activeTab = 'value';

--- a/static/js/database_admin.js
+++ b/static/js/database_admin.js
@@ -1,3 +1,5 @@
+import { openModal, closeModal } from './modal_helper.js';
+
 function initDatabaseControls() {
   const uploadForm = document.getElementById('db-upload-form');
   if (uploadForm) {
@@ -53,26 +55,12 @@ function initDatabaseControls() {
 
 }
 
-let createDbTrigger = null;
-const escHandler = (e) => {
-  if (e.key === 'Escape') {
-    closeCreateDbModal();
-  }
-};
-
 export function openCreateDbModal() {
-  createDbTrigger = document.activeElement;
-  document.getElementById('createDbModal').classList.remove('hidden');
-  document.addEventListener('keydown', escHandler);
+  openModal('createDbModal');
 }
 
 export function closeCreateDbModal() {
-  document.getElementById('createDbModal').classList.add('hidden');
-  document.removeEventListener('keydown', escHandler);
-  if (createDbTrigger) {
-    createDbTrigger.focus();
-    createDbTrigger = null;
-  }
+  closeModal('createDbModal');
   const err = document.getElementById('create-db-error');
   if (err) {
     err.textContent = '';

--- a/static/js/modal_helper.js
+++ b/static/js/modal_helper.js
@@ -1,0 +1,29 @@
+const triggers = {};
+const handlers = {};
+
+export function openModal(id) {
+  const modal = document.getElementById(id);
+  if (!modal) return;
+  triggers[id] = document.activeElement;
+  modal.classList.remove('hidden');
+  handlers[id] = (e) => {
+    if (e.key === 'Escape') {
+      closeModal(id);
+    }
+  };
+  document.addEventListener('keydown', handlers[id]);
+}
+
+export function closeModal(id) {
+  const modal = document.getElementById(id);
+  if (!modal) return;
+  modal.classList.add('hidden');
+  if (handlers[id]) {
+    document.removeEventListener('keydown', handlers[id]);
+    delete handlers[id];
+  }
+  if (triggers[id]) {
+    triggers[id].focus();
+    delete triggers[id];
+  }
+}

--- a/static/js/new_record_modal.js
+++ b/static/js/new_record_modal.js
@@ -1,23 +1,11 @@
-let recordTrigger = null;
-const escHandler = (e) => {
-  if (e.key === 'Escape') {
-    closeNewRecordModal();
-  }
-};
+import { openModal, closeModal } from './modal_helper.js';
 
 export function openNewRecordModal() {
-  recordTrigger = document.activeElement;
-  document.getElementById('new_record_modal').classList.remove('hidden');
-  document.addEventListener('keydown', escHandler);
+  openModal('new_record_modal');
 }
 
 export function closeNewRecordModal() {
-  document.getElementById('new_record_modal').classList.add('hidden');
-  document.removeEventListener('keydown', escHandler);
-  if (recordTrigger) {
-    recordTrigger.focus();
-    recordTrigger = null;
-  }
+  closeModal('new_record_modal');
 }
 
 window.openNewRecordModal = openNewRecordModal;

--- a/views/admin/config.py
+++ b/views/admin/config.py
@@ -13,7 +13,7 @@ from flask import (
 from werkzeug.utils import secure_filename
 from logging_setup import configure_logging
 from db.config import get_config_rows, update_config
-from db.database import check_db_status
+from db.database import check_db_status, init_db_path
 from db.bootstrap import initialize_database, ensure_default_configs
 from db.schema import create_base_table
 from utils.field_registry import FIELD_TYPES


### PR DESCRIPTION
## Summary
- add `static/js/modal_helper.js` for common modal logic
- use the helper in add_table, new_record_modal, bulk_edit_modal, database_admin, and dashboard_modal
- reintroduce `init_db_path` import so tests can patch it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857106e6960833389f485ab17b397be