### PR TITLE
Fix stray dashed lines in layout editor

### DIFF
--- a/static/css/overrides.css
+++ b/static/css/overrides.css
@@ -23,13 +23,9 @@ input[type=number] {
   background-color: var(--bg-card) !important;
 }
 
-/* 2) In edit mode, reset padding only */
+/* 2) In edit mode, reset padding and show outlines */
 #layout-grid.editing .draggable-field {
   padding: 0;
-}
-
-/* 3) In edit mode, show the outlines/shadows again */
-#layout-grid.editing .draggable-field {
   border: 1px blue dashed !important;
   box-shadow: 0 0 0 2px rgba(0,0,0,0.1) !important;
   background-color: transparent !important;
@@ -98,8 +94,6 @@ input[type=number] {
 }
 #dashboard-grid.editing .draggable-field {
   padding: 0;
-}
-#dashboard-grid.editing .draggable-field {
   border: 1px blue dashed !important;
   box-shadow: 0 0 0 2px rgba(0,0,0,0.1) !important;
   /* No background overlay while editing dashboard layout */


### PR DESCRIPTION
## Summary
- consolidate layout-grid and dashboard-grid editing styles to avoid duplicate borders
- revert layout cache exposure and sanitize function added earlier

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685aa0408ddc83338ce623e8a12f27a5