### PR TITLE
Add searchable flag to field types

### DIFF
--- a/db/query_filters.py
+++ b/db/query_filters.py
@@ -2,6 +2,7 @@ import logging
 from db.database import SUPPORTS_REGEX
 from db.schema import get_field_schema
 from db.validation import validate_fields
+from utils.field_registry import FIELD_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -126,9 +127,9 @@ def _build_filters(
         search_term = search.strip()
         all_fields = get_field_schema()[table]
         search_fields = [
-            field
-            for field, meta in all_fields.items()
-            if meta["type"] in ("text", "textarea", "select", "multi_select", "url")
+            f
+            for f, m in all_fields.items()
+            if m["type"] in FIELD_TYPES and FIELD_TYPES[m["type"]].searchable
         ]
         if search_fields:
             validate_fields(table, search_fields)

--- a/tests/test_field_registry.py
+++ b/tests/test_field_registry.py
@@ -9,11 +9,13 @@ def test_register_get_and_size_map():
     # ensure clean state
     if 'tmp_test' in FIELD_TYPES:
         FIELD_TYPES.pop('tmp_test')
-    register_type('tmp_test', sql_type='INTEGER', default_width=7, default_height=9, macro='render_text')
+    register_type('tmp_test', sql_type='INTEGER', default_width=7, default_height=9, macro='render_text', searchable=True)
 
     ft = get_field_type('tmp_test')
     assert ft.name == 'tmp_test'
     assert ft.sql_type == 'INTEGER'
+
+    assert ft.searchable is True
 
     size_map = get_type_size_map()
     assert size_map['tmp_test'] == (7, 9)

--- a/tests/test_query_filters.py
+++ b/tests/test_query_filters.py
@@ -6,6 +6,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from db.database import init_db_path
 from db.query_filters import _build_filters
 from db.schema import get_field_schema
+from utils.field_registry import FIELD_TYPES
 
 init_db_path('data/crossbook.db')
 
@@ -14,7 +15,7 @@ def test_build_filters_search_clause():
     fields = [
         f
         for f, meta in get_field_schema()['character'].items()
-        if meta['type'] in ('text', 'textarea', 'select', 'multi_select', 'url')
+        if meta['type'] in FIELD_TYPES and FIELD_TYPES[meta['type']].searchable
     ]
     clauses, params = _build_filters('character', search='foo')
     assert len(clauses) == 1

--- a/utils/field_registry.py
+++ b/utils/field_registry.py
@@ -1,16 +1,42 @@
 class FieldType:
-    def __init__(self, name, sql_type='TEXT', validator=None, default_width=6, default_height=4, macro=None):
+    def __init__(
+        self,
+        name,
+        sql_type="TEXT",
+        validator=None,
+        default_width=6,
+        default_height=4,
+        macro=None,
+        searchable=False,
+    ):
         self.name = name
         self.sql_type = sql_type
         self.validator = validator
         self.default_width = default_width
         self.default_height = default_height
         self.macro = macro
+        self.searchable = searchable
 
 FIELD_TYPES = {}
 
-def register_type(name, sql_type='TEXT', validator=None, default_width=6, default_height=4, macro=None):
-    FIELD_TYPES[name] = FieldType(name, sql_type, validator, default_width, default_height, macro)
+def register_type(
+    name,
+    sql_type="TEXT",
+    validator=None,
+    default_width=6,
+    default_height=4,
+    macro=None,
+    searchable=False,
+):
+    FIELD_TYPES[name] = FieldType(
+        name,
+        sql_type,
+        validator,
+        default_width,
+        default_height,
+        macro,
+        searchable,
+    )
 
 
 def get_field_type(name):

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -182,13 +182,13 @@ def validate_multi_select_column(values: list[str], options: list[str]) -> dict:
     }
 
 # Register built-in field types with the registry
-register_type('title', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=12, default_height=4, macro='render_text')
-register_type('text', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=12, default_height=4, macro='render_text')
+register_type('title', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=12, default_height=4, macro='render_text', searchable=True)
+register_type('text', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=12, default_height=4, macro='render_text', searchable=True)
 register_type('number', sql_type='REAL', validator=lambda t, f, v: validate_number_column(v), default_width=4, default_height=3, macro='render_number')
 register_type('date', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=6, default_height=4, macro='render_date')
-register_type('select', sql_type='TEXT', validator=lambda t, f, v: validate_select_column(v, SCHEMA[t][f]['options']), default_width=5, default_height=4, macro='render_select')
-register_type('multi_select', sql_type='TEXT', validator=lambda t, f, v: validate_multi_select_column(v, SCHEMA[t][f]['options']), default_width=6, default_height=8, macro='render_multi_select')
+register_type('select', sql_type='TEXT', validator=lambda t, f, v: validate_select_column(v, SCHEMA[t][f]['options']), default_width=5, default_height=4, macro='render_select', searchable=True)
+register_type('multi_select', sql_type='TEXT', validator=lambda t, f, v: validate_multi_select_column(v, SCHEMA[t][f]['options']), default_width=6, default_height=8, macro='render_multi_select', searchable=True)
 register_type('foreign_key', sql_type='TEXT', validator=lambda t, f, v: validate_select_column(v, SCHEMA[t][f]['options']), default_width=5, default_height=10, macro='render_foreign_key')
 register_type('boolean', sql_type='INTEGER', validator=lambda t, f, v: validate_boolean_column(v), default_width=3, default_height=7, macro='render_boolean')
-register_type('textarea', sql_type='TEXT', validator=lambda t, f, v: validate_textarea_column(v), default_width=12, default_height=18, macro='render_textarea')
-register_type('url', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=12, default_height=4, macro='render_url')
+register_type('textarea', sql_type='TEXT', validator=lambda t, f, v: validate_textarea_column(v), default_width=12, default_height=18, macro='render_textarea', searchable=True)
+register_type('url', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=12, default_height=4, macro='render_url', searchable=True)


### PR DESCRIPTION
## Summary
- add `searchable` attribute to `FieldType`
- mark text-like field types as searchable when registered
- use registry when collecting searchable fields
- adjust tests for new `searchable` behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685968c9fb908333810cac4247811883