### PR TITLE
Add dashboard view dropdown

### DIFF
--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -174,7 +174,9 @@ def _create_core_tables(cur: sqlite3.Cursor) -> None:
             col_start INTEGER NOT NULL,
             col_span INTEGER NOT NULL,
             row_start INTEGER NOT NULL,
-            row_span INTEGER NOT NULL
+            row_span INTEGER NOT NULL,
+            styling TEXT,
+            "group" TEXT DEFAULT 'Dashboard'
         )
         """
     )

--- a/db/dashboard.py
+++ b/db/dashboard.py
@@ -31,7 +31,7 @@ def get_dashboard_widgets() -> list[dict]:
         cursor = conn.cursor()
         try:
             cursor.execute(
-                "SELECT id, title, content, widget_type, col_start, col_span, row_start, row_span, styling "
+                "SELECT id, title, content, widget_type, col_start, col_span, row_start, row_span, styling, \"group\" "
                 "FROM dashboard_widget ORDER BY id"
             )
             rows = cursor.fetchall()
@@ -49,6 +49,7 @@ def create_widget(
     col_span: int,
     row_start: int | None,
     row_span: int,
+    group: str = "Dashboard",
 ) -> int | None:
     if row_start is None:
         with get_connection() as conn:
@@ -65,10 +66,19 @@ def create_widget(
             cur.execute(
                 """
                 INSERT INTO dashboard_widget
-                    (title, content, widget_type, col_start, col_span, row_start, row_span)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                    (title, content, widget_type, col_start, col_span, row_start, row_span, "group")
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (title, content, widget_type, col_start, col_span, row_start, row_span),
+                (
+                    title,
+                    content,
+                    widget_type,
+                    col_start,
+                    col_span,
+                    row_start,
+                    row_span,
+                    group,
+                ),
             )
             conn.commit()
             return cur.lastrowid

--- a/static/js/dashboard_grid.js
+++ b/static/js/dashboard_grid.js
@@ -128,10 +128,14 @@ function enableDashboardDrag() {
       colStart: newColStart + 1,
       colSpan:  startRect.colSpan,
       rowStart: newRowStart + 1,
-      rowSpan:  startRect.rowSpan
+      rowSpan:  startRect.rowSpan,
+      group: startRect.group
     };
