### PR TITLE
Add admin field placeholders

### DIFF
--- a/templates/admin/fields_admin.html
+++ b/templates/admin/fields_admin.html
@@ -16,7 +16,10 @@
           <tr>
             <th class="w-64 px-2 py-1">Field</th>
             <th class="w-40 px-2 py-1">Type</th>
-            <th class="w-40 px-2 py-1 text-right">Not&nbsp;Null</th>
+            <th class="w-40 px-2 py-1">Not&nbsp;Null</th>
+            <th class="w-40 px-2 py-1">Change Type</th>
+            <th class="w-20 px-2 py-1">Read Only</th>
+            <th class="w-40 px-2 py-1">Clear Values</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200">
@@ -24,11 +27,17 @@
           <tr>
             <td class="px-2 py-1 font-mono">{{ item.name }}</td>
             <td class="px-2 py-1">{{ item.type }}</td>
-            <td class="px-2 py-1 text-right">{{ item.count }}</td>
+            <td class="px-2 py-1">{{ item.count }}</td>
+            <td class="px-2 py-1"><button type="button" class="btn-secondary">Change</button></td>
+            <td class="px-2 py-1 text-center"><input type="checkbox" disabled></td>
+            <td class="px-2 py-1"><button type="button" class="btn-danger">Clear</button></td>
           </tr>
         {% endfor %}
         </tbody>
       </table>
+      <div class="mt-2">
+        <button type="submit" class="btn-primary">Submit</button>
+      </div>
     </div>
   </details>
   {% endfor %}


### PR DESCRIPTION
## Summary
- expand `admin/fields` table columns
- add placeholder controls for future field admin options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68597606b330833393b298d71a81137d