### PR TITLE
Update field type documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Crossbook is a structured, browser-based knowledge interface for managing conten
 * **Edit History:** Tracks each record’s modifications in an `edit_log`, viewable via an expandable history section. Individual entries now include an **Undo** link to revert that change.
 * **Navigation Bar:** A consistent top navigation (`base.html`) links to Home and all base table sections.
 * **Bulk Edit Modal:** Select rows in a list view and update a single field across all of them at once.
-* **Supported Field Types:** text, number, date, select, multi-select, foreign-key, boolean, textarea, and url, each rendered with the appropriate input control.
+* **Supported Field Types:** text, number, date, select, multi-select, foreign-key, boolean, textarea, and url. All types are declared via `register_type()` in `utils/validation.py`, and templates and JavaScript query this registry to determine the appropriate rendering and validation logic.
 * **Field Type Registry:** All field types are defined programmatically via `utils.validation.register_type`. The registry stores each type's validator, default width/height, rendering macro and SQL storage format. Rendering macros for the built-in types are hardcoded in `macros/fields.html`.
 * **Filter Macros:** Reusable Jinja macros for boolean, select, text, and multi-select filters (`templates/macros/filter_controls.html`).
 * **Text Filter Operators:** `contains`, `equals`, `starts_with`, `ends_with`, `not_contains`, and `regex` operators are available when filtering text fields. Regex matching requires database support and falls back to a normal `LIKE` search if unavailable.


### PR DESCRIPTION
## Summary
- clarify that all field types are registered in `utils/validation.py`
- mention how templates and JS use the registry for rendering and validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68597f7cb5bc8333907d3a9403f85e10