### PR TITLE
Capture error tracebacks in logs

### DIFF
--- a/db/dashboard.py
+++ b/db/dashboard.py
@@ -22,7 +22,7 @@ def sum_field(table: str, field: str) -> float:
             result = cursor.fetchone()[0]
             return result or 0
         except Exception as e:
-            logger.warning(f"[sum_field] SQL error for {table}.{field}: {e}")
+            logger.exception(f"[sum_field] SQL error for {table}.{field}: {e}")
             return 0
 
 # Return all dashboard widgets ordered by id.
@@ -38,7 +38,7 @@ def get_dashboard_widgets() -> list[dict]:
             cols = [d[0] for d in cursor.description]
             return [dict(zip(cols, r)) for r in rows]
         except Exception as e:
-            logger.warning("[get_dashboard_widgets] SQL error: %s", e)
+            logger.exception("[get_dashboard_widgets] SQL error: %s", e)
             return []
 
 def create_widget(
@@ -83,7 +83,7 @@ def create_widget(
             conn.commit()
             return cur.lastrowid
         except Exception as exc:
-            logger.warning("[create_widget] SQL error: %s", exc)
+            logger.exception("[create_widget] SQL error: %s", exc)
             return None
 
 def update_widget_layout(layout_items: list[dict]) -> int:
@@ -156,7 +156,7 @@ def update_widget_styling(widget_id: int, styling: dict) -> bool:
             conn.commit()
             return cur.rowcount > 0
         except Exception as exc:
-            logger.warning("[update_widget_styling] SQL error: %s", exc)
+            logger.exception("[update_widget_styling] SQL error: %s", exc)
             return False
 
 
@@ -172,7 +172,7 @@ def delete_widget(widget_id: int) -> bool:
             conn.commit()
             return cur.rowcount > 0
         except Exception as exc:
-            logger.warning("[delete_widget] SQL error: %s", exc)
+            logger.exception("[delete_widget] SQL error: %s", exc)
             return False
 
 
@@ -184,7 +184,7 @@ def get_base_table_counts() -> list[dict]:
         try:
             cnt = count_records(table)
         except Exception as exc:
-            logger.warning("[get_base_table_counts] error for %s: %s", table, exc)
+            logger.exception("[get_base_table_counts] error for %s: %s", table, exc)
             cnt = 0
         results.append({"table": table, "count": cnt})
     return results
@@ -213,7 +213,7 @@ def get_top_numeric_values(
             rows = cur.fetchall()
             return [{"id": r[0], "value": r[1]} for r in rows]
         except Exception as exc:
-            logger.warning(
+            logger.exception(
                 "[get_top_numeric_values] SQL error for %s.%s: %s", table, field, exc
             )
             return []
@@ -235,7 +235,7 @@ def get_filtered_records(
         )
         return rows
     except Exception as exc:
-        logger.warning(
+        logger.exception(
             "[get_filtered_records] error for %s: %s", table, exc
         )
         return []

--- a/db/edit_history.py
+++ b/db/edit_history.py
@@ -48,7 +48,7 @@ def append_edit_log(
                 new_value,
             )
         except Exception as e:
-            logger.warning("[EDIT LOG ERROR] %s", e)
+            logger.exception("[EDIT LOG ERROR] %s", e)
 
 
 def get_edit_history(table_name: str, record_id: int, limit: int | None = None) -> list[dict]:

--- a/db/records.py
+++ b/db/records.py
@@ -39,7 +39,7 @@ def get_all_records(
                     dir_sql = "DESC" if str(direction).lower() == "desc" else "ASC"
                     sql += f" ORDER BY {sort_field} COLLATE NOCASE {dir_sql}"
                 except Exception:
-                    logger.warning("Invalid sort field: %s", sort_field)
+                    logger.exception("Invalid sort field: %s", sort_field)
 
             if limit is not None:
                 sql += f" LIMIT {int(limit)} OFFSET {int(offset)}"
@@ -51,7 +51,7 @@ def get_all_records(
             cols = [desc[0] for desc in cursor.description]
             return [dict(zip(cols, row)) for row in rows]
         except Exception as e:
-            logger.warning(f"[QUERY ERROR] {e}")
+            logger.exception(f"[QUERY ERROR] {e}")
             return []
 
 
@@ -71,7 +71,7 @@ def count_records(table, search=None, filters=None, ops=None, modes=None):
             row = cursor.fetchone()
             return row[0] if row else 0
         except Exception as e:
-            logger.warning(f"[COUNT ERROR] {e}")
+            logger.exception(f"[COUNT ERROR] {e}")
             return 0
 
 def get_record_by_id(table, record_id):
@@ -142,7 +142,7 @@ def update_field_value(table, record_id, field, new_value):
             )
             success = True
         except Exception as e:
-            logger.error(f"[UPDATE ERROR] {e}")
+            logger.exception(f"[UPDATE ERROR] {e}")
             success = False
         if success:
             touch_last_edited(table, record_id)
@@ -198,7 +198,7 @@ def create_record(table, form_data):
             conn.commit()
             return record_id
         except Exception as e:
-            logger.warning(f"[CREATE ERROR] {e}")
+            logger.exception(f"[CREATE ERROR] {e}")
             return None
 
 def delete_record(table, record_id):
@@ -211,7 +211,7 @@ def delete_record(table, record_id):
             conn.commit()
             return True
         except Exception as e:
-            logger.warning(f"[DELETE ERROR] {e}")
+            logger.exception(f"[DELETE ERROR] {e}")
             return False
 
 def count_nonnull(table: str, field: str) -> int:
@@ -228,7 +228,7 @@ def count_nonnull(table: str, field: str) -> int:
             cursor.execute(sql)
             return cursor.fetchone()[0] or 0
         except Exception as e:
-            logger.warning(f"[count_nonnull] SQL error for {table}.{field}: {e}")
+            logger.exception(f"[count_nonnull] SQL error for {table}.{field}: {e}")
             return 0
 
 
@@ -248,7 +248,7 @@ def field_distribution(table: str, field: str) -> dict[str, int]:
             )
             rows = [r[0] for r in cursor.fetchall()]
         except Exception as e:
-            logger.warning(f"[field_distribution] SQL error for {table}.{field}: {e}")
+            logger.exception(f"[field_distribution] SQL error for {table}.{field}: {e}")
             return {}
 
     counts: dict[str, int] = {}

--- a/db/relationships.py
+++ b/db/relationships.py
@@ -97,7 +97,7 @@ def add_relationship(
             conn.commit()
             success = True
         except Exception as e:
-            logger.warning(f"[RELATIONSHIP ADD ERROR] {e}")
+            logger.exception(f"[RELATIONSHIP ADD ERROR] {e}")
             success = False
         if success:
             touch_last_edited(table_a, id_a)
@@ -138,7 +138,7 @@ def remove_relationship(table_a, id_a, table_b, id_b, *, actor: str | None = Non
             conn.commit()
             success = True
         except Exception as e:
-            logger.warning(f"[RELATIONSHIP REMOVE ERROR] {e}")
+            logger.exception(f"[RELATIONSHIP REMOVE ERROR] {e}")
             success = False
         if success:
             touch_last_edited(table_a, id_a)

--- a/db/schema.py
+++ b/db/schema.py
@@ -117,7 +117,7 @@ def update_foreign_field_options():
                 )
                 options = [r[1] for r in cur.fetchall()]
             except Exception as e:
-                logger.warning(
+                logger.exception(
                     "Skipping %s.%s → %s: %s",
                     table_name,
                     field_name,

--- a/views/records/record_views.py
+++ b/views/records/record_views.py
@@ -322,7 +322,7 @@ def update_relationships(table):
     try:
         update_relationship_visibility(table, visibility)
     except Exception as e:
-        current_app.logger.warning('[relationships] update failed: %s', e)
+        current_app.logger.exception('[relationships] update failed: %s', e)
         return jsonify({'error': 'update failed'}), 500
     return jsonify({'success': True})
 


### PR DESCRIPTION
## Summary
- replace broad exception warnings with `logger.exception` to include stack traces across record CRUD helpers
- upgrade dashboard, relationship, and edit history modules to log exceptions instead of warnings
- ensure schema utilities and view handlers capture stack traces when unexpected errors occur

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeb2857bb08333b44c3884f131256c