### PR TITLE
Refine exception handling in imports and record views

### DIFF
--- a/imports/tasks.py
+++ b/imports/tasks.py
@@ -110,9 +110,18 @@ def _run_import(job_id, table, rows):
         )
         _update_import_status(job_id, status="failed")
         raise
-    except Exception:
+    except ValueError:
         logger.exception(
             "Import job %s for table %s failed",
+            job_id,
+            table,
+            extra={"job_id": job_id, "table": table},
+        )
+        _update_import_status(job_id, status="failed")
+        raise
+    except Exception:
+        logger.exception(
+            "Unexpected error for import job %s table %s",
             job_id,
             table,
             extra={"job_id": job_id, "table": table},

--- a/views/records/record_views.py
+++ b/views/records/record_views.py
@@ -312,9 +312,28 @@ def manage_relationship():
             abort(400, 'Invalid action')
     except HTTPException:
         raise
+    except ValueError as e:
+        logger.warning(
+            'manage_relationship validation failed action=%s %s:%s -> %s:%s',
+            action,
+            table_a,
+            id_a,
+            table_b,
+            id_b,
+            extra={
+                "action": action,
+                "table_a": table_a,
+                "id_a": id_a,
+                "table_b": table_b,
+                "id_b": id_b,
+                "error": str(e),
+            },
+            exc_info=True,
+        )
+        abort(400, str(e))
     except Exception:
         logger.exception(
-            'manage_relationship raised exception action=%s %s:%s -> %s:%s',
+            'Unexpected exception in manage_relationship action=%s %s:%s -> %s:%s',
             action,
             table_a,
             id_a,


### PR DESCRIPTION
## Summary
- Catch `ValueError` separately during import jobs and reserve broad logging for unexpected errors
- Validate relationship operations explicitly and handle unexpected failures distinctly

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b084f273a88333a8b9df85c075c062