### PR TITLE
Add contextual metadata to error logs

### DIFF
--- a/db/config.py
+++ b/db/config.py
@@ -45,9 +45,10 @@ def get_config_rows(sections: str | list[str] | None = None):
         if opts:
             try:
                 item["options"] = json.loads(opts)
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as exc:
                 logger.exception(
-                    "Invalid JSON in config options", extra={"key": item.get("key")}
+                    "Invalid JSON in config options",
+                    extra={"key": item.get("key"), "error": str(exc)},
                 )
                 item["options"] = []
         else:
@@ -70,8 +71,11 @@ def get_layout_defaults() -> dict:
     if row and row[0]:
         try:
             data = json.loads(row[0])
-        except json.JSONDecodeError:
-            logger.exception("Invalid JSON in layout_defaults config")
+        except json.JSONDecodeError as exc:
+            logger.exception(
+                "Invalid JSON in layout_defaults config",
+                extra={"key": "layout_defaults", "error": str(exc)},
+            )
             data = {}
 
     if not data:
@@ -94,8 +98,11 @@ def get_relationship_visibility() -> dict:
         return {}
     try:
         return json.loads(row[0])
-    except json.JSONDecodeError:
-        logger.exception("Invalid JSON in relationship_visibility config")
+    except json.JSONDecodeError as exc:
+        logger.exception(
+            "Invalid JSON in relationship_visibility config",
+            extra={"key": "relationship_visibility", "error": str(exc)},
+        )
         return {}
 
 

--- a/main.py
+++ b/main.py
@@ -47,8 +47,11 @@ if status == 'valid':
                 cfg_path = cfg.get('db_path')
                 if cfg_path:
                     init_db_path(cfg_path)
-    except sqlite3.DatabaseError:
-        logger.exception("Failed to verify database during startup")
+    except sqlite3.DatabaseError as exc:
+        logger.exception(
+            "Failed to verify database during startup",
+            extra={"db_path": DB_PATH, "error": str(exc)},
+        )
         needs_wizard = True
 else:
     needs_wizard = True

--- a/views/admin/__init__.py
+++ b/views/admin/__init__.py
@@ -20,8 +20,11 @@ def reload_app_state() -> None:
         rows = get_config_rows('database')
         cfg = {row['key']: row['value'] for row in rows}
         init_db_path(cfg.get('db_path'))
-    except sqlite3.DatabaseError:
-        logger.exception("Failed to load database configuration")
+    except sqlite3.DatabaseError as exc:
+        logger.exception(
+            "Failed to load database configuration",
+            extra={"db_path": DB_PATH, "error": str(exc)},
+        )
         init_db_path()
 
     card_info, base_tables = refresh_card_cache()


### PR DESCRIPTION
## Summary
- Add database path and error context to startup verification log
- Include db_path and error metadata across database module
- Ensure config-related JSON errors capture key and message details

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0867882b483338be4eab87fb6a2e4