### PR TITLE
Add modal for dashboard view creation

### DIFF
--- a/static/js/dashboard_views.js
+++ b/static/js/dashboard_views.js
@@ -1,6 +1,10 @@
+import { openModal, closeModal } from './modal_helper.js';
+
 export function initDashboardViews() {
   const select = document.getElementById('dashboardViewSelect');
   const addBtn = document.getElementById('addDashboardView');
+  const form = document.getElementById('dashboardViewForm');
+  const nameInput = document.getElementById('dashboardViewName');
 
   function updateVisibility() {
     const view = select ? select.value : 'Dashboard';
@@ -13,20 +17,40 @@ export function initDashboardViews() {
   if (select) {
     select.addEventListener('change', updateVisibility);
   }
-  if (addBtn && select) {
+  function addView(name) {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    select.appendChild(opt);
+    select.value = name;
+    updateVisibility();
+  }
+
+  if (addBtn && select && form && nameInput) {
     addBtn.addEventListener('click', () => {
-      const name = prompt('View name:');
-      if (!name) return;
-      const opt = document.createElement('option');
-      opt.value = name;
-      opt.textContent = name;
-      select.appendChild(opt);
-      select.value = name;
-      updateVisibility();
+      nameInput.value = '';
+      openModal('dashboardViewModal');
+    });
+
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const name = nameInput.value.trim();
+      if (!name) {
+        closeModal('dashboardViewModal');
+        return;
+      }
+      addView(name);
+      closeModal('dashboardViewModal');
     });
   }
   updateVisibility();
 }
+
+export function closeDashboardViewModal() {
+  closeModal('dashboardViewModal');
+}
+
+window.closeDashboardViewModal = closeDashboardViewModal;
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', initDashboardViews);

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -111,6 +111,7 @@
 </div>
 
 {% include "modals/dashboard_modal.html" %}
+{% include "modals/dashboard_view_modal.html" %}
 
 <script>const FIELD_SCHEMA = {{ field_schema | tojson }};</script>
 <script>window.WIDGET_LAYOUT = {{ widget_layout | tojson }};</script>

--- a/templates/modals/dashboard_view_modal.html
+++ b/templates/modals/dashboard_view_modal.html
@@ -1,0 +1,15 @@
+<div id="dashboardViewModal" class="modal-container hidden" onclick="if(event.target.id === 'dashboardViewModal') closeDashboardViewModal()">
+  <div class="modal-box">
+    <button type="button" onclick="closeDashboardViewModal()" class="modal-close">&times;</button>
+    <h3 class="text-lg font-bold mb-4">Create Dashboard View</h3>
+    <form id="dashboardViewForm" class="form-layout">
+      <div class="modal-form-group form-group">
+        <label for="dashboardViewName" class="form-label">View Name</label>
+        <input id="dashboardViewName" type="text" class="form-input" required>
+      </div>
+      <div class="modal-form-group flex justify-end">
+        <button type="submit" class="btn-primary">Add</button>
+      </div>
+    </form>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- show a styled modal when creating dashboard views
- attach the view-creation modal to the dashboard page
- wire up modal logic in `dashboard_views.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859616ae8648333b0a695cf8ca93937