### PR TITLE
Improve bulk edit input type logic

### DIFF
--- a/static/js/bulk_edit_modal.js
+++ b/static/js/bulk_edit_modal.js
@@ -56,13 +56,13 @@ async function buildInput() {
   const container = document.getElementById('bulk-input-container');
   let html = '';
 
-  if (meta.name === 'textarea') {
+  if (meta.is_textarea) {
     html = '<textarea id="bulk-value" class="form-input"></textarea>';
   } else if (meta.numeric) {
     html = '<input id="bulk-value" type="number" class="form-input">';
-  } else if (meta.name === 'boolean') {
+  } else if (meta.is_boolean) {
     html = '<select id="bulk-value" class="form-select"><option value="1">True</option><option value="0">False</option></select>';
-  } else if (meta.allows_foreign_key || meta.name === 'multi_select') {
+  } else if (meta.allows_multiple) {
     html = '<div class="max-h-48 overflow-y-auto border p-2 space-y-1">' +
       options.map(o => `<label class="flex items-center space-x-2"><input type="checkbox" value="${o}" class="bulk-multi-option form-input"><span class="text-sm">${o}</span></label>`).join('') +
       '</div>';
@@ -70,7 +70,7 @@ async function buildInput() {
     html = '<select id="bulk-value" class="form-select">' +
       options.map(o => `<option value="${o}">${o}</option>`).join('') +
       '</select>';
-  } else if (meta.name === 'url') {
+  } else if (meta.is_url) {
     html = '<input id="bulk-value" type="url" class="form-input">';
   } else {
     html = '<input id="bulk-value" type="text" class="form-input">';
@@ -121,7 +121,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const type = fieldSel.selectedOptions[0].dataset.type;
     const meta = fieldTypes[type] || {};
     let value;
-    if (meta.allows_foreign_key || meta.name === 'multi_select') {
+    if (meta.allows_multiple) {
       value = Array.from(document.querySelectorAll('.bulk-multi-option:checked')).map(cb => cb.value);
     } else {
       value = document.getElementById('bulk-value').value;

--- a/tests/test_field_registry.py
+++ b/tests/test_field_registry.py
@@ -9,7 +9,18 @@ def test_register_get_and_size_map():
     # ensure clean state
     if 'tmp_test' in FIELD_TYPES:
         FIELD_TYPES.pop('tmp_test')
-    register_type('tmp_test', sql_type='INTEGER', default_width=7, default_height=9, macro='render_text', searchable=True)
+    register_type(
+        'tmp_test',
+        sql_type='INTEGER',
+        default_width=7,
+        default_height=9,
+        macro='render_text',
+        searchable=True,
+        allows_multiple=True,
+        is_textarea=True,
+        is_boolean=True,
+        is_url=True,
+    )
 
     ft = get_field_type('tmp_test')
     assert ft.name == 'tmp_test'
@@ -20,5 +31,9 @@ def test_register_get_and_size_map():
     size_map = get_type_size_map()
     assert size_map['tmp_test'] == (7, 9)
     assert ft.macro == 'render_text'
+    assert ft.allows_multiple is True
+    assert ft.is_textarea is True
+    assert ft.is_boolean is True
+    assert ft.is_url is True
 
     FIELD_TYPES.pop('tmp_test', None)

--- a/utils/field_registry.py
+++ b/utils/field_registry.py
@@ -13,6 +13,11 @@ class FieldType:
         allows_options=False,
         allows_foreign_key=False,
         searchable=False,
+        *,
+        allows_multiple=False,
+        is_textarea=False,
+        is_boolean=False,
+        is_url=False,
     ):
         self.name = name
         self.sql_type = sql_type
@@ -26,6 +31,10 @@ class FieldType:
         self.allows_options = allows_options
         self.allows_foreign_key = allows_foreign_key
         self.searchable = searchable
+        self.allows_multiple = allows_multiple
+        self.is_textarea = is_textarea
+        self.is_boolean = is_boolean
+        self.is_url = is_url
 
 FIELD_TYPES = {}
 
@@ -42,6 +51,11 @@ def register_type(
     allows_options=False,
     allows_foreign_key=False,
     searchable=False,
+    *,
+    allows_multiple=False,
+    is_textarea=False,
+    is_boolean=False,
+    is_url=False,
 ):
     FIELD_TYPES[name] = FieldType(
         name,
@@ -56,6 +70,10 @@ def register_type(
         allows_options,
         allows_foreign_key,
         searchable,
+        allows_multiple=allows_multiple,
+        is_textarea=is_textarea,
+        is_boolean=is_boolean,
+        is_url=is_url,
     )
 
 

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -260,6 +260,7 @@ register_type(
     filter_macro='multi_select_popover',
     normalizer=normalize_multi,
     allows_options=True,
+    allows_multiple=True,
     searchable=True,
 )
 register_type(
@@ -272,6 +273,7 @@ register_type(
     filter_macro='multi_select_popover',
     normalizer=normalize_multi,
     allows_foreign_key=True,
+    allows_multiple=True,
 )
 register_type(
     'boolean',
@@ -282,6 +284,7 @@ register_type(
     macro='render_boolean',
     filter_macro='boolean_filter',
     normalizer=normalize_boolean,
+    is_boolean=True,
 )
 register_type(
     'textarea',
@@ -292,6 +295,7 @@ register_type(
     macro='render_textarea',
     filter_macro='text_filter',
     searchable=True,
+    is_textarea=True,
 )
 register_type(
     'url',
@@ -302,4 +306,5 @@ register_type(
     macro='render_url',
     filter_macro='text_filter',
     searchable=True,
+    is_url=True,
 )


### PR DESCRIPTION
## Summary
- expose new registry flags for input types
- register built-in field types with new flags
- refactor bulk edit modal to use registry flags
- test new registry flag behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685983a71ed483338b7700a55d67bdfc