### PR TITLE
Add meaningful logging to unused loggers

### DIFF
--- a/db/automation.py
+++ b/db/automation.py
@@ -40,6 +40,12 @@ def create_rule(
         )
         rule_id = cur.lastrowid
         conn.commit()
+    logger.info(
+        "Created automation rule %s (id=%s) for table %s",
+        name,
+        rule_id,
+        table_name,
+    )
     return rule_id
 
 
@@ -55,6 +61,7 @@ def update_rule(rule_id: int, **updates) -> bool:
             params,
         )
         conn.commit()
+    logger.info("Updated automation rule %s with %s", rule_id, updates)
     return True
 
 
@@ -62,11 +69,13 @@ def delete_rule(rule_id: int) -> bool:
     with get_connection() as conn:
         conn.execute("DELETE FROM automation_rules WHERE id = ?", (rule_id,))
         conn.commit()
+    logger.info("Deleted automation rule %s", rule_id)
     return True
 
 
 def get_rules(table_name: str | None = None) -> list[dict]:
     """Return automation rules optionally filtered by table."""
+    logger.debug("Fetching rules for table %s", table_name)
     with get_connection() as conn:
         cur = conn.cursor()
         if table_name:
@@ -89,6 +98,7 @@ def increment_run_count(rule_id: int) -> None:
             (rule_id,),
         )
         conn.commit()
+    logger.debug("Incremented run count for rule %s", rule_id)
 
 
 def reset_run_count(rule_id: int) -> None:
@@ -98,3 +108,4 @@ def reset_run_count(rule_id: int) -> None:
             (rule_id,),
         )
         conn.commit()
+    logger.info("Reset run count for rule %s", rule_id)

--- a/db/query_filters.py
+++ b/db/query_filters.py
@@ -81,6 +81,14 @@ def _build_filters(
     modes=None,
 ):
     """Return SQL where clauses and params for the provided filters/search."""
+    logger.debug(
+        "Building filters table=%s search=%s filters=%s ops=%s modes=%s",
+        table,
+        search,
+        filters,
+        ops,
+        modes,
+    )
     clauses: list[str] = []
     params: list[str] = []
 
@@ -137,4 +145,5 @@ def _build_filters(
             clauses.append("(" + " OR ".join(subconds) + ")")
             params.extend([f"%{search_term}%"] * len(subconds))
 
+    logger.debug("Built clauses=%s params=%s", clauses, params)
     return clauses, params

--- a/views/admin/__init__.py
+++ b/views/admin/__init__.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 def reload_app_state() -> None:
     """Refresh cached navigation and schema data after a DB change."""
+    logger.info("Reloading application state")
     try:
         rows = get_config_rows('database')
         cfg = {row['key']: row['value'] for row in rows}
@@ -28,6 +29,7 @@ def reload_app_state() -> None:
     # Update wizard state based on new database status
     status = check_db_status(DB_PATH)
     current_app.config['NEEDS_WIZARD'] = status != 'valid'
+    logger.debug("App state reloaded with %d base tables", len(base_tables))
 
 
 @admin_bp.route('/admin')

--- a/views/admin/automation.py
+++ b/views/admin/automation.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 @admin_bp.route('/admin/api/automation/rules')
 def list_rules():
+    logger.debug("Listing automation rules")
     return jsonify(get_rules())
 
 
@@ -34,6 +35,7 @@ def create_rule_route():
         bool(data.get('run_on_import')),
         data.get('schedule', 'none'),
     )
+    logger.info("Created automation rule %s", rule_id)
     return jsonify({'id': rule_id})
 
 
@@ -41,29 +43,34 @@ def create_rule_route():
 def update_rule_route(rule_id):
     data = request.get_json(silent=True) or {}
     update_rule(rule_id, **data)
+    logger.info("Updated automation rule %s", rule_id)
     return jsonify({'success': True})
 
 
 @admin_bp.route('/admin/api/automation/rules/<int:rule_id>/delete', methods=['POST'])
 def delete_rule_route(rule_id):
     delete_rule(rule_id)
+    logger.info("Deleted automation rule %s", rule_id)
     return jsonify({'success': True})
 
 
 @admin_bp.route('/admin/api/automation/rules/<int:rule_id>/run', methods=['POST'])
 def run_rule_route(rule_id):
     count = run_rule(rule_id)
+    logger.info("Ran automation rule %s updated=%s", rule_id, count)
     return jsonify({'updated': count})
 
 
 @admin_bp.route('/admin/api/automation/rules/<int:rule_id>/reset', methods=['POST'])
 def reset_rule_route(rule_id):
     reset_run_count(rule_id)
+    logger.info("Reset run count for rule %s", rule_id)
     return jsonify({'success': True})
 
 
 @admin_bp.route('/admin/api/automation/rules/<int:rule_id>/logs')
 def rule_logs(rule_id):
