### PR TITLE
Add table import tweaks

### DIFF
--- a/static/js/wizard_table.js
+++ b/static/js/wizard_table.js
@@ -88,6 +88,36 @@ function removeField(tidx, fidx) {
   updateFieldList(tidx);
 }
 
+function showTableSummaryModal() {
+  const modal = document.getElementById('tableSummaryModal');
+  const list = document.getElementById('table-summary-list');
+  list.innerHTML = '';
+  document.querySelectorAll('.table-form').forEach((div) => {
+    const idx = parseInt(div.dataset.index, 10);
+    const name = div.querySelector('input[name="table_name"]').value.trim();
+    if (!name) return;
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${name}</strong>: ${
+      (tables[idx] || [])
+        .map((f) => f.name)
+        .join(', ') || '(no fields)'
+    }`;
+    list.appendChild(li);
+  });
+  modal.classList.remove('hidden');
+  document.addEventListener('keydown', summaryEscHandler);
+}
+
+function hideTableSummaryModal() {
+  const modal = document.getElementById('tableSummaryModal');
+  modal.classList.add('hidden');
+  document.removeEventListener('keydown', summaryEscHandler);
+}
+
+const summaryEscHandler = (e) => {
+  if (e.key === 'Escape') hideTableSummaryModal();
+};
+
 function updateFieldList(idx) {
   const list = document.getElementById(`fields-list_${idx}`);
   list.innerHTML = '';
@@ -220,6 +250,8 @@ function addTableForm() {
 window.showAddFieldModal = showAddFieldModal;
 window.hideAddFieldModal = hideAddFieldModal;
 window.addTableForm = addTableForm;
+window.showTableSummaryModal = showTableSummaryModal;
+window.hideTableSummaryModal = hideTableSummaryModal;
 
 function initImportSchema() {
   const btn = document.getElementById('import-table-btn');
@@ -241,7 +273,18 @@ function handleImportFile(e) {
       .split(',')
       .map((h) => h.replace(/^"|"$/g, '').trim())
       .filter((h) => h);
-    const idx = addTableForm();
+    let idx;
+    if (
+      tables.length === 1 &&
+      tables[0].length === 0 &&
+      !document
+        .querySelector('.table-form[data-index="0"] input[name="table_name"]')
+        .value.trim()
+    ) {
+      idx = 0;
+    } else {
+      idx = addTableForm();
+    }
     const wrapper = document.querySelector(`.table-form[data-index="${idx}"]`);
     const nameInput = wrapper.querySelector('input[name="table_name"]');
     if (nameInput) {
@@ -261,6 +304,8 @@ document.addEventListener('DOMContentLoaded', () => {
   addTableForm();
   document.getElementById('field-form').addEventListener('submit', addField);
   initImportSchema();
+  const summaryBtn = document.getElementById('schema-summary-btn');
+  if (summaryBtn) summaryBtn.addEventListener('click', showTableSummaryModal);
 });
 
 window.initImportSchema = initImportSchema;

--- a/templates/wizard/wizard_table.html
+++ b/templates/wizard/wizard_table.html
@@ -10,6 +10,7 @@
   <div class="space-x-4">
     <button type="button" id="add-table-btn" onclick="addTableForm()" class="text-teal-600 text-4xl font-bold">+</button>
     <button type="button" id="import-table-btn" class="underline text-blue-600">Import Table Schema</button>
+    <button type="button" id="schema-summary-btn" class="underline text-blue-600">View Tables</button>
     <input type="file" id="import-table-file" accept=".csv" class="hidden">
   </div>
   <div class="wizard-nav">
@@ -54,6 +55,15 @@
         <button type="submit" class="btn-primary px-4 py-2 rounded">Add</button>
       </div>
     </form>
+  </div>
+</div>
+
+<!-- Table Summary Modal -->
+<div id="tableSummaryModal" class="modal-container hidden" onclick="if(event.target.id === 'tableSummaryModal') hideTableSummaryModal()">
+  <div class="modal-box w-96 max-w-full relative">
+    <button type="button" onclick="hideTableSummaryModal()" class="modal-close">&times;</button>
+    <h3 class="text-lg font-bold mb-4">Tables</h3>
+    <ul id="table-summary-list" class="list-disc pl-5 space-y-1"></ul>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- skip creating an empty form when importing table schemas
- allow viewing table summaries in the wizard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594f01780483338b6664c27535c845