### PR TITLE
Centralize field type registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 │   ├── records.py                   # CRUD and list/detail endpoints
 │   └── wizard.py                    # Setup wizard workflow
 ├── utils/                           # Shared helper modules
-│   ├── field_registry.py            # Field type registry and defaults
+│   ├── field_registry.py            # Field type registry with layout sizes and macro names
 │   ├── html_sanitizer.py            # Sanitize editor HTML
 │   └── validation.py                # CSV import validation functions
 ├── tests/                           # Automated tests
@@ -252,7 +252,7 @@ The worker also processes scheduled automation tasks defined in `automation/engi
 * **Templating & Macros:** Jinja2 templates in `templates/` include the core pages (`base.html`, `index.html`, `list_view.html`, `detail_view.html`, `new_record.html`, `dashboard.html`) plus admin and import views. Partial templates like `modals/edit_fields_modal.html` and `modals/bulk_edit_modal.html` are used for modals. Reusable macros live in `templates/macros/fields.html` and `filter_controls.html`.
 
 * **Logging & Monitoring:** Logging is configured via `logging_setup.py` and values stored in the database. Both Flask and root handlers are cleared, then a rotating or timed file handler is attached. Only error-level messages appear in the console. Werkzeug request logs are disabled. Logs capture errors and user actions. See the section below for configuration details.
-* **Utility Helpers:** Helper modules in `utils/` include field type registration, HTML sanitization and the CSV import validator.
+* **Utility Helpers:** Helper modules in `utils/` include field type registration, HTML sanitization and the CSV import validator. The registry centralizes layout defaults and the Jinja macro used for each field type.
 
 * **Data Directory:** Runtime files under `data/`: `crossbook.db` (primary database) and `huey.db` (task queue store). The `db_path` entry in the `config` table can point the application at a different database file.
 

--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -36,26 +36,16 @@ DEFAULT_CONFIGS = [
     ("relationship_visibility", "{}", "general", "json", 0),
 ]
 
-LAYOUT_DEFAULTS = {
-    "width": {
-        "textarea": 12,
-        "select": 5,
-        "text": 12,
-        "foreign_key": 5,
-        "boolean": 3,
-        "number": 4,
-        "multi_select": 6,
-    },
-    "height": {
-        "textarea": 18,
-        "select": 4,
-        "text": 4,
-        "foreign_key": 10,
-        "boolean": 7,
-        "number": 3,
-        "multi_select": 8,
-    },
-}
+
+def get_layout_defaults() -> dict:
+    """Return mapping of field type -> layout width/height defaults."""
+    from utils.field_registry import get_type_size_map
+
+    size_map = get_type_size_map()
+    return {
+        "width": {k: v[0] for k, v in size_map.items()},
+        "height": {k: v[1] for k, v in size_map.items()},
+    }
 
 
 def _copy_config_metadata(cur: sqlite3.Cursor, dest_path: str) -> None:

--- a/db/config.py
+++ b/db/config.py
@@ -52,14 +52,29 @@ def get_config_rows(sections: str | list[str] | None = None):
 
 
 def get_layout_defaults() -> dict:
-    """Return layout width/height defaults from the config table."""
+    """Return layout width/height defaults from the config table or registry."""
+    from utils.field_registry import get_type_size_map
+
     with get_connection() as conn:
         cur = conn.cursor()
         cur.execute("SELECT value FROM config WHERE key = 'layout_defaults'")
         row = cur.fetchone()
 
-    if not row:
-        return {}
+    data = {}
+    if row and row[0]:
+        try:
+            data = json.loads(row[0])
+        except Exception:
+            data = {}
+
+    if not data:
+        size_map = get_type_size_map()
+        data = {
+            "width": {k: v[0] for k, v in size_map.items()},
+            "height": {k: v[1] for k, v in size_map.items()},
+        }
+
+    return data
 
 
 def get_relationship_visibility() -> dict:

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -115,7 +115,7 @@
                  field, value, record.id, request,
                 'detail_view', 'records.update_field',
                 'record_id', field_schema[table][field].type, table,
-                 field_schema, field_macro_map) }}
+                 field_schema, field_macro_map, fields) }}
             <!-- resize handles (hidden until edit mode) -->
             <span class="resize-handle hidden top-left"></span>
             <span class="resize-handle hidden top-right"></span>

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -199,31 +199,16 @@
   {% endif %}
 {% endmacro %}
 
-{% macro render_editable_field(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema, field_macro_map=None) %}
+{% macro render_editable_field(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema, field_macro_map=None, macros_obj=None) %}
   {% set edit_param = request.args.get('edit') %}
   {% set styling = field_schema[table][field].styling or {} %}
   <div class="mt-2 h-full{{ ' font-bold' if styling.bold }}{{ ' italic' if styling.italic }}{{ ' underline' if styling.underline }} draggable-field"
        data-styling='{{ styling | tojson }}'>
     {% do current_app.logger.debug('[render] field=%s type=%s edit_param=%s', field, field_type, edit_param) %}
     <label class="block text-sm font-medium capitalize">{{ field }}</label>
-    {% if field_type == 'text' %}
-      {{ render_text(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
-    {% elif field_type == 'number' %}
-      {{ render_number(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
-    {% elif field_type == 'date' %}
-      {{ render_date(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
-    {% elif field_type == 'select' %}
-      {{ render_select(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
-    {% elif field_type == 'multi_select' %}
-      {{ render_multi_select(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
-    {% elif field_type == 'foreign_key' %}
-      {{ render_foreign_key(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
-    {% elif field_type == 'boolean' %}
-      {{ render_boolean(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
-    {% elif field_type == 'textarea' %}
-      {{ render_textarea(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
-    {% elif field_type == 'url' %}
-      {{ render_url(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
+    {% set macro_name = field_macro_map[field_type] if field_macro_map else None %}
+    {% if macro_name and macros_obj %}
+      {{ (macros_obj | attr(macro_name))(field, value, record_id, request, detail_endpoint, update_endpoint, id_param, field_type, table, field_schema) }}
     {% else %}
       <span class="ml-1" data-field="{{ field }}"><b>{{ field|capitalize }}:</b> {{ value }}</span>
     {% endif %}

--- a/tests/test_field_registry.py
+++ b/tests/test_field_registry.py
@@ -9,7 +9,7 @@ def test_register_get_and_size_map():
     # ensure clean state
     if 'tmp_test' in FIELD_TYPES:
         FIELD_TYPES.pop('tmp_test')
-    register_type('tmp_test', sql_type='INTEGER', default_width=7, default_height=9)
+    register_type('tmp_test', sql_type='INTEGER', default_width=7, default_height=9, macro='render_text')
 
     ft = get_field_type('tmp_test')
     assert ft.name == 'tmp_test'
@@ -17,5 +17,6 @@ def test_register_get_and_size_map():
 
     size_map = get_type_size_map()
     assert size_map['tmp_test'] == (7, 9)
+    assert ft.macro == 'render_text'
 
     FIELD_TYPES.pop('tmp_test', None)

--- a/tests/test_layout_defaults.py
+++ b/tests/test_layout_defaults.py
@@ -1,0 +1,21 @@
+import sqlite3
+from db.database import DB_PATH
+from db.config import get_layout_defaults, update_config
+from utils.field_registry import get_type_size_map
+
+
+def test_get_layout_defaults_uses_registry():
+    with sqlite3.connect(DB_PATH) as conn:
+        row = conn.execute("SELECT value FROM config WHERE key='layout_defaults'").fetchone()
+        original = row[0] if row else ''
+    try:
+        update_config('layout_defaults', '')
+        defaults = get_layout_defaults()
+        size_map = get_type_size_map()
+        expected = {
+            'width': {k: v[0] for k, v in size_map.items()},
+            'height': {k: v[1] for k, v in size_map.items()},
+        }
+        assert defaults == expected
+    finally:
+        update_config('layout_defaults', original)


### PR DESCRIPTION
## Summary
- store macro names for editable fields in field registry
- generate layout defaults from the registry
- dynamically dispatch macros for detail view fields
- document centralized field registry
- test get_layout_defaults fallbacks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685961baddd08333ab1e97e481f8d313