### PR TITLE
Handle invalid DB file extensions

### DIFF
--- a/static/js/database_admin.js
+++ b/static/js/database_admin.js
@@ -39,7 +39,10 @@ function initDatabaseControls() {
         body: fd,
         headers: { 'Accept': 'application/json' }
       })
-        .then(r => r.json())
+        .then(r => r.json().then(data => {
+          if (!r.ok) throw data;
+          return data;
+        }))
         .then(data => {
           if (data.redirect) {
             window.location.href = data.redirect;
@@ -72,10 +75,10 @@ function initDatabaseControls() {
         })
         .catch(err => {
           if (uploadErr) {
-            uploadErr.textContent = err.message;
+            uploadErr.textContent = err.error || err.message;
             uploadErr.classList.remove('hidden');
           } else {
-            console.error('Failed to change database:', err);
+            console.error('Failed to change database:', err.error || err);
           }
         });
     });
@@ -104,7 +107,10 @@ export function submitCreateDb(event) {
   const fd = new FormData();
   fd.append('create_name', name);
   fetch('/admin/config/db', { method: 'POST', body: fd, headers: { 'Accept': 'application/json' } })
-    .then(r => r.json())
+    .then(r => r.json().then(data => {
+      if (!r.ok) throw data;
+      return data;
+    }))
     .then(data => {
       if (data.redirect) {
         window.location.href = data.redirect;
@@ -130,10 +136,10 @@ export function submitCreateDb(event) {
     .catch(err => {
       const errEl = document.getElementById('create-db-error');
       if (errEl) {
-        errEl.textContent = err.message;
+        errEl.textContent = err.error || err.message;
         errEl.classList.remove('hidden');
       } else {
-        console.error('Failed to create database:', err);
+        console.error('Failed to create database:', err.error || err);
       }
     });
 }

--- a/tests/test_admin_config.py
+++ b/tests/test_admin_config.py
@@ -29,6 +29,20 @@ def test_config_db_upload_redirects(client, monkeypatch):
     assert resp.headers['Location'].endswith('/admin/database')
 
 
+def test_config_db_upload_invalid_extension_json(client):
+    import io
+
+    data = {'file': (io.BytesIO(b'data'), 'temp.txt')}
+    resp = client.post(
+        '/admin/config/db',
+        data=data,
+        content_type='multipart/form-data',
+        headers={'Accept': 'application/json'},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json() == {'error': 'invalid_extension'}
+
+
 def test_config_db_create_redirects_to_wizard(client, monkeypatch):
     from views.admin import config as cfg
 

--- a/views/admin/config.py
+++ b/views/admin/config.py
@@ -74,7 +74,9 @@ def update_database_file():
     if 'file' in request.files and request.files['file'].filename:
         file = request.files['file']
         filename = secure_filename(file.filename)
-        if not filename.endswith('.db'):
+        if not filename.lower().endswith('.db'):
+            if wants_json:
+                return jsonify({'error': 'invalid_extension'}), 400
             return redirect(url_for('admin.database_page'))
         save_path = os.path.join('data', filename)
         file.save(save_path)


### PR DESCRIPTION
## Summary
- Return `invalid_extension` error when uploaded database file does not end in `.db`
- Surface server-provided errors on database admin page instead of console exceptions
- Test coverage for invalid database upload extension

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2cf4070fc8333b0229db1666c9fb1