+    logger.debug("Fetching logs for rule %s", rule_id)
     with get_connection() as conn:
         cur = conn.cursor()
         cur.execute(
@@ -84,4 +91,5 @@ def rollback_entry():
     if not entry:
         return jsonify({'error': 'not_found'}), 404
     revert_edit(entry)
+    logger.info("Rolled back edit entry %s", entry_id)
     return jsonify({'success': True})

--- a/views/admin/dashboard.py
+++ b/views/admin/dashboard.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 def dashboard():
     widgets = get_dashboard_widgets()
     view = request.args.get("view") or "Dashboard"
+    logger.debug("Rendering dashboard view %s", view)
     groups = sorted({(w.get("group") or "Dashboard") for w in widgets})
     for w in widgets:
         if w.get('widget_type') == 'table':
@@ -89,6 +90,7 @@ def dashboard_create_widget():
     if not widget_id:
         return jsonify({'error': 'Failed to create widget'}), 500
 
+    logger.info("Created dashboard widget %s type=%s", widget_id, widget_type)
     return jsonify({'success': True, 'id': widget_id})
 
 
@@ -99,6 +101,7 @@ def dashboard_update_layout():
         return jsonify({'error': 'Invalid JSON or missing `layout`'}), 400
     layout_items = data['layout']
     updated = update_widget_layout(layout_items)
+    logger.info("Updated dashboard layout for %d items", len(layout_items))
     return jsonify({'success': True, 'updated': updated})
 
 
@@ -110,6 +113,11 @@ def dashboard_update_style():
     if widget_id is None or not isinstance(styling, dict):
         return jsonify({'error': 'Invalid data'}), 400
     success = update_widget_styling(widget_id, styling)
+    logger.info(
+        "Updated dashboard styling widget=%s success=%s",
+        widget_id,
+        bool(success),
+    )
     return jsonify({'success': bool(success)})
 
 
@@ -119,6 +127,7 @@ def dashboard_delete_widget(widget_id):
     success = delete_widget(widget_id)
     if not success:
         return jsonify({'error': 'Failed to delete widget'}), 500
+    logger.info("Deleted dashboard widget %s", widget_id)
     return jsonify({'success': True})
 
 
@@ -126,6 +135,7 @@ def dashboard_delete_widget(widget_id):
 def dashboard_base_count():
     """Return counts for all base tables."""
     data = get_base_table_counts()
+    logger.debug("Returning base table counts")
     return jsonify(data)
 
 
@@ -148,6 +158,9 @@ def dashboard_top_numeric():
         )
     except ValueError:
         return jsonify([]), 400
+    logger.debug(
+        "Top numeric for %s.%s limit=%s direction=%s", table, field, limit, direction
+    )
     return jsonify(data)
 
 
@@ -165,4 +178,11 @@ def dashboard_filtered_records():
         data = get_filtered_records(table, filters=search, order_by=order_by, limit=limit)
     except ValueError:
         return jsonify([]), 400
+    logger.debug(
+        "Filtered records for %s search=%s order_by=%s limit=%s",
+        table,
+        search,
+        order_by,
+        limit,
+    )
     return jsonify(data)

--- a/views/api/__init__.py
+++ b/views/api/__init__.py
@@ -12,5 +12,6 @@ def api_base_tables():
     """Return configured base tables with display info."""
     with get_connection() as conn:
         data = load_card_info(conn)
+    logger.debug("Loaded %d base tables", len(data))
     return jsonify(data)
 

--- a/views/records/list_views.py
+++ b/views/records/list_views.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 @records_bp.route('/<table>')
 @require_base_table
 def list_view(table):
+    logger.debug("Rendering list view for %s with args %s", table, dict(request.args))
     ctx = build_list_context(table)
     if request.accept_mimetypes.best == 'application/json':
         rows = render_template('_record_rows.html', **ctx)
@@ -38,6 +39,7 @@ def api_list(table):
     """Return id and label info for records in the table."""
     search = request.args.get('search')
     limit = request.args.get('limit', type=int)
+    logger.debug("api_list table=%s search=%s limit=%s", table, search, limit)
 
     with get_connection() as conn:
         cur = conn.cursor()
@@ -72,6 +74,7 @@ def api_list(table):
 @records_bp.route('/api/<table>/records')
 @require_base_table
 def api_records(table):
+    logger.debug("api_records table=%s args=%s", table, dict(request.args))
     ctx = build_list_context(table)
     rows = render_template('_record_rows.html', **ctx)
     pager = render_template('_pagination.html', **ctx)
@@ -92,6 +95,7 @@ def export_csv(table):
     """Stream CSV of records using current filters and search."""
     params = parse_list_params(table)
     fields = [f for f in params['fields'] if not f.startswith('_')]
+    logger.info("Exporting CSV for %s fields=%s", table, fields)
     ids_param = request.args.getlist('ids') or request.args.get('ids', '')
     if isinstance(ids_param, str):
         ids = [i for i in ids_param.split(',') if i]


### PR DESCRIPTION
## Summary
- add debug and info logs to list view and record API endpoints
- log automation rule operations and filter building
- instrument admin routes and dashboard actions with meaningful logging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af1a4fc1f0833393ad7f2d648dbc6e