### PR TITLE
Reload metadata when changing database

### DIFF
--- a/static/js/database_admin.js
+++ b/static/js/database_admin.js
@@ -56,7 +56,7 @@ function initDatabaseControls() {
               const color = data.status === 'valid' ? 'text-green-600' : 'text-red-600';
               disp.classList.add(color);
             }
-            window.location.reload();
+            window.location.href = '/';
           } else if (data.error) {
             if (uploadErr) {
               uploadErr.textContent = data.error;

--- a/tests/test_admin_config.py
+++ b/tests/test_admin_config.py
@@ -26,7 +26,7 @@ def test_config_db_upload_redirects(client, monkeypatch):
     data = {'file': (io.BytesIO(b'data'), 'temp.db')}
     resp = client.post('/admin/config/db', data=data, content_type='multipart/form-data')
     assert resp.status_code == 302
-    assert resp.headers['Location'].endswith('/admin/database')
+    assert resp.headers['Location'].endswith('/')
 
 
 def test_config_db_upload_invalid_extension_json(client):

--- a/views/admin/__init__.py
+++ b/views/admin/__init__.py
@@ -1,9 +1,10 @@
 from flask import Blueprint, render_template, redirect, url_for, current_app
 import logging
-from db.schema import refresh_card_cache, update_foreign_field_options
+import sqlite3
+
+from db.schema import load_card_info, load_base_tables, update_foreign_field_options
 from db.config import get_config_rows
 from db.database import init_db_path, check_db_status, DB_PATH
-import sqlite3
 
 admin_bp = Blueprint('admin', __name__)
 
@@ -27,7 +28,9 @@ def reload_app_state() -> None:
         )
         init_db_path()
 
-    card_info, base_tables = refresh_card_cache()
+    with sqlite3.connect(DB_PATH) as conn:
+        card_info = load_card_info(conn)
+        base_tables = load_base_tables(conn)
     current_app.config['CARD_INFO'] = card_info
     current_app.config['BASE_TABLES'] = base_tables
     update_foreign_field_options()

--- a/views/admin/config.py
+++ b/views/admin/config.py
@@ -102,9 +102,14 @@ def update_database_file():
             return redirect(url_for('admin.database_page'))
         update_config('db_path', save_path)
         reload_app_state()
+        status = check_db_status(save_path)
         if wants_json:
-            return jsonify({'db_path': save_path, 'status': check_db_status(save_path)})
-        return redirect(url_for('admin.database_page'))
+            return jsonify({
+                'db_path': save_path,
+                'status': status,
+                'redirect': url_for('home'),
+            })
+        return redirect(url_for('home'))
 
     name = request.form.get('create_name')
     if name:


### PR DESCRIPTION
## Summary
- Refresh card and base table caches after database path update
- Initialize new database path on reload
- Redirect to home page after selecting a new database

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b42cd68c848333b8bc76649b5cf0a3