### PR TITLE
Fix popover clipping in modals

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -397,7 +397,7 @@ a:hover {
   width: 24rem; /* w-96 */
   max-width: 100%;
   max-height: 85vh; /* allow modal to grow but stay within viewport */
-  overflow-y: auto; /* scroll when content exceeds available height */
+  overflow: visible; /* let popovers escape modal bounds */
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- update modal-box style to allow dropdowns to overflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac03acc708333b61d1cfe4f45aa3a