### PR TITLE
Fix dashboard operation highlight

### DIFF
--- a/templates/modals/dashboard_modal.html
+++ b/templates/modals/dashboard_modal.html
@@ -24,7 +24,7 @@
           {% for op in ['Sum', 'Count', 'Math'] %}
           <label class="flex-1 cursor-pointer">
             <input type="radio" name="dashboardOperation" value="{{ op|lower }}" class="sr-only peer">
-            <div class="p-2 border rounded text-center peer-checked:bg-primary peer-checked:text-white">
+            <div class="p-2 border rounded text-center peer-checked:bg-secondary peer-checked:text-white">
               {{ op }}
             </div>
           </label>


### PR DESCRIPTION
## Summary
- update the dashboard "Value" operation radio buttons to highlight with the secondary color

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ac2108c4c8333b3b81dead252df54