### PR TITLE
Allow title field type in dropdown

### DIFF
--- a/static/js/edit_fields.js
+++ b/static/js/edit_fields.js
@@ -22,7 +22,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   await loadFieldTypes();
 
   Object.keys(fieldTypes).forEach((t) => {
-    if (t === 'title') return;
     const opt = document.createElement('option');
     opt.value = t;
     opt.textContent = t;


### PR DESCRIPTION
## Summary
- stop skipping the `title` field type when building the field type select, so all types from `/api/field-types` appear

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2bb64933c8333af3a07a5958051f5