### PR TITLE
Handle database setup errors

### DIFF
--- a/static/js/database_admin.js
+++ b/static/js/database_admin.js
@@ -5,12 +5,17 @@ function initDatabaseControls() {
   if (uploadForm) {
     const fileInput = uploadForm.querySelector('input[type="file"]');
     const changeBtn = document.getElementById('change-db-btn');
+    const uploadErr = document.getElementById('change-db-error');
     if (changeBtn) {
       changeBtn.disabled = true;
       changeBtn.classList.add('opacity-50', 'cursor-not-allowed');
     }
     if (fileInput) {
       fileInput.addEventListener('change', () => {
+        if (uploadErr) {
+          uploadErr.textContent = '';
+          uploadErr.classList.add('hidden');
+        }
         if (fileInput.files && fileInput.files.length > 0) {
           console.log('File chosen:', fileInput.files[0].name);
           if (changeBtn) {
@@ -34,12 +39,7 @@ function initDatabaseControls() {
         body: fd,
         headers: { 'Accept': 'application/json' }
       })
-        .then(r => {
-          if (!r.ok) {
-            throw new Error('Server responded with status ' + r.status);
-          }
-          return r.json();
-        })
+        .then(r => r.json())
         .then(data => {
           if (data.redirect) {
             window.location.href = data.redirect;
@@ -55,13 +55,28 @@ function initDatabaseControls() {
             }
             window.location.reload();
           } else if (data.error) {
-            console.error('Failed to change database:', data.error);
+            if (uploadErr) {
+              uploadErr.textContent = data.error;
+              uploadErr.classList.remove('hidden');
+            } else {
+              console.error('Failed to change database:', data.error);
+            }
           } else {
-            console.error('Failed to change database: no db_path returned');
+            if (uploadErr) {
+              uploadErr.textContent = 'Failed to change database';
+              uploadErr.classList.remove('hidden');
+            } else {
+              console.error('Failed to change database: no db_path returned');
+            }
           }
         })
         .catch(err => {
-          console.error('Failed to change database:', err);
+          if (uploadErr) {
+            uploadErr.textContent = err.message;
+            uploadErr.classList.remove('hidden');
+          } else {
+            console.error('Failed to change database:', err);
+          }
         });
     });
   }
@@ -110,6 +125,15 @@ export function submitCreateDb(event) {
           err.textContent = data.error;
           err.classList.remove('hidden');
         }
+      }
+    })
+    .catch(err => {
+      const errEl = document.getElementById('create-db-error');
+      if (errEl) {
+        errEl.textContent = err.message;
+        errEl.classList.remove('hidden');
+      } else {
+        console.error('Failed to create database:', err);
       }
     });
 }

--- a/templates/admin/database_admin.html
+++ b/templates/admin/database_admin.html
@@ -11,6 +11,7 @@
         <input type="file" name="file" accept=".db" class="form-control" />
         <button id="change-db-btn" type="submit" class="btn-danger opacity-50 cursor-not-allowed" disabled>Change Database</button>
       </form>
+      <div id="change-db-error" class="text-red-600 hidden"></div>
     <button id="create-db-btn" type="button" class="btn-primary" onclick="openCreateDbModal()">Create New DB</button>
   </div>
 </div>

--- a/views/admin/config.py
+++ b/views/admin/config.py
@@ -78,8 +78,26 @@ def update_database_file():
             return redirect(url_for('admin.database_page'))
         save_path = os.path.join('data', filename)
         file.save(save_path)
-        initialize_database(save_path)
-        ensure_default_configs(save_path)
+        try:
+            initialize_database(save_path)
+        except Exception as exc:
+            logger.exception(
+                'Failed to initialize database',
+                extra={'path': save_path, 'error': str(exc)},
+            )
+            if wants_json:
+                return jsonify({'error': str(exc)}), 500
+            return redirect(url_for('admin.database_page'))
+        try:
+            ensure_default_configs(save_path)
+        except Exception as exc:
+            logger.exception(
+                'Failed to ensure default configs',
+                extra={'path': save_path, 'error': str(exc)},
+            )
+            if wants_json:
+                return jsonify({'error': str(exc)}), 500
+            return redirect(url_for('admin.database_page'))
         update_config('db_path', save_path)
         reload_app_state()
         if wants_json:
@@ -93,8 +111,26 @@ def update_database_file():
             filename += '.db'
         save_path = os.path.join('data', filename)
         open(save_path, 'a').close()
-        initialize_database(save_path)
-        ensure_default_configs(save_path)
+        try:
+            initialize_database(save_path)
+        except Exception as exc:
+            logger.exception(
+                'Failed to initialize database',
+                extra={'path': save_path, 'error': str(exc)},
+            )
+            if wants_json:
+                return jsonify({'error': str(exc)}), 500
+            return redirect(url_for('admin.database_page'))
+        try:
+            ensure_default_configs(save_path)
+        except Exception as exc:
+            logger.exception(
+                'Failed to ensure default configs',
+                extra={'path': save_path, 'error': str(exc)},
+            )
+            if wants_json:
+                return jsonify({'error': str(exc)}), 500
+            return redirect(url_for('admin.database_page'))
         update_config('db_path', save_path)
         reload_app_state()
         session['wizard_progress'] = {'database': True, 'skip_import': True}


### PR DESCRIPTION
## Summary
- wrap database initialization and default config setup in try/except blocks
- surface database initialization errors in the admin UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2bc69f04083339af1c9917e3a526f