### PR TITLE
Disable DB change button until file chosen

### DIFF
--- a/static/js/database_admin.js
+++ b/static/js/database_admin.js
@@ -4,12 +4,25 @@ function initDatabaseControls() {
   const uploadForm = document.getElementById('db-upload-form');
   if (uploadForm) {
     const fileInput = uploadForm.querySelector('input[type="file"]');
+    const changeBtn = document.getElementById('change-db-btn');
+    if (changeBtn) {
+      changeBtn.disabled = true;
+      changeBtn.classList.add('opacity-50', 'cursor-not-allowed');
+    }
     if (fileInput) {
       fileInput.addEventListener('change', () => {
         if (fileInput.files && fileInput.files.length > 0) {
           console.log('File chosen:', fileInput.files[0].name);
+          if (changeBtn) {
+            changeBtn.disabled = false;
+            changeBtn.classList.remove('opacity-50', 'cursor-not-allowed');
+          }
         } else {
           console.log('File input cleared');
+          if (changeBtn) {
+            changeBtn.disabled = true;
+            changeBtn.classList.add('opacity-50', 'cursor-not-allowed');
+          }
         }
       });
     }

--- a/templates/admin/database_admin.html
+++ b/templates/admin/database_admin.html
@@ -7,10 +7,10 @@
 <div class="mx-auto w-11/12 max-w-screen-md space-y-6">
   <div class="card p-4 space-y-4">
     <div id="db-path-display" class="px-2 py-1 text-sm font-mono rounded {{ 'text-green-600' if db_status == 'valid' else 'text-red-600' }}">{{ db_path }}</div>
-    <form id="db-upload-form" class="flex items-center space-x-2" enctype="multipart/form-data">
-      <input type="file" name="file" accept=".db" class="form-control" />
-      <button type="submit" class="btn-danger">Change Database</button>
-    </form>
+      <form id="db-upload-form" class="flex items-center space-x-2" enctype="multipart/form-data">
+        <input type="file" name="file" accept=".db" class="form-control" />
+        <button id="change-db-btn" type="submit" class="btn-danger opacity-50 cursor-not-allowed" disabled>Change Database</button>
+      </form>
     <button id="create-db-btn" type="button" class="btn-primary" onclick="openCreateDbModal()">Create New DB</button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- disable the Change Database button by default
- enable button when a file is selected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595e3e5b5883339abc2defc13bea84