### PR TITLE
Implement crawler file counting

### DIFF
--- a/db/bootstrap.py
+++ b/db/bootstrap.py
@@ -34,6 +34,8 @@ DEFAULT_CONFIGS = [
     ("filename", "logs/crossbook.log", "general", "string", 0),
     ("heading", "", "home", "string", 1),
     ("relationship_visibility", "{}", "general", "json", 0),
+    ("crawler_folders", "[]", "crawler", "json", 0),
+    ("crawler_file_count", 0, "crawler", "integer", 0),
 ]
 
 

--- a/main.py
+++ b/main.py
@@ -75,11 +75,13 @@ from views.admin import admin_bp
 from views.records.record_views import records_bp
 from views.wizard import wizard_bp
 from views.api import api_bp
+from views.crawler import crawler_bp
 
 app.register_blueprint(admin_bp)
 app.register_blueprint(records_bp)
 app.register_blueprint(wizard_bp)
 app.register_blueprint(api_bp)
+app.register_blueprint(crawler_bp)
 
 @app.context_processor
 def inject_field_schema():

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import json
+import tempfile
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from main import app
+from db.database import init_db_path
+from db.config import update_config, get_config_rows
+
+init_db_path('data/crossbook.db')
+app.testing = True
+client = app.test_client()
+
+
+def test_crawler_scan_counts_enabled_folders(tmp_path):
+    enabled_dir = tmp_path / 'enabled'
+    disabled_dir = tmp_path / 'disabled'
+    enabled_dir.mkdir()
+    disabled_dir.mkdir()
+    for i in range(3):
+        (enabled_dir / f'e{i}.txt').write_text('x')
+    for i in range(2):
+        (disabled_dir / f'd{i}.txt').write_text('x')
+
+    folders = [
+        {'path': str(enabled_dir), 'enabled': True},
+        {'path': str(disabled_dir), 'enabled': False},
+    ]
+    update_config('crawler_folders', json.dumps(folders))
+
+    resp = client.post('/crawler/scan')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['file_count'] == 3
+
+    rows = get_config_rows()
+    cfg = {r['key']: r['value'] for r in rows}
+    assert int(cfg.get('crawler_file_count')) == 3
+
+    resp = client.get('/crawler')
+    assert resp.status_code == 200
+    assert resp.get_json()['file_count'] == 3

--- a/views/crawler.py
+++ b/views/crawler.py
@@ -1,0 +1,41 @@
+from flask import Blueprint, jsonify
+import os
+import json
+from db.config import get_config_rows, update_config
+
+crawler_bp = Blueprint('crawler', __name__)
+
+
+def _load_folders():
+    rows = get_config_rows()
+    cfg = {row['key']: row['value'] for row in rows}
+    folders_raw = cfg.get('crawler_folders', '[]')
+    try:
+        folders = json.loads(folders_raw)
+        if isinstance(folders, dict):
+            folders = [{"path": p, "enabled": e} for p, e in folders.items()]
+    except Exception:
+        folders = []
+    file_count = int(cfg.get('crawler_file_count') or 0)
+    return folders, file_count
+
+
+@crawler_bp.route('/crawler')
+def crawler_status():
+    _, count = _load_folders()
+    return jsonify({'file_count': count})
+
+
+@crawler_bp.route('/crawler/scan', methods=['POST'])
+def crawler_scan():
+    folders, _ = _load_folders()
+    total = 0
+    for folder in folders:
+        if not folder.get('enabled'):
+            continue
+        path = folder.get('path')
+        if path and os.path.isdir(path):
+            for _, _, files in os.walk(path):
+                total += len(files)
+    update_config('crawler_file_count', str(total))
+    return jsonify({'file_count': total})


### PR DESCRIPTION
## Summary
- support crawler config defaults
- register new crawler blueprint
- add crawler endpoint for scanning enabled folders and updating file count
- test crawler file count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687752943b40833387e62529748dc6ce