### PR TITLE
Add edit fields modal to admin page

### DIFF
--- a/templates/admin/fields_admin.html
+++ b/templates/admin/fields_admin.html
@@ -35,11 +35,23 @@
         {% endfor %}
         </tbody>
       </table>
-      <div class="mt-2">
+      <div class="mt-2 flex items-center space-x-2">
+        <button type="button" class="btn-primary" onclick="openLayoutModal('edit_fields_modal_{{ table }}')">Edit Fields</button>
         <button type="submit" class="btn-primary">Submit</button>
       </div>
-    </div>
+      {% with record={'id': 0}, modal_id='edit_fields_modal_' ~ table %}
+        {% include "modals/edit_fields_modal.html" %}
+      {% endwith %}
+      </div>
   </details>
   {% endfor %}
 </div>
+<script type="module">
+  window.openLayoutModal = function(id) {
+    document.getElementById(id).classList.remove('hidden');
+  };
+  window.closeLayoutModal = function(id) {
+    document.getElementById(id).classList.add('hidden');
+  };
+</script>
 {% endblock %}

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -258,11 +258,11 @@
 <script src="{{ url_for('static', filename='js/relation_visibility.js') }}"></script>
 
 <script type="module">
-  window.openLayoutModal = function () {
-    document.getElementById("edit_fields_modal").classList.remove("hidden");
+  window.openLayoutModal = function (id = "edit_fields_modal") {
+    document.getElementById(id).classList.remove("hidden");
   };
-  window.closeLayoutModal = function () {
-    document.getElementById("edit_fields_modal").classList.add("hidden");
+  window.closeLayoutModal = function (id = "edit_fields_modal") {
+    document.getElementById(id).classList.add("hidden");
   };
 </script>
 <script type="module" src="{{ url_for('static', filename='js/field_ajax.js') }}"></script>

--- a/templates/modals/edit_fields_modal.html
+++ b/templates/modals/edit_fields_modal.html
@@ -1,7 +1,8 @@
-<div id="edit_fields_modal" class="modal-container hidden"
-     onclick="if(event.target.id === 'edit_fields_modal') closeLayoutModal()">
+{% set _modal_id = modal_id or 'edit_fields_modal' %}
+<div id="{{ _modal_id }}" class="modal-container hidden"
+     onclick="if(event.target.id === '{{ _modal_id }}') closeLayoutModal('{{ _modal_id }}')">
   <div class="modal-box w-96 max-w-full relative">
-    <button type="button" onclick="closeLayoutModal()" class="modal-close">&times;</button>
+    <button type="button" onclick="closeLayoutModal('{{ _modal_id }}')" class="modal-close">&times;</button>
     <div class="mb-4 border-b border-gray-200">
       <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="editFieldsTabs" role="tablist">
         <li class="mr-2" role="presentation">


### PR DESCRIPTION
## Summary
- allow unique edit fields modals via new `modal_id` parameter
- add table-specific Edit Fields button and modal on admin Fields page
- make modal open/close helpers accept an id so multiple modals can coexist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa0d87a2c8333928ee436ebdcf076