### PR TITLE
Load field editor script once

### DIFF
--- a/templates/admin/fields_admin.html
+++ b/templates/admin/fields_admin.html
@@ -46,6 +46,7 @@
   </details>
   {% endfor %}
 </div>
+<script src="{{ url_for('static', filename='js/edit_fields.js') }}"></script>
 <script type="module">
   window.openLayoutModal = function(id) {
     document.getElementById(id).classList.remove('hidden');

--- a/templates/detail_view.html
+++ b/templates/detail_view.html
@@ -274,6 +274,7 @@
 
 {% include "modals/edit_fields_modal.html" %}
 {% include "modals/new_record_modal.html" %}
+<script src="{{ url_for('static', filename='js/edit_fields.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/new_record_modal.js') }}"></script>
 
 {% endblock %}

--- a/templates/modals/edit_fields_modal.html
+++ b/templates/modals/edit_fields_modal.html
@@ -51,7 +51,6 @@
                   class="btn-primary px-4 py-2 rounded">Submit</button>
         </div>
       </form>
-      <script src="{{ url_for('static', filename='js/edit_fields.js') }}"></script>
     </div>
 
     <!-- Remove Field Pane -->


### PR DESCRIPTION
## Summary
- Prevent multiple inclusion of edit_fields.js by removing script from modal partial
- Include edit_fields.js once on pages that use field editing features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1915a316883338dd43048b91b8e64