### PR TITLE
Use display names for relationship labels

### DIFF
--- a/db/relationships.py
+++ b/db/relationships.py
@@ -57,9 +57,15 @@ def get_related_records(source_table, record_id):
             if not row:
                 continue
             item = {"id": row[0], "name": row[1], "two_way": bool(two_way)}
+            # Determine display label for the related table
+            row_label = cur.execute(
+                "SELECT display_name FROM config_base_tables WHERE table_name = ?",
+                (target_table,),
+            ).fetchone()
+            table_label = row_label[0] if row_label else target_table.capitalize()
             group = related.setdefault(
                 target_table,
-                {"label": target_table.capitalize() + "s", "items": []},
+                {"label": table_label, "items": []},
             )
             group["items"].append(item)
     return related

--- a/views/records/record_views.py
+++ b/views/records/record_views.py
@@ -41,6 +41,8 @@ def detail_view(table, record_id):
         abort(404)
     existing_related = get_related_records(table, record_id)
     base_tables = current_app.config['BASE_TABLES']
+    card_info = current_app.config.get('CARD_INFO', [])
+    label_map = {c['table_name']: c['display_name'] for c in card_info}
     visibility_all = get_relationship_visibility().get(table, {})
     related = []
     for tbl in base_tables:
@@ -48,7 +50,7 @@ def detail_view(table, record_id):
             continue
         group = existing_related.get(
             tbl,
-            {"label": tbl.capitalize() + "s", "items": []},
+            {"label": label_map.get(tbl, tbl.capitalize()), "items": []},
         )
         vis = visibility_all.get(tbl, {})
         related.append((tbl, group, vis))


### PR DESCRIPTION
## Summary
- use display names from `config_base_tables` for relationship labels
- drop the automatic `+ 's'` capitalization when showing related record groups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a7d187adc8333984ee01d16b067e0