### PR TITLE
Remove overridden teal utilities

### DIFF
--- a/static/js/dashboard_modal.js
+++ b/static/js/dashboard_modal.js
@@ -23,8 +23,8 @@ function setActiveTab(name) {
     if (tab) {
       const active = n === name;
       tab.setAttribute('aria-selected', active ? 'true' : 'false');
-      tab.classList.toggle('text-teal-600', active);
-      tab.classList.toggle('border-teal-600', active);
+      tab.classList.toggle('text-primary', active);
+      tab.classList.toggle('border-primary', active);
       tab.classList.toggle('border-transparent', !active);
       tab.classList.toggle('hover:text-gray-600', !active);
       tab.classList.toggle('hover:border-gray-300', !active);

--- a/static/js/dashboard_modal/table.js
+++ b/static/js/dashboard_modal/table.js
@@ -142,7 +142,7 @@ export async function initTableWidgets() {
       input.type = 'radio';
       input.name = 'filteredTable';
       input.value = tbl;
-      input.className = 'rounded border-gray-300 text-teal-600 shadow-sm focus:ring-teal-500';
+      input.className = 'rounded border-gray-300 text-primary shadow-sm focus:ring-teal-500';
       input.addEventListener('change', () => {
         filteredTable = tbl;
         if (filteredTableToggleLabel) filteredTableToggleLabel.textContent = tbl;
@@ -188,7 +188,7 @@ export async function initTableWidgets() {
       input.type = 'radio';
       input.name = 'filteredSort';
       input.value = fld;
-      input.className = 'rounded border-gray-300 text-teal-600 shadow-sm focus:ring-teal-500';
+      input.className = 'rounded border-gray-300 text-primary shadow-sm focus:ring-teal-500';
       input.addEventListener('change', () => {
         filteredSort = fld;
         if (filteredSortToggleLabel) filteredSortToggleLabel.textContent = fld;
@@ -298,7 +298,7 @@ export function updateTablePreview() {
         tableData = rows || [];
         tableData.forEach(r => {
           const tr = document.createElement('tr');
-          tr.innerHTML = `<td class="px-2 py-1"><a href="/${tbl}/${r.id}" class="text-teal-600 underline">${r.id}</a></td><td class="px-2 py-1">${r.value}</td>`;
+          tr.innerHTML = `<td class="px-2 py-1"><a href="/${tbl}/${r.id}" class="text-primary underline">${r.id}</a></td><td class="px-2 py-1">${r.value}</td>`;
           tablePreviewBodyEl.appendChild(tr);
         });
         tablePreviewEl.classList.remove('hidden');
@@ -335,7 +335,7 @@ export function updateTablePreview() {
         tableData.forEach(r => {
           const tr = document.createElement('tr');
           const label = r[labelField];
-          tr.innerHTML = `<td class="px-2 py-1"><a href="/${filteredTable}/${r.id}" class="text-teal-600 underline">${r.id}</a></td><td class="px-2 py-1">${label ?? ''}</td>`;
+          tr.innerHTML = `<td class="px-2 py-1"><a href="/${filteredTable}/${r.id}" class="text-primary underline">${r.id}</a></td><td class="px-2 py-1">${label ?? ''}</td>`;
           tablePreviewBodyEl.appendChild(tr);
         });
         tablePreviewEl.classList.remove('hidden');

--- a/static/js/dashboard_modal/value.js
+++ b/static/js/dashboard_modal/value.js
@@ -285,14 +285,14 @@ export function populateFieldDropdown(dropdown, restrictNumeric, allowedTypes, c
       input.type = 'radio';
       input.name = 'fieldSelect';
       input.value = val;
-      input.className = 'rounded border-gray-300 text-teal-600 shadow-sm focus:ring-teal-500';
+      input.className = 'rounded border-gray-300 text-primary shadow-sm focus:ring-teal-500';
       input.addEventListener('change', () => {
         callback(val);
         dropdown.classList.add('hidden');
       });
       const span = document.createElement('span');
       span.className = 'text-sm';
-      span.innerHTML = `<strong>${table}</strong>: ${field} <span class="text-teal-600 text-xs">(${type})</span>`;
+      span.innerHTML = `<strong>${table}</strong>: ${field} <span class="text-primary text-xs">(${type})</span>`;
       label.appendChild(input);
       label.appendChild(span);
       dropdown.appendChild(label);

--- a/static/js/field_ajax.js
+++ b/static/js/field_ajax.js
@@ -90,11 +90,11 @@ function updateSelectedTagsDOM(formEl) {
   checkboxes.forEach(cb => {
     if (cb.checked) {
       const span = document.createElement('span');
-      span.className = 'inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full';
+      span.className = 'inline-flex items-center bg-primary-light text-primary text-xs px-2 py-1 rounded-full';
       span.textContent = cb.value;
       const btn = document.createElement('button');
       btn.type = 'button';
-      btn.className = 'ml-1 text-teal-600 hover:text-red-500';
+      btn.className = 'ml-1 text-primary hover:text-red-500';
       btn.textContent = '×';
       btn.onclick = () => {
         cb.checked = false;

--- a/static/js/tag_selector.js
+++ b/static/js/tag_selector.js
@@ -5,9 +5,9 @@
 
     <div class="flex flex-wrap gap-1 mb-2 tag-container">
       {% for tag in selected_options if tag %}
-        <span class="inline-flex items-center bg-teal-100 text-teal-700 text-xs px-2 py-1 rounded-full">
+        <span class="inline-flex items-center bg-primary-light text-primary text-xs px-2 py-1 rounded-full">
           {{ tag }}
-          <button type="button" class="ml-1 text-teal-600 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=' + JSON.stringify('{{ tag }}') + ']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
+          <button type="button" class="ml-1 text-primary hover:text-red-500" onclick="this.closest('form').querySelector('input[value=' + JSON.stringify('{{ tag }}') + ']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
         </span>
       {% endfor %}
     </div>
@@ -26,7 +26,7 @@
             value="{{ option }}"
             {% if option in selected_options %}checked{% endif %}
             onchange="submitMultiSelectAuto(this.form)"
-            class="rounded border-gray-300 text-teal-600 shadow-sm focus:ring-teal-600"
+            class="rounded border-gray-300 text-primary shadow-sm focus:ring-teal-600"
           >
           <span class="text-sm">{{ option }}</span>
         </label>

--- a/templates/admin/config_admin.html
+++ b/templates/admin/config_admin.html
@@ -38,7 +38,7 @@
                 {% elif item.type in ('integer', 'number') %}
                   <input type="number" name="value" value="{{ item.value }}" class="form-control flex-grow">
                 {% elif item.type == 'boolean' %}
-                  <input type="checkbox" name="value" value="1" {% if item.value in ('1', 1, True, 'true') %}checked{% endif %} class="h-4 w-4 text-teal-600 bg-dark border-gray-300 rounded focus:ring-teal-600">
+                  <input type="checkbox" name="value" value="1" {% if item.value in ('1', 1, True, 'true') %}checked{% endif %} class="h-4 w-4 text-primary bg-dark border-gray-300 rounded focus:ring-teal-600">
                   <input type="hidden" name="value" value="0">
                 {% elif item.type == 'date' %}
                   <input type="date" name="value" value="{{ item.value }}" class="form-control flex-grow">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -83,13 +83,13 @@
             {% elif widget.parsed.type == 'top-numeric' %}
               {% set tbl = widget.parsed.table %}
               {% for row in widget.parsed.data if widget.parsed %}
-                <tr><td class="px-2 py-1"><a href="/{{ tbl }}/{{ row.id }}" class="text-teal-600 underline">{{ row.id }}</a></td><td class="px-2 py-1">{{ row.value }}</td></tr>
+                <tr><td class="px-2 py-1"><a href="/{{ tbl }}/{{ row.id }}" class="text-primary underline">{{ row.id }}</a></td><td class="px-2 py-1">{{ row.value }}</td></tr>
               {% endfor %}
             {% elif widget.parsed.type == 'filtered-records' %}
               {% set tbl = widget.parsed.table %}
               {% set label_field = get_title_field(tbl) or tbl %}
               {% for row in widget.parsed.data if widget.parsed %}
-                <tr><td class="px-2 py-1"><a href="/{{ tbl }}/{{ row.id }}" class="text-teal-600 underline">{{ row.id }}</a></td><td class="px-2 py-1">{{ row[label_field] }}</td></tr>
+                <tr><td class="px-2 py-1"><a href="/{{ tbl }}/{{ row.id }}" class="text-primary underline">{{ row.id }}</a></td><td class="px-2 py-1">{{ row[label_field] }}</td></tr>
               {% endfor %}
             {% else %}
               {% for row in widget.parsed.data if widget.parsed %}

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -129,14 +129,14 @@
 
     {% if edit_history %}
       <details class="mt-6 text-sm text-gray-600">
-        <summary class="cursor-pointer font-medium text-teal-600">
+        <summary class="cursor-pointer font-medium text-primary">
           Edit History
         </summary>
-        <ul class="mt-2 space-y-1 text-teal-800">
+        <ul class="mt-2 space-y-1 text-primary">
         {% for row in edit_history %}
           <li>
             [{{ row.timestamp }}] {{ row.field_name }}: {{ row.old_value }} → {{ row.new_value }}{% if row.actor %} ({{ row.actor }}){% endif %}
-            <button class="ml-2 text-sm text-teal-600 underline" onclick="undoEdit({{ row.id }}, '{{ table }}', {{ record.id }})">Undo</button>
+            <button class="ml-2 text-sm text-primary underline" onclick="undoEdit({{ row.id }}, '{{ table }}', {{ record.id }})">Undo</button>
           </li>
         {% endfor %}
         </ul>
@@ -145,7 +145,7 @@
   </div>
 
   <!-- Right: Related Content -->
-  <div id="related-pages" class="w-full md:w-1/3 lg:w-1/4 xl:w-64 border-l-2 border-teal-200 pl-6 flex-shrink-0">
+  <div id="related-pages" class="w-full md:w-1/3 lg:w-1/4 xl:w-64 border-l-2 border-primary-light pl-6 flex-shrink-0">
     <div id="header_container" class="flex items-center mb-2">
       <h2 class="text-xl font-semibold">Related Pages</h2>
       <div id="relation-visibility-wrapper" class="relative inline-block text-left ml-2 hidden">
@@ -175,7 +175,7 @@
         </div>
       </div>
     </div>
-    <ul id="related-pages-list" class="space-y-2 text-teal-700 text-sm">
+    <ul id="related-pages-list" class="space-y-2 text-primary text-sm">
       {% for section, group, vis in related %}
         {% set has_items = group['items']|length > 0 %}
         {% set hide = vis.hidden and (vis.force or not has_items) %}

--- a/templates/import_view.html
+++ b/templates/import_view.html
@@ -24,7 +24,7 @@
       </form>
       {% endif %}
       {% if num_records is defined %}
-      <div class="bg-teal-100 text-teal-800 px-4 py-2 rounded whitespace-nowrap">
+      <div class="bg-primary-light text-primary px-4 py-2 rounded whitespace-nowrap">
         Total Records: {{ num_records if num_records is not none else 'None' }}
       </div>
       {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,7 @@
   </a>
   {% endfor %}
   <a href="#" id="card-add-table" onclick="openAddTableModal()" class="card-link flex items-center justify-center">
-    <span id="add-table-icon" class="text-teal-600 text-5xl font-bold">+</span>
+    <span id="add-table-icon" class="text-primary text-5xl font-bold">+</span>
   </a>
 </div>
 

--- a/templates/macros/fields.html
+++ b/templates/macros/fields.html
@@ -64,7 +64,7 @@
         {% for tag in selected_options if tag %}
           <span class="tag-pill">
             {{ tag }}
-            <button type="button" class="ml-1 text-teal-600 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=\'{{ tag }}\']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
+            <button type="button" class="ml-1 text-primary hover:text-red-500" onclick="this.closest('form').querySelector('input[value=\'{{ tag }}\']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
           </span>
         {% endfor %}
       </div>
@@ -84,7 +84,7 @@
               value="{{ option }}"
               {% if option in selected_options %}checked{% endif %}
               onchange="submitMultiSelectAuto(this.form)"
-              class="rounded border-gray-300 text-teal-600 shadow-sm focus:ring-teal-600"
+              class="rounded border-gray-300 text-primary shadow-sm focus:ring-teal-600"
             >
             <span class="text-sm">{{ option }}</span>
           </label>
@@ -136,7 +136,7 @@
           {% for tag in selected_options if tag %}
             <span class="tag-pill">
               {{ tag }}
-              <button type="button" class="ml-1 text-teal-600 hover:text-red-500" onclick="this.closest('form').querySelector('input[value=\'{{ tag }}\']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
+              <button type="button" class="ml-1 text-primary hover:text-red-500" onclick="this.closest('form').querySelector('input[value=\'{{ tag }}\']').checked = false; submitMultiSelectAuto(this.closest('form'))">×</button>
             </span>
           {% endfor %}
       </div>
@@ -156,7 +156,7 @@
               value="{{ option }}"
               {% if option in selected_options %}checked{% endif %}
               onchange="submitMultiSelectAuto(this.form)"
-              class="rounded border-gray-300 text-teal-600 shadow-sm focus:ring-teal-600"
+              class="rounded border-gray-300 text-primary shadow-sm focus:ring-teal-600"
             >
             <span class="text-sm">{{ option }}</span>
           </label>

--- a/templates/macros/filter_controls.html
+++ b/templates/macros/filter_controls.html
@@ -4,7 +4,7 @@
   <div class="filter-chip">
     <select
       name="{{ field }}_op"
-      class="operator-select appearance-none text-xs rounded-full border-0 bg-transparent text-center text-teal-600 cursor-pointer w-auto"
+      class="operator-select appearance-none text-xs rounded-full border-0 bg-transparent text-center text-primary cursor-pointer w-auto"
       title="Operator"
     >
       <option value="contains"    title="Contains"      {% if operator=='contains'    %}selected{% endif %}>Contains</option>

--- a/templates/modals/dashboard_modal.html
+++ b/templates/modals/dashboard_modal.html
@@ -6,7 +6,7 @@
     <div class="mb-4 border-b border-gray-200">
       <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="dashboardTab" role="tablist">
         <li class="mr-2" role="presentation">
-          <button id="tab-value" type="button" role="tab" aria-controls="pane-value" aria-selected="true" class="inline-block p-2 rounded-t-lg border-b-2 text-teal-600 border-teal-600">Value</button>
+          <button id="tab-value" type="button" role="tab" aria-controls="pane-value" aria-selected="true" class="inline-block p-2 rounded-t-lg border-b-2 text-primary border-primary">Value</button>
         </li>
         <li class="mr-2" role="presentation">
           <button id="tab-table" type="button" role="tab" aria-controls="pane-table" aria-selected="false" class="inline-block p-2 rounded-t-lg border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300">Table</button>
@@ -24,7 +24,7 @@
           {% for op in ['Sum', 'Count', 'Math'] %}
           <label class="flex-1 cursor-pointer">
             <input type="radio" name="dashboardOperation" value="{{ op|lower }}" class="sr-only peer">
-            <div class="p-2 border rounded text-center peer-checked:bg-teal-600 peer-checked:text-white">
+            <div class="p-2 border rounded text-center peer-checked:bg-primary peer-checked:text-white">
               {{ op }}
             </div>
           </label>
@@ -41,11 +41,11 @@
           <div id="aggToggle1" class="flex">
             <label class="cursor-pointer">
               <input type="radio" name="agg1" value="sum" class="sr-only peer" checked>
-              <div class="p-1 border rounded-l text-center peer-checked:bg-teal-600 peer-checked:text-white">Sum</div>
+              <div class="p-1 border rounded-l text-center peer-checked:bg-primary peer-checked:text-white">Sum</div>
             </label>
             <label class="cursor-pointer">
               <input type="radio" name="agg1" value="count" class="sr-only peer">
-              <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-teal-600 peer-checked:text-white">Count</div>
+              <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-primary peer-checked:text-white">Count</div>
             </label>
           </div>
         </div>
@@ -54,7 +54,7 @@
           {% for op in ['Add', 'Subtract', 'Multiply', 'Divide', 'Average'] %}
           <label class="flex-1 cursor-pointer">
             <input type="radio" name="mathOperation" value="{{ op|lower }}" class="sr-only peer">
-            <div class="p-2 border rounded text-center peer-checked:bg-teal-600 peer-checked:text-white">
+            <div class="p-2 border rounded text-center peer-checked:bg-primary peer-checked:text-white">
               {{ op }}
             </div>
           </label>
@@ -71,11 +71,11 @@
           <div id="aggToggle2" class="flex">
             <label class="cursor-pointer">
               <input type="radio" name="agg2" value="sum" class="sr-only peer" checked>
-              <div class="p-1 border rounded-l text-center peer-checked:bg-teal-600 peer-checked:text-white">Sum</div>
+              <div class="p-1 border rounded-l text-center peer-checked:bg-primary peer-checked:text-white">Sum</div>
             </label>
             <label class="cursor-pointer">
               <input type="radio" name="agg2" value="count" class="sr-only peer">
-              <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-teal-600 peer-checked:text-white">Count</div>
+              <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-primary peer-checked:text-white">Count</div>
             </label>
           </div>
         </div>
@@ -194,11 +194,11 @@
         <div id="chartOrientContainer" class="flex mb-4 hidden">
           <label class="cursor-pointer">
             <input type="radio" name="chartOrient" value="x" class="sr-only peer" checked>
-            <div class="p-1 border rounded-l text-center peer-checked:bg-teal-600 peer-checked:text-white">X Axis</div>
+            <div class="p-1 border rounded-l text-center peer-checked:bg-primary peer-checked:text-white">X Axis</div>
           </label>
           <label class="cursor-pointer">
             <input type="radio" name="chartOrient" value="y" class="sr-only peer">
-            <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-teal-600 peer-checked:text-white">Y Axis</div>
+            <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-primary peer-checked:text-white">Y Axis</div>
           </label>
         </div>
         <div id="chartYFieldContainer" class="mb-4 hidden">
@@ -213,15 +213,15 @@
         <div id="chartAggContainer" class="flex mb-4 hidden">
           <label class="cursor-pointer">
             <input type="radio" name="chartAgg" value="" class="sr-only peer" checked>
-            <div class="p-1 border rounded-l text-center peer-checked:bg-teal-600 peer-checked:text-white">None</div>
+            <div class="p-1 border rounded-l text-center peer-checked:bg-primary peer-checked:text-white">None</div>
           </label>
           <label class="cursor-pointer">
             <input type="radio" name="chartAgg" value="sum" class="sr-only peer">
-            <div class="p-1 border border-l-0 text-center peer-checked:bg-teal-600 peer-checked:text-white">Sum</div>
+            <div class="p-1 border border-l-0 text-center peer-checked:bg-primary peer-checked:text-white">Sum</div>
           </label>
           <label class="cursor-pointer">
             <input type="radio" name="chartAgg" value="count" class="sr-only peer">
-            <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-teal-600 peer-checked:text-white">Count</div>
+            <div class="p-1 border border-l-0 rounded-r text-center peer-checked:bg-primary peer-checked:text-white">Count</div>
           </label>
         </div>
         <input id="chartTitleInput" type="text" placeholder="Widget Title" class="form-input w-full mb-4 hidden" />

--- a/templates/wizard/wizard_table.html
+++ b/templates/wizard/wizard_table.html
@@ -8,7 +8,7 @@
 <form method="post" id="tables-form" class="space-y-4">
   <div id="tables-container"></div>
   <div class="space-x-4">
-    <button type="button" id="add-table-btn" onclick="addTableForm()" class="text-teal-600 text-4xl font-bold">+</button>
+    <button type="button" id="add-table-btn" onclick="addTableForm()" class="text-primary text-4xl font-bold">+</button>
     <button type="button" id="import-table-btn" class="underline text-blue-600">Import Table Schema</button>
     <button type="button" id="schema-summary-btn" class="underline text-blue-600">View Tables</button>
     <input type="file" id="import-table-file" accept=".csv" class="hidden">


### PR DESCRIPTION
## Summary
- cleanup teal utility classes that are overridden to purple
- update JS snippets and templates to use `text-primary`, `bg-primary`, and `border-primary`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b3d2901c83339c6256eb267244f2