### PR TITLE
Add coverage for field type API serialization

### DIFF
--- a/tests/test_api_field_types.py
+++ b/tests/test_api_field_types.py
@@ -1,14 +1,18 @@
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from main import app
-from db.database import init_db_path
+EXPECTED_KEYS = {
+    "sql_type",
+    "default_width",
+    "default_height",
+    "numeric",
+    "allows_options",
+    "allows_foreign_key",
+    "searchable",
+    "allows_multiple",
+    "is_textarea",
+    "is_boolean",
+    "is_url",
+}
 
-init_db_path('data/crossbook.db')
-app.testing = True
-client = app.test_client()
-
-def test_api_field_types_returns_serializable_data():
+def test_api_field_types_returns_serializable_data(client):
     resp = client.get('/api/field-types')
     assert resp.status_code == 200
     data = resp.get_json()
@@ -18,3 +22,14 @@ def test_api_field_types_returns_serializable_data():
     assert isinstance(meta, dict)
     assert meta.get('sql_type') == 'TEXT'
     assert meta.get('allows_options') is False
+
+
+def test_api_field_types_exposes_only_serializable_keys(client):
+    resp = client.get('/api/field-types')
+    data = resp.get_json()
+
+    for meta in data.values():
+        # ensure only expected keys are returned
+        assert set(meta.keys()) == EXPECTED_KEYS
+        # and no callable values slipped through
+        assert not any(callable(v) for v in meta.values())


### PR DESCRIPTION
## Summary
- update `/api/field-types` test to rely on pytest fixture
- ensure the endpoint only exposes serializable field metadata

## Testing
- `pytest tests/test_api_field_types.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859873f279083339e5d13d33e0b9723