### PR TITLE
Enhance logging with contextual extra metadata

### DIFF
--- a/automation/engine.py
+++ b/automation/engine.py
@@ -12,7 +12,11 @@ def run_rule(rule_id: int) -> int:
     """Execute a single automation rule. Returns number of records updated."""
     rules = [r for r in get_rules() if r["id"] == rule_id]
     if not rules:
-        logger.info("Rule %s not found", rule_id)
+        logger.info(
+            "Rule %s not found",
+            rule_id,
+            extra={"rule_id": rule_id},
+        )
         return 0
     rule = rules[0]
     table = rule["table_name"]

--- a/db/automation.py
+++ b/db/automation.py
@@ -45,6 +45,7 @@ def create_rule(
         name,
         rule_id,
         table_name,
+        extra={"rule_id": rule_id, "table": table_name, "rule_name": name},
     )
     return rule_id
 
@@ -61,7 +62,12 @@ def update_rule(rule_id: int, **updates) -> bool:
             params,
         )
         conn.commit()
-    logger.info("Updated automation rule %s with %s", rule_id, updates)
+    logger.info(
+        "Updated automation rule %s with %s",
+        rule_id,
+        updates,
+        extra={"rule_id": rule_id, "updates": updates},
+    )
     return True
 
 
@@ -69,13 +75,21 @@ def delete_rule(rule_id: int) -> bool:
     with get_connection() as conn:
         conn.execute("DELETE FROM automation_rules WHERE id = ?", (rule_id,))
         conn.commit()
-    logger.info("Deleted automation rule %s", rule_id)
+    logger.info(
+        "Deleted automation rule %s",
+        rule_id,
+        extra={"rule_id": rule_id},
+    )
     return True
 
 
 def get_rules(table_name: str | None = None) -> list[dict]:
     """Return automation rules optionally filtered by table."""
-    logger.debug("Fetching rules for table %s", table_name)
+    logger.debug(
+        "Fetching rules for table %s",
+        table_name,
+        extra={"table": table_name},
+    )
     with get_connection() as conn:
         cur = conn.cursor()
         if table_name:
@@ -98,7 +112,11 @@ def increment_run_count(rule_id: int) -> None:
             (rule_id,),
         )
         conn.commit()
-    logger.debug("Incremented run count for rule %s", rule_id)
+    logger.debug(
+        "Incremented run count for rule %s",
+        rule_id,
+        extra={"rule_id": rule_id},
+    )
 
 
 def reset_run_count(rule_id: int) -> None:
@@ -108,4 +126,8 @@ def reset_run_count(rule_id: int) -> None:
             (rule_id,),
         )
         conn.commit()
-    logger.info("Reset run count for rule %s", rule_id)
+    logger.info(
+        "Reset run count for rule %s",
+        rule_id,
+        extra={"rule_id": rule_id},
+    )

--- a/db/dashboard.py
+++ b/db/dashboard.py
@@ -23,7 +23,13 @@ def sum_field(table: str, field: str) -> float:
             result = cursor.fetchone()[0]
             return result or 0
         except sqlite3.DatabaseError as e:
-            logger.exception(f"[sum_field] SQL error for {table}.{field}: {e}")
+            logger.exception(
+                "[sum_field] SQL error for %s.%s: %s",
+                table,
+                field,
+                e,
+                extra={"table": table, "field": field},
+            )
             return 0
 
 # Return all dashboard widgets ordered by id.
@@ -39,7 +45,11 @@ def get_dashboard_widgets() -> list[dict]:
             cols = [d[0] for d in cursor.description]
             return [dict(zip(cols, r)) for r in rows]
         except sqlite3.DatabaseError as e:
