### PR TITLE
Add admin fields overview page

### DIFF
--- a/templates/admin/admin.html
+++ b/templates/admin/admin.html
@@ -21,5 +21,9 @@
     <h2 class="card-title">Automation</h2>
     <p class="admin-cards">Manage the frequency and content of your rules/automation</p>
   </a>
+  <a href="/admin/fields" class="card-link">
+    <h2 class="card-title">Fields</h2>
+    <p class="admin-cards">View field stats across tables</p>
+  </a>
 </div>
 {% endblock %}

--- a/templates/admin/fields_admin.html
+++ b/templates/admin/fields_admin.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block title %}Fields{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl font-bold mb-6">Fields</h1>
+<div class="mx-auto w-11/12 max-w-screen-2xl space-y-6">
+  {% for table, items in tables.items() %}
+  <details class="card" {% if loop.first %}open{% endif %}>
+    <summary class="cursor-pointer px-4 py-2 bg-card rounded-t font-semibold text-lg text-light">
+      {{ table }}
+    </summary>
+    <div class="p-4 overflow-x-auto">
+      <table class="min-w-full text-sm text-left text-light divide-y">
+        <thead class="text-xs uppercase bg-card">
+          <tr>
+            <th class="w-64 px-2 py-1">Field</th>
+            <th class="w-40 px-2 py-1">Type</th>
+            <th class="w-40 px-2 py-1 text-right">Not&nbsp;Null</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+        {% for item in items %}
+          <tr>
+            <td class="px-2 py-1 font-mono">{{ item.name }}</td>
+            <td class="px-2 py-1">{{ item.type }}</td>
+            <td class="px-2 py-1 text-right">{{ item.count }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </details>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/views/admin/__init__.py
+++ b/views/admin/__init__.py
@@ -53,6 +53,7 @@ from . import dashboard  # noqa: F401  # register routes
 from . import config  # noqa: F401  # register routes
 from . import imports  # noqa: F401  # register routes
 from . import automation  # noqa: F401  # register routes
+from . import fields  # noqa: F401  # register routes
 
 __all__ = [
     'admin_bp',

--- a/views/admin/fields.py
+++ b/views/admin/fields.py
@@ -1,0 +1,29 @@
+import logging
+from flask import render_template, current_app
+
+from db.schema import get_field_schema
+from db.records import count_nonnull
+from . import admin_bp
+
+logger = logging.getLogger(__name__)
+
+@admin_bp.route('/admin/fields')
+def admin_fields():
+    """Display tables and field info including not-null counts."""
+    schema = get_field_schema()
+    base_tables = current_app.config.get('BASE_TABLES', [])
+    table_data: dict[str, list[dict]] = {}
+    for table in base_tables:
+        fields = []
+        tbl_schema = schema.get(table, {})
+        for field, meta in tbl_schema.items():
+            if field == 'id' or meta.get('type') == 'hidden':
+                continue
+            try:
+                nn = count_nonnull(table, field)
+            except Exception:
+                logger.exception('Failed counting %s.%s', table, field)
+                nn = 0
+            fields.append({'name': field, 'type': meta.get('type'), 'count': nn})
+        table_data[table] = fields
+    return render_template('admin/fields_admin.html', tables=table_data)


### PR DESCRIPTION
## Summary
- create `admin/fields` page to list tables with field info
- display field types and not-null counts using `count_nonnull`
- link new page from Admin dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859731c3d308333a0a10dd371b28ab8