### PR TITLE
Improve exception logging across application

### DIFF
--- a/db/config.py
+++ b/db/config.py
@@ -1,6 +1,9 @@
 from datetime import datetime
 from db.database import get_connection
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def get_config_rows(sections: str | list[str] | None = None):
@@ -43,6 +46,9 @@ def get_config_rows(sections: str | list[str] | None = None):
             try:
                 item["options"] = json.loads(opts)
             except json.JSONDecodeError:
+                logger.exception(
+                    "Invalid JSON in config options", extra={"key": item.get("key")}
+                )
                 item["options"] = []
         else:
             item["options"] = []
@@ -65,6 +71,7 @@ def get_layout_defaults() -> dict:
         try:
             data = json.loads(row[0])
         except json.JSONDecodeError:
+            logger.exception("Invalid JSON in layout_defaults config")
             data = {}
 
     if not data:
@@ -88,6 +95,7 @@ def get_relationship_visibility() -> dict:
     try:
         return json.loads(row[0])
     except json.JSONDecodeError:
+        logger.exception("Invalid JSON in relationship_visibility config")
         return {}
 
 

--- a/db/dashboard.py
+++ b/db/dashboard.py
@@ -122,6 +122,11 @@ def update_widget_layout(layout_items: list[dict]) -> int:
                 row_start = float(item.get("rowStart", 0))
                 row_span = float(item.get("rowSpan", 0))
             except (TypeError, ValueError):
