### PR TITLE
Fix numeric field checks in dashboard modal

### DIFF
--- a/static/js/dashboard_modal/value.js
+++ b/static/js/dashboard_modal/value.js
@@ -110,7 +110,7 @@ function isNumericField(val) {
   if (fieldTypes && fieldTypes[type]) {
     return !!fieldTypes[type].numeric;
   }
-  return type === 'number';
+  return false;
 }
 
 function toggleDisabled(label, input, disabled) {
@@ -275,7 +275,7 @@ export function populateFieldDropdown(dropdown, restrictNumeric, allowedTypes, c
     const fields = Object.keys(tableSchema);
     fields.forEach(field => {
       const type = tableSchema[field] ? tableSchema[field].type : '';
-      if (restrictNumeric && type !== 'number') return;
+      if (restrictNumeric && !(fieldTypes && fieldTypes[type] && fieldTypes[type].numeric)) return;
       if (allowedTypes && !allowedTypes.includes(type)) return;
       if (excludeTypes && excludeTypes.includes(type)) return;
       const val = `${table}:${field}`;


### PR DESCRIPTION
## Summary
- use cached field registry to determine numeric types
- leverage registry when populating dropdown options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685982bc858c8333a1bfc8330aab82c6