### PR TITLE
Use FIELD_TYPES metadata in templates

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,6 +104,7 @@ def inject_field_schema():
         'field_macro_map': macro_map,
         'filter_macro_map': filter_macro_map,
         'current_app': current_app,
+        'FIELD_TYPES': FIELD_TYPES,
     }
 
 @app.route("/")

--- a/templates/modals/edit_fields_modal.html
+++ b/templates/modals/edit_fields_modal.html
@@ -38,7 +38,7 @@
             <option value="" disabled selected>Select field</option>
             {% for source_table, fields in field_schema.items() %}
               {% for field, meta in fields.items() %}
-                {% if meta.type in ['select', 'multi_select'] %}
+                {% if meta.type in FIELD_TYPES and FIELD_TYPES[meta.type].allows_options %}
                   <option value="{{ source_table }}.{{ field }}">{{ source_table }} → {{ field }}</option>
                 {% endif %}
               {% endfor %}

--- a/templates/wizard/wizard_table.html
+++ b/templates/wizard/wizard_table.html
@@ -44,7 +44,7 @@
           <option value="" disabled selected>Select field</option>
           {% for source_table, fields in field_schema.items() %}
             {% for field, meta in fields.items() %}
-              {% if meta.type in ['select', 'multi_select'] %}
+              {% if meta.type in FIELD_TYPES and FIELD_TYPES[meta.type].allows_options %}
                 <option value="{{ source_table }}.{{ field }}">{{ source_table }} → {{ field }}</option>
               {% endif %}
             {% endfor %}


### PR DESCRIPTION
## Summary
- expose `FIELD_TYPES` to templates
- use `allows_options` metadata when listing foreign key targets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685983ae061c833380c2bf57271138e9