### PR TITLE
Fix dark mode background for input-sm

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -284,6 +284,8 @@ a:hover {
 /* Small input used for inline editing */
 .input-sm {
   border: 1px solid var(--color-primary-light);
+  background-color: var(--bg-card);
+  color: var(--text-light);
   padding: 0.125rem 0.25rem; /* py-0.5 px-1 */
   font-size: 0.875rem; /* text-sm */
   border-radius: 0.25rem; /* rounded */


### PR DESCRIPTION
## Summary
- ensure `.input-sm` uses dark mode colors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac9b600ac83339c8354468305462d