### PR TITLE
Improve wizard file upload feedback

### DIFF
--- a/templates/wizard/wizard_database.html
+++ b/templates/wizard/wizard_database.html
@@ -2,6 +2,9 @@
 {% block title %}Setup - Database{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">Step 1: Choose or Create Database</h1>
+{% if error %}
+  <p class="text-red-600 mb-4">{{ error }}</p>
+{% endif %}
 <form method="post" enctype="multipart/form-data" class="space-y-4">
   <div class="form-group">
     <label class="block mb-1">Upload Database File</label>

--- a/templates/wizard/wizard_import.html
+++ b/templates/wizard/wizard_import.html
@@ -2,6 +2,9 @@
 {% block title %}Setup - Import Data{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">Step 4: Import CSV Data (optional)</h1>
+{% if error %}
+  <p class="text-red-600 mb-4">{{ error }}</p>
+{% endif %}
 <form method="post" enctype="multipart/form-data" class="space-y-4">
   <div class="form-group">
     <label class="block mb-1">Table</label>


### PR DESCRIPTION
## Summary
- add error handling to wizard database step
- validate import step and show CSV upload errors
- display error messages in database and import templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595704cc1883338cdca09240c95910