+                logger.warning(
+                    "Invalid widget layout values",
+                    exc_info=True,
+                    extra={"widget_id": widget_id},
+                )
                 continue
 
             logger.debug(
@@ -155,7 +160,7 @@ def update_widget_styling(widget_id: int, styling: dict) -> bool:
     try:
         styling_json = json.dumps(styling or {})
     except (TypeError, ValueError) as exc:
-        logger.info(
+        logger.exception(
             "[update_widget_styling] invalid styling for %s: %s",
             widget_id,
             exc,

--- a/db/relationships.py
+++ b/db/relationships.py
@@ -53,6 +53,9 @@ def get_related_records(source_table, record_id):
             try:
                 validate_table(target_table)
             except ValueError:
+                logger.warning(
+                    "Invalid related table", exc_info=True, extra={"table": target_table}
+                )
                 continue
             row = _get_label(cur, target_table, target_id)
             if not row:

--- a/db/schema.py
+++ b/db/schema.py
@@ -49,11 +49,19 @@ def load_field_schema():
                 try:
                     schema[table][field]["options"] = json.loads(options)
                 except json.JSONDecodeError:
+                    logger.exception(
+                        "Invalid JSON in field options",
+                        extra={"table": table, "field": field},
+                    )
                     schema[table][field]["options"] = []
             if styling is not None:
                 try:
                     schema[table][field]["styling"] = json.loads(styling)
                 except json.JSONDecodeError:
+                    logger.exception(
+                        "Invalid JSON in field styling",
+                        extra={"table": table, "field": field},
+                    )
                     schema[table][field]["styling"] = styling
         return schema
 
@@ -228,6 +236,11 @@ def update_layout(table: str, layout_items: list[dict]) -> int:
                 row_start = float(item.get("rowStart", 0))
                 row_span = float(item.get("rowSpan", 0))
             except (TypeError, ValueError):
+                logger.warning(
+                    "Invalid layout values",
+                    exc_info=True,
+                    extra={"table": table, "field": field},
+                )
                 continue
 
             logger.debug(
@@ -292,6 +305,9 @@ def update_field_styling(table: str, field: str, styling_dict: dict) -> bool:
     try:
         styling_json = json.dumps(styling_dict or {})
     except (TypeError, ValueError) as exc:
+        logger.exception(
+            "Invalid styling data", extra={"table": table, "field": field}
+        )
         raise ValueError("Invalid styling data") from exc
 
     with get_connection() as conn:

--- a/imports/tasks.py
+++ b/imports/tasks.py
@@ -61,6 +61,10 @@ def _run_import(job_id, table, rows):
                 if create_record(table, row) is None:
                     raise sqlite3.DatabaseError("Failed to create")
             except (sqlite3.DatabaseError, ValueError) as exc:  # noqa: BLE001
+                logger.exception(
+                    "Failed to import row",  # noqa: TRY401
+                    extra={"job_id": job_id, "table": table, "row": idx},
+                )
                 errors.append({"row": idx, "message": str(exc)})
             if idx % 10 == 0 or idx == len(rows):
                 logger.info(

--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ if status == 'valid':
                 if cfg_path:
                     init_db_path(cfg_path)
     except sqlite3.DatabaseError:
+        logger.exception("Failed to verify database during startup")
         needs_wizard = True
 else:
     needs_wizard = True

--- a/utils/record_ops.py
+++ b/utils/record_ops.py
@@ -24,6 +24,7 @@ def _normalize_value(ftype: str, value: Any) -> str:
         try:
             return str(float(value))
         except (TypeError, ValueError):
+            logger.warning("Failed to normalize number", exc_info=True)
             return "0"
     if ftype in {"multi_select", "foreign_key"}:
         if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):

--- a/utils/records_helpers.py
+++ b/utils/records_helpers.py
@@ -1,8 +1,11 @@
 from functools import wraps
+import logging
 from flask import request, abort
 from db.validation import validate_table
 from db.schema import get_field_schema
 from db.records import get_all_records, count_records
+
+logger = logging.getLogger(__name__)
 
 
 def require_base_table(func):
@@ -15,6 +18,7 @@ def require_base_table(func):
         try:
             validate_table(table)
         except ValueError:
+            logger.exception("Unknown table requested", extra={"table": table})
             abort(404)
         return func(*args, **kwargs)
     return wrapper

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -113,6 +113,7 @@ def validate_number_column(values, integer_only=False):
         try:
             int(s) if integer_only else float(s)
         except ValueError:
+            logger.debug("Invalid numeric value", exc_info=True)
             invalid += 1
             details["invalid"].append({"row": idx, "reason": "not a number", })
             continue
@@ -200,6 +201,7 @@ def normalize_number(value):
     try:
         return str(float(value))
     except (TypeError, ValueError):
+        logger.warning("Failed to normalize number", exc_info=True)
         return "0"
 
 

--- a/views/admin/__init__.py
+++ b/views/admin/__init__.py
@@ -21,6 +21,7 @@ def reload_app_state() -> None:
         cfg = {row['key']: row['value'] for row in rows}
         init_db_path(cfg.get('db_path'))
     except sqlite3.DatabaseError:
+        logger.exception("Failed to load database configuration")
         init_db_path()
 
     card_info, base_tables = refresh_card_cache()

--- a/views/admin/config.py
+++ b/views/admin/config.py
@@ -45,6 +45,9 @@ def config_page():
             try:
                 item['parsed'] = json.loads(item.get('value') or '{}')
             except json.JSONDecodeError:
+                logger.exception(
+                    "Failed to parse JSON config", extra={"key": item.get('key')}
+                )
                 item['parsed'] = {}
         if item['key'] == 'db_path':
             continue

--- a/views/admin/imports.py
+++ b/views/admin/imports.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from flask import render_template, request, jsonify
 from db.schema import get_field_schema
 from imports.import_csv import parse_csv
@@ -7,7 +8,7 @@ from db.database import get_connection
 from imports.tasks import process_import, init_import_table
 from . import admin_bp
 
-
+logger = logging.getLogger(__name__)
 @admin_bp.route('/import', methods=['GET', 'POST'])
 def import_records():
     schema = get_field_schema()
@@ -111,6 +112,7 @@ def import_status_route():
     try:
         import_id = int(request.args.get('importId', 0))
     except (TypeError, ValueError):
+        logger.warning("Invalid importId provided", exc_info=True)
         return jsonify({'error': 'Invalid importId'}), 400
 
     with get_connection() as conn:


### PR DESCRIPTION
## Summary
- log unknown base tables in records helpers
- capture row-level import failures with stack traces
- add defensive JSON and layout parsing with exception logging in admin dashboard
- expand database and configuration logging for easier troubleshooting
- ensure relationship management errors propagate detailed logs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b078fee4508333b58b13530c692af4