### PR TITLE
Fix field type API

### DIFF
--- a/tests/test_api_field_types.py
+++ b/tests/test_api_field_types.py
@@ -1,0 +1,20 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from main import app
+from db.database import init_db_path
+
+init_db_path('data/crossbook.db')
+app.testing = True
+client = app.test_client()
+
+def test_api_field_types_returns_serializable_data():
+    resp = client.get('/api/field-types')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, dict)
+    assert 'text' in data
+    meta = data['text']
+    assert isinstance(meta, dict)
+    assert meta.get('sql_type') == 'TEXT'
+    assert meta.get('allows_options') is False

--- a/views/admin/config.py
+++ b/views/admin/config.py
@@ -109,8 +109,25 @@ def update_database_file():
 
 @admin_bp.route('/api/field-types')
 def api_field_types():
-    """Return list of available field types."""
-    return jsonify({name: vars(ft) for name, ft in FIELD_TYPES.items()})
+    """Return list of available field types in a JSON serialisable form."""
+
+    def serialize_ft(ft):
+        return {
+            "sql_type": ft.sql_type,
+            "default_width": ft.default_width,
+            "default_height": ft.default_height,
+            "numeric": ft.numeric,
+            "allows_options": ft.allows_options,
+            "allows_foreign_key": ft.allows_foreign_key,
+            "searchable": ft.searchable,
+            "allows_multiple": ft.allows_multiple,
+            "is_textarea": ft.is_textarea,
+            "is_boolean": ft.is_boolean,
+            "is_url": ft.is_url,
+        }
+
+    data = {name: serialize_ft(ft) for name, ft in FIELD_TYPES.items()}
+    return jsonify(data)
 
 
 @admin_bp.route('/add-table', methods=['POST'])


### PR DESCRIPTION
## Summary
- fix `/api/field-types` to return serializable data
- add regression test for field type API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598b36fff08333a7714c6a79996fe1