### PR TITLE
Refactor grid utilities

### DIFF
--- a/static/js/dashboard_grid.js
+++ b/static/js/dashboard_grid.js
@@ -1,3 +1,5 @@
+import { intersects, revertPosition } from './grid_utils.js';
+
 const defaultWidgetWidth = {
   value: 4,
   table: 10,
@@ -43,25 +45,6 @@ function exitEditMode() {
   if (editBtn) editBtn.classList.remove('hidden');
 }
 
-function intersects(a, b) {
-  return (
-    a.colStart <  b.colStart + b.colSpan  &&
-    b.colStart <  a.colStart + a.colSpan  &&
-    a.rowStart   <  b.rowStart   + b.rowSpan &&
-    b.rowStart   <  a.rowStart   + a.rowSpan
-  );
-}
-
-function revertPosition(el) {
-  const prev = el._prevRect;
-  if (!prev) return;
-  el.style.gridColumn = `${prev.colStart} / span ${prev.colSpan}`;
-  el.style.gridRow    = `${prev.rowStart} / span ${prev.rowSpan}`;
-  el.style.left = '';
-  el.style.top  = '';
-  el.style.position = '';
-  widgetLayout[el.dataset.widget] = { ...prev };
-}
 
 function saveDashboardLayout() {
   const layout = Object.entries(widgetLayout).map(([id, rect]) => ({
@@ -127,7 +110,7 @@ function enableDashboardDrag() {
     if (!isDragging) return;
     isDragging = false;
     if (!grid.classList.contains('editing')) {
-      revertPosition(widgetEl);
+      revertPosition(widgetEl, widgetLayout);
       console.debug('[dashboard] drag revert', widgetId);
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
@@ -151,7 +134,7 @@ function enableDashboardDrag() {
       other !== widgetId && intersects(widgetLayout[widgetId], rect)
     );
     if (hasOverlap) {
-      revertPosition(widgetEl);
+      revertPosition(widgetEl, widgetLayout);
       console.debug('[dashboard] drag revert', widgetId);
     } else {
       widgetEl.style.left = '';
@@ -233,7 +216,7 @@ function enableDashboardResize() {
     if (!isResizing) return;
     isResizing = false;
     if (!grid.classList.contains('editing')) {
-      revertPosition(widgetEl);
+      revertPosition(widgetEl, widgetLayout);
       console.debug('[dashboard] resize revert', widgetId);
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
@@ -254,7 +237,7 @@ function enableDashboardResize() {
       id !== widgetId && intersects(newRect, rect)
     );
     if (hasOverlap) {
-      revertPosition(widgetEl);
+      revertPosition(widgetEl, widgetLayout);
       console.debug('[dashboard] resize revert', widgetId);
     } else {
       widgetLayout[widgetId] = newRect;

--- a/static/js/grid_utils.js
+++ b/static/js/grid_utils.js
@@ -1,0 +1,25 @@
+export function intersects(a, b) {
+  return (
+    a.colStart < b.colStart + b.colSpan &&
+    b.colStart < a.colStart + a.colSpan &&
+    a.rowStart < b.rowStart + b.rowSpan &&
+    b.rowStart < a.rowStart + a.rowSpan
+  );
+}
+
+export function revertPosition(el, layout) {
+  const prev = el._prevRect;
+  if (!prev) return;
+  const { colStart, colSpan, rowStart, rowSpan } = prev;
+  el.style.gridColumn = `${colStart} / span ${colSpan}`;
+  el.style.gridRow = `${rowStart} / span ${rowSpan}`;
+  el.style.left = '';
+  el.style.top = '';
+  el.style.width = '';
+  el.style.height = '';
+  el.style.position = '';
+  if (layout) {
+    const key = el.dataset.field || el.dataset.widget;
+    if (key) layout[key] = { ...prev };
+  }
+}

--- a/static/js/layout_editor.js
+++ b/static/js/layout_editor.js
@@ -1,3 +1,5 @@
+import { intersects, revertPosition } from './grid_utils.js';
+
 const PCT_SNAP = 5;                // snap to 5% steps
 let CONTAINER_WIDTH;
 
@@ -31,35 +33,6 @@ function onLoadJS(){
   bindEventHandlers();
 }
 
-function intersects(a, b) {
-  return (
-    a.colStart <  b.colStart + b.colSpan  &&
-    b.colStart <  a.colStart + a.colSpan  &&
-    a.rowStart   <  b.rowStart   + b.rowSpan &&
-    b.rowStart   <  a.rowStart   + a.rowSpan
-  );
-}
-
-function revertPosition(el) {
-  const prev = el._prevRect;
-  if (!prev) {
-    // Intentionally silent if no previous rect
-    return;
-  }
-  const startCol = prev.colStart;
-  const spanCol  = prev.colSpan;
-  const startRow = prev.rowStart;
-  const spanRow  = prev.rowSpan;
-  el.style.gridColumn = `${startCol} / span ${spanCol}`;
-  el.style.gridRow    = `${startRow} / span ${spanRow}`;
-  el.style.left     = '';
-  el.style.width    = '';
-  el.style.top      = '';
-  el.style.height   = '';
-  el.style.position = '';
-  layoutCache[el.dataset.field] = { ...prev };
-  console.debug('[layout] revert', el.dataset.field, prev);
-}
 
 function resetLayout() {
   console.debug('[layout] resetLayout');
@@ -226,7 +199,7 @@ function enableVanillaDrag() {
     }
     if (overlapWith) {
       // snap back
-      revertPosition(fieldEl);
+      revertPosition(fieldEl, layoutCache);
       console.warn(`[layout] drag revert due to overlap with ${overlapWith}`);
       return;
     }
@@ -354,7 +327,7 @@ function enableVanillaResize() {
       }
     }
     if (overlapWith) {
-      revertPosition(fieldEl);
+      revertPosition(fieldEl, layoutCache);
       console.warn(`[layout] resize revert due to overlap with ${overlapWith}`);
     } else {
       layoutCache[field] = newRect;

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -252,7 +252,7 @@
       }
     });
   </script>
-<script src="{{ url_for('static', filename='js/layout_editor.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/layout_editor.js') }}"></script>
 <script src="{{ url_for('static', filename='js/field_styling.js') }}"></script>
 <script src="{{ url_for('static', filename='js/header_field_visibility.js') }}"></script>
 <script src="{{ url_for('static', filename='js/relation_visibility.js') }}"></script>


### PR DESCRIPTION
## Summary
- add `static/js/grid_utils.js` with reusable `intersects` and `revertPosition`
- import shared helpers in dashboard and layout scripts
- update detail view to load `layout_editor.js` as a module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685715266c8c83339a651464215301eb