### PR TITLE
Fix draggable field highlight in dark mode

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -19,7 +19,8 @@ input[type=number] {
 #layout-grid .draggable-field.active-edit {
   border: 1px blue dashed !important;
   box-shadow: 0 0 0 2px rgba(0,0,0,0.1) !important;
-  background-color: #fafafa !important;
+  /* Use dark mode card color instead of white */
+  background-color: var(--bg-card) !important;
 }
 
 /* 2) In edit mode, reset padding only */


### PR DESCRIPTION
## Summary
- keep draggable fields dark while editing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68598d59b9d48333aa0fc8f8f8d6da2d