### PR TITLE
Reload metadata when changing database

### DIFF
--- a/views/admin/__init__.py
+++ b/views/admin/__init__.py
@@ -1,9 +1,10 @@
 from flask import Blueprint, render_template, redirect, url_for, current_app
 import logging
-from db.schema import refresh_card_cache, update_foreign_field_options
+import sqlite3
+
+from db.schema import load_card_info, load_base_tables, update_foreign_field_options
 from db.config import get_config_rows
 from db.database import init_db_path, check_db_status, DB_PATH
-import sqlite3
 
 admin_bp = Blueprint('admin', __name__)
 
@@ -27,7 +28,9 @@ def reload_app_state() -> None:
         )
         init_db_path()
 
-    card_info, base_tables = refresh_card_cache()
+    with sqlite3.connect(DB_PATH) as conn:
+        card_info = load_card_info(conn)
+        base_tables = load_base_tables(conn)
     current_app.config['CARD_INFO'] = card_info
     current_app.config['BASE_TABLES'] = base_tables
     update_foreign_field_options()


### PR DESCRIPTION
## Summary
- Refresh card and base table caches after database path update
- Initialize new database path on reload

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b42cd68c848333b8bc76649b5cf0a3