### PR TITLE
Fix wizard table schema import button

### DIFF
--- a/templates/wizard/wizard_table.html
+++ b/templates/wizard/wizard_table.html
@@ -67,6 +67,5 @@
   </div>
 </div>
 
-<script src="{{ url_for('static', filename='js/edit_fields.js') }}"></script>
 <script src="{{ url_for('static', filename='js/wizard_table.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove edit_fields.js from the setup wizard HTML template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685987d66c188333af87a18a058bbc12