### PR TITLE
Refine logging levels to match README guidance

### DIFF
--- a/automation/engine.py
+++ b/automation/engine.py
@@ -12,7 +12,7 @@ def run_rule(rule_id: int) -> int:
     """Execute a single automation rule. Returns number of records updated."""
     rules = [r for r in get_rules() if r["id"] == rule_id]
     if not rules:
-        logger.warning("Rule %s not found", rule_id)
+        logger.info("Rule %s not found", rule_id)
         return 0
     rule = rules[0]
     table = rule["table_name"]

--- a/db/dashboard.py
+++ b/db/dashboard.py
@@ -140,7 +140,7 @@ def update_widget_styling(widget_id: int, styling: dict) -> bool:
     try:
         styling_json = json.dumps(styling or {})
     except (TypeError, ValueError) as exc:
-        logger.warning("[update_widget_styling] invalid styling for %s: %s", widget_id, exc)
+        logger.info("[update_widget_styling] invalid styling for %s: %s", widget_id, exc)
         return False
 
     with get_connection() as conn:

--- a/db/schema.py
+++ b/db/schema.py
@@ -295,10 +295,10 @@ def update_field_styling(table: str, field: str, styling_dict: dict) -> bool:
 def create_base_table(table_name: str, description: str, title_field: str) -> bool:
     """Create a new base table and associated metadata."""
     if not table_name.isidentifier():
-        logger.error("Invalid table name: %s", table_name)
+        logger.info("Invalid table name: %s", table_name)
         return False
     if not title_field.isidentifier():
-        logger.error("Invalid title field: %s", title_field)
+        logger.info("Invalid title field: %s", title_field)
         return False
 
     with get_connection() as conn:
@@ -310,7 +310,7 @@ def create_base_table(table_name: str, description: str, title_field: str) -> bo
                 (table_name,),
             )
             if cur.fetchone():
-                logger.error("Table %s already exists", table_name)
+                logger.info("Table %s already exists", table_name)
                 return False
 
             # Create the base table with timestamp columns

--- a/views/records/record_views.py
+++ b/views/records/record_views.py
@@ -120,13 +120,13 @@ def add_field_route(table, record_id):
         logger.info('Added column to %s: field=%r type=%r', table, field_name, field_type)
         return redirect(url_for('records.detail_view', table=table, record_id=record_id))
     except json.JSONDecodeError as e:
-        logger.warning('add_field_route invalid styling JSON: %s', e)
+        logger.info('add_field_route invalid styling JSON: %s', e)
         return 'Invalid styling data', 400
     except sqlite3.DatabaseError as e:
         logger.exception('add_field_route database error: %s', e)
         return 'Server error', 500
     except ValueError as e:
-        logger.warning('add_field_route validation failed: %s', e)
+        logger.info('add_field_route validation failed: %s', e)
         return str(e), 400
 
 


### PR DESCRIPTION
## Summary
- reduce false warning logs in automation, dashboard, and record views modules
- treat invalid table creation inputs as info messages instead of errors
- keep logging consistent with project guidelines

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afeeafafb48333b1f6ddbe9496cf76