### PR TITLE
Fix reset-layout button style

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -105,7 +105,7 @@ a:hover {
 .btn-primary,
 .btn-secondary,
 .btn-danger {
-  color: #fff;
+  color: var(--text-light);
   padding: 0.25rem 0.75rem;
   border-radius: 0.25rem;
   display: inline-block;

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -42,7 +42,7 @@
       <button id="save-layout" class="btn-primary px-4 py-2 hidden rounded">
         Save Layout
       </button>
-      <button id="reset-layout" class="px-4 py-2 bg-secondary-light text-black rounded hidden">
+      <button id="reset-layout" class="btn-secondary px-4 py-2 rounded hidden">
         Reset Layout
       </button>
       <button


### PR DESCRIPTION
## Summary
- use btn-secondary for the Reset Layout button
- use `var(--text-light)` for button text colors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859904aa5588333bbafa0c538fbbd3c