### PR TITLE
Fix stray dashed lines in layout editor

### DIFF
--- a/static/js/layout_editor.js
+++ b/static/js/layout_editor.js
@@ -19,6 +19,17 @@ function initLayout() {
   console.debug('[layout] initLayout width', CONTAINER_WIDTH);
 }
 
+function sanitizeLayoutCache() {
+  if (typeof layoutCache === 'undefined') return;
+  Object.entries(layoutCache).forEach(([field, rect]) => {
+    rect.colStart = Math.max(1, parseInt(rect.colStart) || 1);
+    rect.colSpan  = Math.max(1, parseInt(rect.colSpan)  || 1);
+    rect.rowStart = Math.max(1, parseInt(rect.rowStart) || 1);
+    rect.rowSpan  = Math.max(1, parseInt(rect.rowSpan)  || 1);
+    layoutCache[field] = rect;
+  });
+}
+
 function bindEventHandlers() {
   const saveLayoutBtn  = document.getElementById('save-layout');
   const resetLayoutBtn = document.getElementById('reset-layout');
@@ -29,6 +40,7 @@ function bindEventHandlers() {
 
 function onLoadJS(){
   console.debug('[layout] onLoadJS');
+  sanitizeLayoutCache();
   initLayout();
   bindEventHandlers();
 }

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -228,7 +228,7 @@
   </div>
 
 
-<script>const layoutCache = {{ field_schema_layout | tojson }};</script>
+<script>window.layoutCache = {{ field_schema_layout | tojson }};</script>
 <script>window.FIELD_LAYOUT_DEFAULTS = {{ field_layout_defaults | tojson }};</script>
 <script>window.RELATION_VISIBILITY = {{ relationship_visibility | tojson }};</script>
 <script>


### PR DESCRIPTION
## Summary
- sanitize layout cache entries to enforce minimum grid dimensions
- expose `layoutCache` globally for layout editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa0408ddc83338ce623e8a12f27a5