### PR TITLE
Update boolean toggle knob style

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -213,6 +213,10 @@ a:hover {
 .bg-card { background-color: var(--bg-card); }
 .text-light { color: var(--text-light); }
 
+.toggle-knob {
+  background-color: var(--text-light);
+}
+
 .table-row-odd { background-color: #1f2937; }
 .table-row-even { background-color: #273043; }
 .table-row-hover:hover { background-color: #374151; }

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -183,7 +183,7 @@
     <input type="hidden" name="new_value_override" value="{{ '0' if value in ('1', 1, True) else '1' }}">
     <button type="submit" class="relative inline-flex items-center w-10 h-6 rounded-full transition-colors duration-300 {{ 'bg-green-500' if value in ('1', 1, True) else 'bg-red-500' }}">
       <span class="sr-only">{{ 'Yes' if value in ('1', 1, True) else 'No' }}</span>
-      <span class="inline-block w-4 h-4 transform bg-white rounded-full transition-transform duration-300 {{ 'translate-x-5' if value in ('1', 1, True) else 'translate-x-1' }}"></span>
+      <span class="inline-block w-4 h-4 transform toggle-knob rounded-full transition-transform duration-300 {{ 'translate-x-5' if value in ('1', 1, True) else 'translate-x-1' }}"></span>
     </button>
     <span class="ajax-status text-xs text-gray-500 ml-1 hidden"></span>
   </form>


### PR DESCRIPTION
## Summary
- style boolean toggle using a new `.toggle-knob` class
- add `.toggle-knob` with light text color to CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859939fd13483338ba5d71d29a5e513