### PR TITLE
Fix CSV field size limit restoration

### DIFF
--- a/imports/import_csv.py
+++ b/imports/import_csv.py
@@ -5,8 +5,12 @@ from io import StringIO
 def parse_csv(file):
     decoded = file.read().decode("utf-8")
     csv_stream = StringIO(decoded)
+    original_limit = csv.field_size_limit()
     csv.field_size_limit(sys.maxsize)
-    reader = csv.DictReader(csv_stream)
-    rows = list(reader)  
-    headers = reader.fieldnames
+    try:
+        reader = csv.DictReader(csv_stream)
+        rows = list(reader)
+        headers = reader.fieldnames
+    finally:
+        csv.field_size_limit(original_limit)
     return headers, rows

--- a/tests/test_import_csv.py
+++ b/tests/test_import_csv.py
@@ -11,8 +11,8 @@ def test_parse_csv_decodes_and_parses_rows():
     sample = b"col1,col2\nA,1\nB,2\n"
     original_limit = csv.field_size_limit()
     headers, rows = parse_csv(io.BytesIO(sample))
-    csv.field_size_limit(original_limit)
     assert headers == ["col1", "col2"]
     assert rows == [{"col1": "A", "col2": "1"}, {"col1": "B", "col2": "2"}]
+    assert csv.field_size_limit() == original_limit
 
 


### PR DESCRIPTION
## Summary
- keep the original CSV field size limit and restore it in `parse_csv`
- verify `parse_csv` resets the limit in the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aaf25a6188333a88b486613fe08cf