-            logger.exception("[get_dashboard_widgets] SQL error: %s", e)
+            logger.exception(
+                "[get_dashboard_widgets] SQL error: %s",
+                e,
+                extra={"error": str(e)},
+            )
             return []
 
 def create_widget(
@@ -84,7 +94,11 @@ def create_widget(
             conn.commit()
             return cur.lastrowid
         except sqlite3.DatabaseError as exc:
-            logger.exception("[create_widget] SQL error: %s", exc)
+            logger.exception(
+                "[create_widget] SQL error: %s",
+                exc,
+                extra={"error": str(exc)},
+            )
             return None
 
 def update_widget_layout(layout_items: list[dict]) -> int:
@@ -117,6 +131,7 @@ def update_widget_layout(layout_items: list[dict]) -> int:
                 col_span,
                 row_start,
                 row_span,
+                extra={"widget_id": widget_id},
             )
             cur.execute(
                 """
@@ -140,7 +155,12 @@ def update_widget_styling(widget_id: int, styling: dict) -> bool:
     try:
         styling_json = json.dumps(styling or {})
     except (TypeError, ValueError) as exc:
-        logger.info("[update_widget_styling] invalid styling for %s: %s", widget_id, exc)
+        logger.info(
+            "[update_widget_styling] invalid styling for %s: %s",
+            widget_id,
+            exc,
+            extra={"widget_id": widget_id, "error": str(exc)},
+        )
         return False
 
     with get_connection() as conn:
@@ -157,7 +177,11 @@ def update_widget_styling(widget_id: int, styling: dict) -> bool:
             conn.commit()
             return cur.rowcount > 0
         except sqlite3.DatabaseError as exc:
-            logger.exception("[update_widget_styling] SQL error: %s", exc)
+            logger.exception(
+                "[update_widget_styling] SQL error: %s",
+                exc,
+                extra={"widget_id": widget_id, "error": str(exc)},
+            )
             return False
 
 
@@ -173,7 +197,11 @@ def delete_widget(widget_id: int) -> bool:
             conn.commit()
             return cur.rowcount > 0
         except sqlite3.DatabaseError as exc:
-            logger.exception("[delete_widget] SQL error: %s", exc)
+            logger.exception(
+                "[delete_widget] SQL error: %s",
+                exc,
+                extra={"widget_id": widget_id, "error": str(exc)},
+            )
             return False
 
 
@@ -185,7 +213,12 @@ def get_base_table_counts() -> list[dict]:
         try:
             cnt = count_records(table)
         except sqlite3.DatabaseError as exc:
-            logger.exception("[get_base_table_counts] error for %s: %s", table, exc)
+            logger.exception(
+                "[get_base_table_counts] error for %s: %s",
+                table,
+                exc,
+                extra={"table": table, "error": str(exc)},
+            )
             cnt = 0
         results.append({"table": table, "count": cnt})
     return results
@@ -215,7 +248,11 @@ def get_top_numeric_values(
             return [{"id": r[0], "value": r[1]} for r in rows]
         except sqlite3.DatabaseError as exc:
             logger.exception(
-                "[get_top_numeric_values] SQL error for %s.%s: %s", table, field, exc
+                "[get_top_numeric_values] SQL error for %s.%s: %s",
+                table,
+                field,
+                exc,
+                extra={"table": table, "field": field, "error": str(exc)},
             )
             return []
 
@@ -237,6 +274,9 @@ def get_filtered_records(
         return rows
     except sqlite3.DatabaseError as exc:
         logger.exception(
-            "[get_filtered_records] error for %s: %s", table, exc
+            "[get_filtered_records] error for %s: %s",
+            table,
+            exc,
+            extra={"table": table, "error": str(exc)},
         )
         return []

--- a/db/query_filters.py
+++ b/db/query_filters.py
@@ -88,6 +88,7 @@ def _build_filters(
         filters,
         ops,
         modes,
+        extra={"table": table, "search": search},
     )
     clauses: list[str] = []
     params: list[str] = []
@@ -145,5 +146,10 @@ def _build_filters(
             clauses.append("(" + " OR ".join(subconds) + ")")
             params.extend([f"%{search_term}%"] * len(subconds))
 
-    logger.debug("Built clauses=%s params=%s", clauses, params)
+    logger.debug(
+        "Built clauses=%s params=%s",
+        clauses,
+        params,
+        extra={"table": table, "clauses": clauses},
+    )
     return clauses, params

--- a/db/relationships.py
+++ b/db/relationships.py
@@ -98,7 +98,17 @@ def add_relationship(
             conn.commit()
             success = True
         except sqlite3.DatabaseError as e:
-            logger.exception(f"[RELATIONSHIP ADD ERROR] {e}")
+            logger.exception(
+                "[RELATIONSHIP ADD ERROR] %s",
+                e,
+                extra={
+                    "table_a": table_a,
+                    "id_a": id_a,
+                    "table_b": table_b,
+                    "id_b": id_b,
+                    "error": str(e),
+                },
+            )
             success = False
         if success:
             touch_last_edited(table_a, id_a)
@@ -139,7 +149,17 @@ def remove_relationship(table_a, id_a, table_b, id_b, *, actor: str | None = Non
             conn.commit()
             success = True
         except sqlite3.DatabaseError as e:
-            logger.exception(f"[RELATIONSHIP REMOVE ERROR] {e}")
+            logger.exception(
+                "[RELATIONSHIP REMOVE ERROR] %s",
+                e,
+                extra={
+                    "table_a": table_a,
+                    "id_a": id_a,
+                    "table_b": table_b,
+                    "id_b": id_b,
+                    "error": str(e),
+                },
+            )
             success = False
         if success:
             touch_last_edited(table_a, id_a)

--- a/main.py
+++ b/main.py
@@ -86,10 +86,18 @@ app.register_blueprint(api_bp)
 @app.context_processor
 def inject_field_schema():
     schema = get_field_schema()
-    logger.debug("Injected field schema keys 2: %s", list(schema.keys()))
+    logger.debug(
+        "Injected field schema keys 2: %s",
+        list(schema.keys()),
+        extra={"schema_keys": list(schema.keys())},
+    )
 
     macro_map = {name: ft.macro for name, ft in FIELD_TYPES.items() if ft.macro}
-    logger.debug("Field macro map keys: %s", list(macro_map.keys()))
+    logger.debug(
+        "Field macro map keys: %s",
+        list(macro_map.keys()),
+        extra={"macro_keys": list(macro_map.keys())},
+    )
 
     filter_macro_map = {
         name: ft.filter_macro

--- a/utils/record_ops.py
+++ b/utils/record_ops.py
@@ -53,7 +53,17 @@ def update_record_field(table: str, record_id: int, field: str, value: Any) -> s
         append_edit_log(table, record_id, field, str(prev_value), str(new_value))
 
     logger.info(
-        "Field updated for %s id=%s: %s -> %r", table, record_id, field, new_value
+        "Field updated for %s id=%s: %s -> %r",
+        table,
+        record_id,
+        field,
+        new_value,
+        extra={
+            "table": table,
+            "record_id": record_id,
+            "field": field,
+            "new_value": new_value,
+        },
     )
     return new_value
 
@@ -71,5 +81,11 @@ def bulk_update_records(table: str, ids: list[int], field: str, value: Any) -> i
         if update_field_value(table, rid, field, new_value):
             append_edit_log(table, rid, field, None, str(new_value))
             updated += 1
-    logger.info("Bulk updated %s records for %s.%s", updated, table, field)
+    logger.info(
+        "Bulk updated %s records for %s.%s",
+        updated,
+        table,
+        field,
+        extra={"table": table, "field": field, "updated": updated},
+    )
     return updated

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -12,11 +12,17 @@ def get_options(table: str, field: str) -> list[str]:
     return schema.get(table, {}).get(field, {}).get("options", [])
 
 def validation_sorter(table, field, header, fieldType, values):
-    logger.debug("✅ Validation function was triggered.")
+    logger.debug(
+        "✅ Validation function was triggered.",
+        extra={"table": table, "field": field},
+    )
 
     ft = get_field_type(fieldType)
     if not ft or not ft.validator:
-        logger.debug("no validation for this datatype")
+        logger.debug(
+            "no validation for this datatype",
+            extra={"datatype": fieldType},
+        )
         return {}
 
     result = ft.validator(table, field, values)

--- a/views/admin/__init__.py
+++ b/views/admin/__init__.py
@@ -12,7 +12,10 @@ logger = logging.getLogger(__name__)
 
 def reload_app_state() -> None:
     """Refresh cached navigation and schema data after a DB change."""
-    logger.info("Reloading application state")
+    logger.info(
+        "Reloading application state",
+        extra={"action": "reload_app_state"},
+    )
     try:
         rows = get_config_rows('database')
         cfg = {row['key']: row['value'] for row in rows}
@@ -29,7 +32,11 @@ def reload_app_state() -> None:
     # Update wizard state based on new database status
     status = check_db_status(DB_PATH)
     current_app.config['NEEDS_WIZARD'] = status != 'valid'
-    logger.debug("App state reloaded with %d base tables", len(base_tables))
+    logger.debug(
+        "App state reloaded with %d base tables",
+        len(base_tables),
+        extra={"base_table_count": len(base_tables)},
+    )
 
 
 @admin_bp.route('/admin')

--- a/views/admin/automation.py
+++ b/views/admin/automation.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 @admin_bp.route('/admin/api/automation/rules')
 def list_rules():
-    logger.debug("Listing automation rules")
+    logger.debug("Listing automation rules", extra={"route": "list_rules"})
     return jsonify(get_rules())
 
 
@@ -35,7 +35,11 @@ def create_rule_route():
         bool(data.get('run_on_import')),
         data.get('schedule', 'none'),
     )
-    logger.info("Created automation rule %s", rule_id)
+    logger.info(
+        "Created automation rule %s",
+        rule_id,
+        extra={"rule_id": rule_id},
+    )
     return jsonify({'id': rule_id})
 
 
@@ -43,34 +47,55 @@ def create_rule_route():
 def update_rule_route(rule_id):
     data = request.get_json(silent=True) or {}
     update_rule(rule_id, **data)
-    logger.info("Updated automation rule %s", rule_id)
+    logger.info(
+        "Updated automation rule %s",
+        rule_id,
+        extra={"rule_id": rule_id},
+    )
     return jsonify({'success': True})
 
 
 @admin_bp.route('/admin/api/automation/rules/<int:rule_id>/delete', methods=['POST'])
 def delete_rule_route(rule_id):
     delete_rule(rule_id)
-    logger.info("Deleted automation rule %s", rule_id)
+    logger.info(
+        "Deleted automation rule %s",
+        rule_id,
+        extra={"rule_id": rule_id},
+    )
     return jsonify({'success': True})
 
 
 @admin_bp.route('/admin/api/automation/rules/<int:rule_id>/run', methods=['POST'])
 def run_rule_route(rule_id):
     count = run_rule(rule_id)
-    logger.info("Ran automation rule %s updated=%s", rule_id, count)
+    logger.info(
+        "Ran automation rule %s updated=%s",
+        rule_id,
+        count,
+        extra={"rule_id": rule_id, "updated": count},
+    )
     return jsonify({'updated': count})
 
 
 @admin_bp.route('/admin/api/automation/rules/<int:rule_id>/reset', methods=['POST'])
 def reset_rule_route(rule_id):
     reset_run_count(rule_id)
-    logger.info("Reset run count for rule %s", rule_id)
+    logger.info(
+        "Reset run count for rule %s",
+        rule_id,
+        extra={"rule_id": rule_id},
+    )
     return jsonify({'success': True})
 
 
 @admin_bp.route('/admin/api/automation/rules/<int:rule_id>/logs')
 def rule_logs(rule_id):
-    logger.debug("Fetching logs for rule %s", rule_id)
+    logger.debug(
+        "Fetching logs for rule %s",
+        rule_id,
+        extra={"rule_id": rule_id},
+    )
     with get_connection() as conn:
         cur = conn.cursor()
         cur.execute(
@@ -91,5 +116,9 @@ def rollback_entry():
     if not entry:
         return jsonify({'error': 'not_found'}), 404
     revert_edit(entry)
-    logger.info("Rolled back edit entry %s", entry_id)
+    logger.info(
+        "Rolled back edit entry %s",
+        entry_id,
+        extra={"entry_id": entry_id},
+    )
     return jsonify({'success': True})

--- a/views/admin/config.py
+++ b/views/admin/config.py
@@ -147,7 +147,12 @@ def add_table():
     try:
         success = create_base_table(table_name, description, table_name)
     except (sqlite3.DatabaseError, ValueError) as exc:
-        logger.exception('Failed to create table %s: %s', table_name, exc)
+        logger.exception(
+            'Failed to create table %s: %s',
+            table_name,
+            exc,
+            extra={"table": table_name, "error": str(exc)},
+        )
         return jsonify({'error': str(exc)}), 400
     if not success:
         return jsonify({'error': 'Failed to create table'}), 400

--- a/views/admin/dashboard.py
+++ b/views/admin/dashboard.py
@@ -22,7 +22,11 @@ logger = logging.getLogger(__name__)
 def dashboard():
     widgets = get_dashboard_widgets()
     view = request.args.get("view") or "Dashboard"
-    logger.debug("Rendering dashboard view %s", view)
+    logger.debug(
+        "Rendering dashboard view %s",
+        view,
+        extra={"view": view},
+    )
     groups = sorted({(w.get("group") or "Dashboard") for w in widgets})
     for w in widgets:
         if w.get('widget_type') == 'table':
@@ -90,7 +94,12 @@ def dashboard_create_widget():
     if not widget_id:
         return jsonify({'error': 'Failed to create widget'}), 500
 
-    logger.info("Created dashboard widget %s type=%s", widget_id, widget_type)
+    logger.info(
+        "Created dashboard widget %s type=%s",
+        widget_id,
+        widget_type,
+        extra={"widget_id": widget_id, "widget_type": widget_type},
+    )
     return jsonify({'success': True, 'id': widget_id})
 
 
@@ -101,7 +110,11 @@ def dashboard_update_layout():
         return jsonify({'error': 'Invalid JSON or missing `layout`'}), 400
     layout_items = data['layout']
     updated = update_widget_layout(layout_items)
-    logger.info("Updated dashboard layout for %d items", len(layout_items))
+    logger.info(
+        "Updated dashboard layout for %d items",
+        len(layout_items),
+        extra={"item_count": len(layout_items)},
+    )
     return jsonify({'success': True, 'updated': updated})
 
 
@@ -117,6 +130,7 @@ def dashboard_update_style():
         "Updated dashboard styling widget=%s success=%s",
         widget_id,
         bool(success),
+        extra={"widget_id": widget_id, "success": bool(success)},
     )
     return jsonify({'success': bool(success)})
 
@@ -127,7 +141,11 @@ def dashboard_delete_widget(widget_id):
     success = delete_widget(widget_id)
     if not success:
         return jsonify({'error': 'Failed to delete widget'}), 500
-    logger.info("Deleted dashboard widget %s", widget_id)
+    logger.info(
+        "Deleted dashboard widget %s",
+        widget_id,
+        extra={"widget_id": widget_id},
+    )
     return jsonify({'success': True})
 
 
@@ -135,7 +153,7 @@ def dashboard_delete_widget(widget_id):
 def dashboard_base_count():
     """Return counts for all base tables."""
     data = get_base_table_counts()
-    logger.debug("Returning base table counts")
+    logger.debug("Returning base table counts", extra={"route": "dashboard_base_count"})
     return jsonify(data)
 
 
@@ -159,7 +177,17 @@ def dashboard_top_numeric():
     except ValueError:
         return jsonify([]), 400
     logger.debug(
-        "Top numeric for %s.%s limit=%s direction=%s", table, field, limit, direction
+        "Top numeric for %s.%s limit=%s direction=%s",
+        table,
+        field,
+        limit,
+        direction,
+        extra={
+            "table": table,
+            "field": field,
+            "limit": limit,
+            "direction": direction,
+        },
     )
     return jsonify(data)
 
@@ -184,5 +212,11 @@ def dashboard_filtered_records():
         search,
         order_by,
         limit,
+        extra={
+            "table": table,
+            "search": search,
+            "order_by": order_by,
+            "limit": limit,
+        },
     )
     return jsonify(data)

--- a/views/admin/fields.py
+++ b/views/admin/fields.py
@@ -23,7 +23,12 @@ def admin_fields():
             try:
                 nn = count_nonnull(table, field)
             except (sqlite3.DatabaseError, ValueError):
-                logger.exception('Failed counting %s.%s', table, field)
+                logger.exception(
+                    'Failed counting %s.%s',
+                    table,
+                    field,
+                    extra={"table": table, "field": field},
+                )
                 nn = 0
             fields.append({'name': field, 'type': meta.get('type'), 'count': nn})
         table_data[table] = fields

--- a/views/api/__init__.py
+++ b/views/api/__init__.py
@@ -12,6 +12,10 @@ def api_base_tables():
     """Return configured base tables with display info."""
     with get_connection() as conn:
         data = load_card_info(conn)
-    logger.debug("Loaded %d base tables", len(data))
+    logger.debug(
+        "Loaded %d base tables",
+        len(data),
+        extra={"base_table_count": len(data)},
+    )
     return jsonify(data)
 

--- a/views/records/list_views.py
+++ b/views/records/list_views.py
@@ -16,7 +16,12 @@ logger = logging.getLogger(__name__)
 @records_bp.route('/<table>')
 @require_base_table
 def list_view(table):
-    logger.debug("Rendering list view for %s with args %s", table, dict(request.args))
+    logger.debug(
+        "Rendering list view for %s with args %s",
+        table,
+        dict(request.args),
+        extra={"table": table},
+    )
     ctx = build_list_context(table)
     if request.accept_mimetypes.best == 'application/json':
         rows = render_template('_record_rows.html', **ctx)
@@ -39,7 +44,13 @@ def api_list(table):
     """Return id and label info for records in the table."""
     search = request.args.get('search')
     limit = request.args.get('limit', type=int)
-    logger.debug("api_list table=%s search=%s limit=%s", table, search, limit)
+    logger.debug(
+        "api_list table=%s search=%s limit=%s",
+        table,
+        search,
+        limit,
+        extra={"table": table, "search": search, "limit": limit},
+    )
 
     with get_connection() as conn:
         cur = conn.cursor()
@@ -74,7 +85,12 @@ def api_list(table):
 @records_bp.route('/api/<table>/records')
 @require_base_table
 def api_records(table):
-    logger.debug("api_records table=%s args=%s", table, dict(request.args))
+    logger.debug(
+        "api_records table=%s args=%s",
+        table,
+        dict(request.args),
+        extra={"table": table},
+    )
     ctx = build_list_context(table)
     rows = render_template('_record_rows.html', **ctx)
     pager = render_template('_pagination.html', **ctx)
@@ -95,7 +111,12 @@ def export_csv(table):
     """Stream CSV of records using current filters and search."""
     params = parse_list_params(table)
     fields = [f for f in params['fields'] if not f.startswith('_')]
-    logger.info("Exporting CSV for %s fields=%s", table, fields)
+    logger.info(
+        "Exporting CSV for %s fields=%s",
+        table,
+        fields,
+        extra={"table": table, "fields": fields},
+    )
     ids_param = request.args.getlist('ids') or request.args.get('ids', '')
     if isinstance(ids_param, str):
         ids = [i for i in ids_param.split(',') if i]

--- a/views/wizard.py
+++ b/views/wizard.py
@@ -95,7 +95,11 @@ def database_step():
             else:
                 error = 'Please upload a file or enter a name.'
         except (sqlite3.DatabaseError, OSError, ValueError) as exc:
-            logger.exception('Failed to handle database file: %s', exc)
+            logger.exception(
+                'Failed to handle database file: %s',
+                exc,
+                extra={"error": str(exc)},
+            )
             error = f'Failed to save file: {exc}'
 
         if not error:
@@ -205,7 +209,10 @@ def table_step():
                     try:
                         field_defs = json.loads(fields_json)
                     except json.JSONDecodeError:
-                        logger.exception('Failed to parse fields_json')
+                        logger.exception(
+                            'Failed to parse fields_json',
+                            extra={"error": "invalid_json"},
+                        )
 
                 for f in field_defs:
                     name = to_identifier(f.get('name'), 'f_')
@@ -224,7 +231,11 @@ def table_step():
                             f.get('foreign_key'),
                         )
                     except (sqlite3.DatabaseError, ValueError):
-                        logger.exception('Failed to add field %s', name)
+                        logger.exception(
+                            'Failed to add field %s',
+                            name,
+                            extra={"field": name},
+                        )
                 any_created = True
             else:
                 error = f'Table "{table_name}" could not be created.'
@@ -262,9 +273,13 @@ def import_step():
                     try:
                         create_record(table, row)
                     except (sqlite3.DatabaseError, ValueError):
-                        logger.exception('Failed to import row')
+                        logger.exception('Failed to import row', extra={"table": table})
             except (sqlite3.DatabaseError, ValueError, UnicodeDecodeError) as exc:
-                logger.exception('Failed to import CSV: %s', exc)
+                logger.exception(
+                    'Failed to import CSV: %s',
+                    exc,
+                    extra={"error": str(exc), "table": table},
+                )
                 error = f'Failed to import CSV: {exc}'
         else:
             error = 'Please select a table and upload a .csv file.'


### PR DESCRIPTION
## Summary
- provide structured context for import jobs, automation rules, and record updates using `extra` metadata in logging calls
- annotate view handlers and database utilities with relevant fields (e.g., table, record IDs) for richer log records

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b01d5fe1688333bf369222c7c08846