### PR TITLE
Remove legacy title field type check in wizard

### DIFF
--- a/static/js/wizard_table.js
+++ b/static/js/wizard_table.js
@@ -195,7 +195,6 @@ async function initFieldTypeSelect() {
   if (!select) return;
   await loadFieldTypes();
   Object.keys(fieldTypes).forEach((t) => {
-    if (t === 'title') return;
     const opt = document.createElement('option');
     opt.value = t;
     opt.textContent = t;


### PR DESCRIPTION
## Summary
- remove special-case filter for `title` field type in the wizard field type selector, relying on the dedicated Title Field dropdown

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2bb73e454833395df1030d82aa9da