+    const currentView = window.DASHBOARD_VIEW || 'Dashboard';
     const hasOverlap = Object.entries(widgetLayout).some(([other, rect]) =>
-      other !== widgetId && intersects(widgetLayout[widgetId], rect)
+      other !== widgetId &&
+      rect.group === currentView &&
+      intersects(widgetLayout[widgetId], rect)
     );
     if (hasOverlap) {
       revertPosition(widgetEl, widgetLayout);
@@ -231,10 +235,14 @@ function enableDashboardResize() {
       colStart: parseInt(partsCol[0]),
       colSpan:  parseInt(partsCol[3]),
       rowStart: parseInt(partsRow[0]),
-      rowSpan:  parseInt(partsRow[3])
+      rowSpan:  parseInt(partsRow[3]),
+      group: widgetLayout[widgetId].group
     };
+    const currentView = window.DASHBOARD_VIEW || 'Dashboard';
     const hasOverlap = Object.entries(widgetLayout).some(([id, rect]) =>
-      id !== widgetId && intersects(newRect, rect)
+      id !== widgetId &&
+      rect.group === currentView &&
+      intersects(newRect, rect)
     );
     if (hasOverlap) {
       revertPosition(widgetEl, widgetLayout);

--- a/static/js/dashboard_modal/chart.js
+++ b/static/js/dashboard_modal/chart.js
@@ -200,7 +200,8 @@ export async function createChartWidget() {
     col_start: 1,
     col_span: 10,
     row_start: 1,
-    row_span: 12
+    row_span: 12,
+    group: window.DASHBOARD_VIEW || 'Dashboard'
   };
   try {
     const res = await fetch('/dashboard/widget', {

--- a/static/js/dashboard_modal/table.js
+++ b/static/js/dashboard_modal/table.js
@@ -354,7 +354,8 @@ export async function createTableWidget() {
     col_start: 1,
     col_span: 10,
     row_start: 1,
-    row_span: 8
+    row_span: 8,
+    group: window.DASHBOARD_VIEW || 'Dashboard'
   };
   try {
     const res = await fetch('/dashboard/widget', {

--- a/static/js/dashboard_modal/value.js
+++ b/static/js/dashboard_modal/value.js
@@ -400,7 +400,8 @@ export async function createValueWidget() {
     col_start: 1,
     col_span: 4,
     row_start: 1,
-    row_span: 3
+    row_span: 3,
+    group: window.DASHBOARD_VIEW || 'Dashboard'
   };
 
   try {

--- a/static/js/dashboard_views.js
+++ b/static/js/dashboard_views.js
@@ -1,0 +1,35 @@
+export function initDashboardViews() {
+  const select = document.getElementById('dashboardViewSelect');
+  const addBtn = document.getElementById('addDashboardView');
+
+  function updateVisibility() {
+    const view = select ? select.value : 'Dashboard';
+    window.DASHBOARD_VIEW = view;
+    document.querySelectorAll('#dashboard-grid .dashboard-widget').forEach(el => {
+      el.classList.toggle('hidden', el.dataset.group !== view);
+    });
+  }
+
+  if (select) {
+    select.addEventListener('change', updateVisibility);
+  }
+  if (addBtn && select) {
+    addBtn.addEventListener('click', () => {
+      const name = prompt('View name:');
+      if (!name) return;
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name;
+      select.appendChild(opt);
+      select.value = name;
+      updateVisibility();
+    });
+  }
+  updateVisibility();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initDashboardViews);
+} else {
+  initDashboardViews();
+}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -8,6 +8,17 @@
 <button id="dashboard_save" class="btn-secondary hidden">Save Layout</button>
 {% endblock %}
 
+{% block header_actions %}
+<div class="flex items-center space-x-2">
+  <select id="dashboardViewSelect" class="form-select px-2 py-1 text-sm">
+    {% for g in groups %}
+    <option value="{{ g }}" {% if g == view %}selected{% endif %}>{{ g }}</option>
+    {% endfor %}
+  </select>
+  <button id="addDashboardView" class="btn-secondary px-2">+</button>
+</div>
+{% endblock %}
+
 {% block content %}
 <div class="flex items-center mb-4">
   <h1 class="text-3xl font-bold mr-4">Dashboard</h1>
@@ -31,11 +42,13 @@
       'colStart': col_start,
       'colSpan': col_span,
       'rowStart': row_start,
-      'rowSpan': row_span
+      'rowSpan': row_span,
+      'group': widget.group or 'Dashboard'
     } }) %}
     <div id="widget-{{ widget.id }}" class="dashboard-widget draggable-field min-h-0 border p-2 rounded shadow bg-card"
          data-widget="{{ widget.id }}"
          data-type="{{ widget.widget_type }}"
+         data-group="{{ widget.group or 'Dashboard' }}"
          {% if widget.widget_type in ['chart', 'value'] %}data-config='{{ widget.content }}'{% endif %}
          data-styling="{{ widget.styling or '{}' }}"
          style="grid-column: {{ col_start }} / span {{ col_span }}; grid-row: {{ row_start }} / span {{ row_span }};">
@@ -101,6 +114,7 @@
 
 <script>const FIELD_SCHEMA = {{ field_schema | tojson }};</script>
 <script>window.WIDGET_LAYOUT = {{ widget_layout | tojson }};</script>
+<script>window.DASHBOARD_VIEW = {{ view | tojson }}; window.DASHBOARD_GROUPS = {{ groups | tojson }};</script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('#dashboard-grid .draggable-field').forEach(el => {
@@ -122,5 +136,6 @@
 <script type="module" src="{{ url_for('static', filename='js/dashboard_grid.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_charts.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_values.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/dashboard_views.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/dashboard_update.js') }}"></script>
 {% endblock %}

--- a/views/admin/dashboard.py
+++ b/views/admin/dashboard.py
@@ -21,13 +21,17 @@ logger = logging.getLogger(__name__)
 @admin_bp.route('/dashboard')
 def dashboard():
     widgets = get_dashboard_widgets()
+    view = request.args.get("view") or "Dashboard"
+    groups = sorted({(w.get("group") or "Dashboard") for w in widgets})
     for w in widgets:
         if w.get('widget_type') == 'table':
             try:
                 w['parsed'] = json.loads(w.get('content') or '{}')
             except Exception:
                 w['parsed'] = {}
-    return render_template('dashboard.html', widgets=widgets)
+    return render_template(
+        'dashboard.html', widgets=widgets, view=view, groups=groups
+    )
 
 
 @admin_bp.route('/dashboard/widget', methods=['POST'])
@@ -70,6 +74,7 @@ def dashboard_create_widget():
         if content is None:
             content = ''
 
+    group = (data.get('group') or 'Dashboard').strip() or 'Dashboard'
     widget_id = create_widget(
         title,
         content,
@@ -78,6 +83,7 @@ def dashboard_create_widget():
         col_span,
         None,
         row_span,
+        group,
     )
 
     if not widget_id:


### PR DESCRIPTION
## Summary
- allow multiple dashboard views
- store widget view grouping in DB
- restrict overlap checks to current view
- create widgets in the active view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595d80406c8333a889f82f21b768b8