### PR TITLE
Update field type registry with filter and normalization settings

### DIFF
--- a/utils/validation.py
+++ b/utils/validation.py
@@ -181,14 +181,125 @@ def validate_multi_select_column(values: list[str], options: list[str]) -> dict:
         "details": details
     }
 
+
+def normalize_boolean(value):
+    return "1" if str(value).lower() in {"1", "true", "on", "yes"} else "0"
+
+
+def normalize_number(value):
+    try:
+        return str(float(value))
+    except (TypeError, ValueError):
+        return "0"
+
+
+def normalize_multi(value):
+    if isinstance(value, (list, tuple, set)):
+        return ", ".join(str(v) for v in value)
+    return "" if value is None else str(value)
+
 # Register built-in field types with the registry
-register_type('title', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=12, default_height=4, macro='render_text', searchable=True)
-register_type('text', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=12, default_height=4, macro='render_text', searchable=True)
-register_type('number', sql_type='REAL', validator=lambda t, f, v: validate_number_column(v), default_width=4, default_height=3, macro='render_number')
-register_type('date', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=6, default_height=4, macro='render_date')
-register_type('select', sql_type='TEXT', validator=lambda t, f, v: validate_select_column(v, SCHEMA[t][f]['options']), default_width=5, default_height=4, macro='render_select', searchable=True)
-register_type('multi_select', sql_type='TEXT', validator=lambda t, f, v: validate_multi_select_column(v, SCHEMA[t][f]['options']), default_width=6, default_height=8, macro='render_multi_select', searchable=True)
-register_type('foreign_key', sql_type='TEXT', validator=lambda t, f, v: validate_select_column(v, SCHEMA[t][f]['options']), default_width=5, default_height=10, macro='render_foreign_key')
-register_type('boolean', sql_type='INTEGER', validator=lambda t, f, v: validate_boolean_column(v), default_width=3, default_height=7, macro='render_boolean')
-register_type('textarea', sql_type='TEXT', validator=lambda t, f, v: validate_textarea_column(v), default_width=12, default_height=18, macro='render_textarea', searchable=True)
-register_type('url', sql_type='TEXT', validator=lambda t, f, v: validate_text_column(v), default_width=12, default_height=4, macro='render_url', searchable=True)
+register_type(
+    'title',
+    sql_type='TEXT',
+    validator=lambda t, f, v: validate_text_column(v),
+    default_width=12,
+    default_height=4,
+    macro='render_text',
+    filter_macro='text_filter',
+    searchable=True,
+)
+register_type(
+    'text',
+    sql_type='TEXT',
+    validator=lambda t, f, v: validate_text_column(v),
+    default_width=12,
+    default_height=4,
+    macro='render_text',
+    filter_macro='text_filter',
+    searchable=True,
+)
+register_type(
+    'number',
+    sql_type='REAL',
+    validator=lambda t, f, v: validate_number_column(v),
+    default_width=4,
+    default_height=3,
+    macro='render_number',
+    filter_macro='number_filter',
+    normalizer=normalize_number,
+    numeric=True,
+)
+register_type(
+    'date',
+    sql_type='TEXT',
+    validator=lambda t, f, v: validate_text_column(v),
+    default_width=6,
+    default_height=4,
+    macro='render_date',
+    filter_macro='date_filter',
+)
+register_type(
+    'select',
+    sql_type='TEXT',
+    validator=lambda t, f, v: validate_select_column(v, SCHEMA[t][f]['options']),
+    default_width=5,
+    default_height=4,
+    macro='render_select',
+    filter_macro='select_filter',
+    allows_options=True,
+    searchable=True,
+)
+register_type(
+    'multi_select',
+    sql_type='TEXT',
+    validator=lambda t, f, v: validate_multi_select_column(v, SCHEMA[t][f]['options']),
+    default_width=6,
+    default_height=8,
+    macro='render_multi_select',
+    filter_macro='multi_select_popover',
+    normalizer=normalize_multi,
+    allows_options=True,
+    searchable=True,
+)
+register_type(
+    'foreign_key',
+    sql_type='TEXT',
+    validator=lambda t, f, v: validate_select_column(v, SCHEMA[t][f]['options']),
+    default_width=5,
+    default_height=10,
+    macro='render_foreign_key',
+    filter_macro='multi_select_popover',
+    normalizer=normalize_multi,
+    allows_foreign_key=True,
+)
+register_type(
+    'boolean',
+    sql_type='INTEGER',
+    validator=lambda t, f, v: validate_boolean_column(v),
+    default_width=3,
+    default_height=7,
+    macro='render_boolean',
+    filter_macro='boolean_filter',
+    normalizer=normalize_boolean,
+)
+register_type(
+    'textarea',
+    sql_type='TEXT',
+    validator=lambda t, f, v: validate_textarea_column(v),
+    default_width=12,
+    default_height=18,
+    macro='render_textarea',
+    filter_macro='text_filter',
+    searchable=True,
+)
+register_type(
+    'url',
+    sql_type='TEXT',
+    validator=lambda t, f, v: validate_text_column(v),
+    default_width=12,
+    default_height=4,
+    macro='render_url',
+    filter_macro='text_filter',
+    searchable=True,
+)


### PR DESCRIPTION
## Summary
- add normalizer helpers
- register built‑in field types with filter macros and other new flags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596cddcad883338afa34ed3a4ada0c